### PR TITLE
feat: 질문 등록 페이지 구현 (#2)

### DIFF
--- a/src/features/qna/categories/handler.ts
+++ b/src/features/qna/categories/handler.ts
@@ -1,0 +1,50 @@
+import { http, HttpResponse } from 'msw'
+import type { CategoriesResponse } from './types'
+
+const mockCategories: CategoriesResponse = [
+  {
+    id: 1,
+    name: 'Python',
+    category_type: 'large',
+    children: [
+      { id: 11, name: '기초 문법', category_type: 'medium', children: [] },
+      { id: 12, name: '자료구조', category_type: 'medium', children: [] },
+      { id: 13, name: '알고리즘', category_type: 'medium', children: [] },
+    ],
+  },
+  {
+    id: 2,
+    name: 'JavaScript',
+    category_type: 'large',
+    children: [
+      { id: 21, name: 'ES6+', category_type: 'medium', children: [] },
+      { id: 22, name: 'DOM', category_type: 'medium', children: [] },
+      { id: 23, name: '비동기', category_type: 'medium', children: [] },
+    ],
+  },
+  {
+    id: 3,
+    name: 'React',
+    category_type: 'large',
+    children: [
+      { id: 31, name: 'Hooks', category_type: 'medium', children: [] },
+      { id: 32, name: '상태 관리', category_type: 'medium', children: [] },
+      { id: 33, name: '라우팅', category_type: 'medium', children: [] },
+    ],
+  },
+  {
+    id: 4,
+    name: 'Django',
+    category_type: 'large',
+    children: [
+      { id: 41, name: 'ORM', category_type: 'medium', children: [] },
+      { id: 42, name: 'REST API', category_type: 'medium', children: [] },
+    ],
+  },
+]
+
+export const categoriesHandler = [
+  http.get('/api/v1/qna/categories/', () => {
+    return HttpResponse.json(mockCategories)
+  }),
+]

--- a/src/features/qna/categories/index.ts
+++ b/src/features/qna/categories/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/qna/categories/queries.ts
+++ b/src/features/qna/categories/queries.ts
@@ -1,0 +1,17 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { CategoriesResponse } from './types'
+
+const categoriesQueryOptions = queryOptions({
+  queryKey: ['qna', 'categories'],
+  queryFn: async () => {
+    const { data } = await api.get<CategoriesResponse>(
+      '/api/v1/qna/categories/'
+    )
+    return data
+  },
+})
+
+export function useQnaCategories() {
+  return useSuspenseQuery(categoriesQueryOptions)
+}

--- a/src/features/qna/categories/types.ts
+++ b/src/features/qna/categories/types.ts
@@ -1,0 +1,8 @@
+export interface UserCategory {
+  id: number
+  name: string
+  category_type: string
+  children: UserCategory[]
+}
+
+export type CategoriesResponse = UserCategory[]

--- a/src/features/qna/question-write/handler.ts
+++ b/src/features/qna/question-write/handler.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw'
+import type { QuestionCreateResponse } from './types'
+
+export const questionWriteHandler = [
+  http.post('/api/v1/qna/questions/', async () => {
+    const response: QuestionCreateResponse = {
+      message: '질문이 성공적으로 등록되었습니다.',
+      question_id: Math.floor(Math.random() * 1000) + 1,
+    }
+    return HttpResponse.json(response, { status: 201 })
+  }),
+]

--- a/src/features/qna/question-write/index.ts
+++ b/src/features/qna/question-write/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/qna/question-write/queries.ts
+++ b/src/features/qna/question-write/queries.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { QuestionCreateRequest, QuestionCreateResponse } from './types'
+
+export function useCreateQuestion() {
+  return useMutation({
+    mutationFn: async (payload: QuestionCreateRequest) => {
+      const { data } = await api.post<QuestionCreateResponse>(
+        '/api/v1/qna/questions/',
+        payload
+      )
+      return data
+    },
+  })
+}

--- a/src/features/qna/question-write/types.ts
+++ b/src/features/qna/question-write/types.ts
@@ -1,0 +1,10 @@
+export interface QuestionCreateRequest {
+  category_id: number
+  title: string
+  content: string
+}
+
+export interface QuestionCreateResponse {
+  message: string
+  question_id: number
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,8 +1,11 @@
 import { http, HttpResponse } from 'msw'
+import { categoriesHandler } from '@/features/qna/categories'
+import { questionWriteHandler } from '@/features/qna/question-write'
 
 export const handlers = [
-  // 예시 핸들러 — 실제 API에 맞게 수정하세요
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
+  ...categoriesHandler,
+  ...questionWriteHandler,
 ]

--- a/src/pages/qna/QnaWritePage.tsx
+++ b/src/pages/qna/QnaWritePage.tsx
@@ -2,6 +2,183 @@
  * @figma 질문 등록페이지 (내용O)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-9533&m=dev
  * @figma 질문 등록페이지 (내용X)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-9690&m=dev
  */
+import { Suspense, useState } from 'react'
+import { useNavigate } from 'react-router'
+import MDEditor from '@uiw/react-md-editor'
+import { Button, Dropdown, Input, AlertModal } from '@/components'
+import { useQnaCategories } from '@/features/qna/categories'
+import { useCreateQuestion } from '@/features/qna/question-write'
+import { ROUTES } from '@/constants/routes'
+
+const MIN_CONTENT_LENGTH = 5
+
+function QnaWriteForm() {
+  const navigate = useNavigate()
+  const { data: categories } = useQnaCategories()
+  const { mutate: createQuestion, isPending } = useCreateQuestion()
+
+  const [largeCategoryId, setLargeCategoryId] = useState<string>('')
+  const [mediumCategoryId, setMediumCategoryId] = useState<string>('')
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState<string | undefined>('')
+  const [alertMessage, setAlertMessage] = useState('')
+  const [isAlertOpen, setIsAlertOpen] = useState(false)
+
+  const largeOptions = categories.map((cat) => ({
+    value: String(cat.id),
+    label: cat.name,
+  }))
+
+  const selectedLarge = categories.find(
+    (cat) => String(cat.id) === largeCategoryId
+  )
+
+  const mediumOptions =
+    selectedLarge?.children.map((child) => ({
+      value: String(child.id),
+      label: child.name,
+    })) ?? []
+
+  const handleLargeChange = (value: string) => {
+    setLargeCategoryId(value)
+    setMediumCategoryId('')
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const isCategoryMissing = !largeCategoryId || !mediumCategoryId
+    const isContentInvalid =
+      !content || content.trim().length < MIN_CONTENT_LENGTH
+
+    if (isCategoryMissing) {
+      setAlertMessage('카테고리를 선택해 주세요.')
+      setIsAlertOpen(true)
+      return
+    }
+    if (!title.trim()) {
+      setAlertMessage('제목을 입력해 주세요.')
+      setIsAlertOpen(true)
+      return
+    }
+    if (isContentInvalid) {
+      setAlertMessage(`내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`)
+      setIsAlertOpen(true)
+      return
+    }
+
+    createQuestion(
+      {
+        category_id: Number(mediumCategoryId),
+        title: title.trim(),
+        content: content.trim(),
+      },
+      {
+        onSuccess: (data) => {
+          navigate(
+            ROUTES.QNA.DETAIL.replace(':questionId', String(data.question_id))
+          )
+        },
+        onError: () => {
+          setAlertMessage('질문 등록에 실패했습니다. 다시 시도해 주세요.')
+          setIsAlertOpen(true)
+        },
+      }
+    )
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        {/* 카테고리 선택 */}
+        <div className="flex flex-col gap-3">
+          <label className="text-text-heading text-sm font-medium">
+            카테고리
+            <span className="text-error ml-1">*</span>
+          </label>
+          <div className="flex gap-3">
+            <Dropdown
+              options={largeOptions}
+              value={largeCategoryId}
+              onChange={handleLargeChange}
+              placeholder="대분류 선택"
+              className="flex-1"
+            />
+            <Dropdown
+              options={mediumOptions}
+              value={mediumCategoryId}
+              onChange={setMediumCategoryId}
+              placeholder="중분류 선택"
+              disabled={!largeCategoryId}
+              className="flex-1"
+            />
+          </div>
+        </div>
+
+        {/* 제목 */}
+        <Input
+          label="제목"
+          placeholder="제목을 입력해 주세요. (3~100자)"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={100}
+        />
+
+        {/* 내용 */}
+        <div className="flex flex-col gap-3">
+          <label className="text-text-heading text-sm font-medium">
+            내용
+            <span className="text-error ml-1">*</span>
+          </label>
+          <div data-color-mode="light">
+            <MDEditor
+              value={content}
+              onChange={setContent}
+              height={400}
+              preview="live"
+              visibleDragbar={false}
+            />
+          </div>
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex justify-end gap-3">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => navigate(ROUTES.QNA.LIST)}
+            disabled={isPending}
+          >
+            취소
+          </Button>
+          <Button type="submit" variant="primary" loading={isPending}>
+            등록하기
+          </Button>
+        </div>
+      </form>
+
+      <AlertModal
+        isOpen={isAlertOpen}
+        onClose={() => setIsAlertOpen(false)}
+        message={alertMessage}
+      />
+    </>
+  )
+}
+
 export function QnaWritePage() {
-  return <div>질문 등록</div>
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <h1 className="text-text-heading mb-8 text-2xl font-bold">질문 등록</h1>
+      <Suspense
+        fallback={
+          <div className="text-text-muted flex h-40 items-center justify-center">
+            로딩 중...
+          </div>
+        }
+      >
+        <QnaWriteForm />
+      </Suspense>
+    </div>
+  )
 }


### PR DESCRIPTION
## 관련 이슈

- closes #2

## 작업 내용

- `src/features/qna/question-write/` — 질문 등록 API 연동 (types, queries, handler, index)
- `src/features/qna/categories/` — 카테고리 목록 API 연동 (types, queries, handler, index)
- `src/mocks/handlers.ts` — MSW 핸들러 등록
- `src/pages/qna/QnaWritePage.tsx` — 질문 등록 페이지 구현

## 변경 사항

- 대분류/중분류 Dropdown 카테고리 선택 (대분류 선택 시 중분류 동적 필터링)
- 제목 Input 입력
- `@uiw/react-md-editor` 마크다운 에디터 (live preview 모드)
- 미입력 시 AlertModal 팝업 표시
- 등록 성공 시 질문 상세 페이지로 navigate

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다