### PR TITLE
feat: 질문 등록 페이지 구현 (#2)

### DIFF
--- a/src/features/qna/categories/handler.ts
+++ b/src/features/qna/categories/handler.ts
@@ -44,7 +44,7 @@ const mockCategories: CategoriesResponse = [
 ]
 
 export const categoriesHandler = [
-  http.get('/api/v1/qna/categories/', () => {
+  http.get(`${import.meta.env.VITE_API_BASE_URL}/qna/categories/`, () => {
     return HttpResponse.json(mockCategories)
   }),
 ]

--- a/src/features/qna/categories/handler.ts
+++ b/src/features/qna/categories/handler.ts
@@ -1,0 +1,50 @@
+import { http, HttpResponse } from 'msw'
+import type { CategoriesResponse } from './types'
+
+const mockCategories: CategoriesResponse = [
+  {
+    id: 1,
+    name: 'Python',
+    category_type: 'large',
+    children: [
+      { id: 11, name: '기초 문법', category_type: 'medium', children: [] },
+      { id: 12, name: '자료구조', category_type: 'medium', children: [] },
+      { id: 13, name: '알고리즘', category_type: 'medium', children: [] },
+    ],
+  },
+  {
+    id: 2,
+    name: 'JavaScript',
+    category_type: 'large',
+    children: [
+      { id: 21, name: 'ES6+', category_type: 'medium', children: [] },
+      { id: 22, name: 'DOM', category_type: 'medium', children: [] },
+      { id: 23, name: '비동기', category_type: 'medium', children: [] },
+    ],
+  },
+  {
+    id: 3,
+    name: 'React',
+    category_type: 'large',
+    children: [
+      { id: 31, name: 'Hooks', category_type: 'medium', children: [] },
+      { id: 32, name: '상태 관리', category_type: 'medium', children: [] },
+      { id: 33, name: '라우팅', category_type: 'medium', children: [] },
+    ],
+  },
+  {
+    id: 4,
+    name: 'Django',
+    category_type: 'large',
+    children: [
+      { id: 41, name: 'ORM', category_type: 'medium', children: [] },
+      { id: 42, name: 'REST API', category_type: 'medium', children: [] },
+    ],
+  },
+]
+
+export const categoriesHandler = [
+  http.get('/api/v1/qna/categories/', () => {
+    return HttpResponse.json(mockCategories)
+  }),
+]

--- a/src/features/qna/categories/index.ts
+++ b/src/features/qna/categories/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/qna/categories/queries.ts
+++ b/src/features/qna/categories/queries.ts
@@ -1,0 +1,17 @@
+import { queryOptions, useSuspenseQuery } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { CategoriesResponse } from './types'
+
+const categoriesQueryOptions = queryOptions({
+  queryKey: ['qna', 'categories'],
+  queryFn: async () => {
+    const { data } = await api.get<CategoriesResponse>(
+      '/api/v1/qna/categories/'
+    )
+    return data
+  },
+})
+
+export function useQnaCategories() {
+  return useSuspenseQuery(categoriesQueryOptions)
+}

--- a/src/features/qna/categories/queries.ts
+++ b/src/features/qna/categories/queries.ts
@@ -5,9 +5,7 @@ import type { CategoriesResponse } from './types'
 const categoriesQueryOptions = queryOptions({
   queryKey: ['qna', 'categories'],
   queryFn: async () => {
-    const { data } = await api.get<CategoriesResponse>(
-      '/api/v1/qna/categories/'
-    )
+    const { data } = await api.get<CategoriesResponse>('/qna/categories/')
     return data
   },
 })

--- a/src/features/qna/categories/types.ts
+++ b/src/features/qna/categories/types.ts
@@ -1,0 +1,8 @@
+export interface UserCategory {
+  id: number
+  name: string
+  category_type: string
+  children: UserCategory[]
+}
+
+export type CategoriesResponse = UserCategory[]

--- a/src/features/qna/question-write/handler.ts
+++ b/src/features/qna/question-write/handler.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse } from 'msw'
+import type { QuestionCreateResponse } from './types'
+
+export const questionWriteHandler = [
+  http.post('/api/v1/qna/questions/', async () => {
+    const response: QuestionCreateResponse = {
+      message: '질문이 성공적으로 등록되었습니다.',
+      question_id: Math.floor(Math.random() * 1000) + 1,
+    }
+    return HttpResponse.json(response, { status: 201 })
+  }),
+]

--- a/src/features/qna/question-write/handler.ts
+++ b/src/features/qna/question-write/handler.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw'
 import type { QuestionCreateResponse } from './types'
 
 export const questionWriteHandler = [
-  http.post('/api/v1/qna/questions/', async () => {
+  http.post(`${import.meta.env.VITE_API_BASE_URL}/qna/questions/`, async () => {
     const response: QuestionCreateResponse = {
       message: '질문이 성공적으로 등록되었습니다.',
       question_id: Math.floor(Math.random() * 1000) + 1,

--- a/src/features/qna/question-write/index.ts
+++ b/src/features/qna/question-write/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/qna/question-write/queries.ts
+++ b/src/features/qna/question-write/queries.ts
@@ -1,15 +1,18 @@
 import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
 import api from '@/api/instance'
 import type { QuestionCreateRequest, QuestionCreateResponse } from './types'
 
 export function useCreateQuestion() {
-  return useMutation({
-    mutationFn: async (payload: QuestionCreateRequest) => {
-      const { data } = await api.post<QuestionCreateResponse>(
-        '/api/v1/qna/questions/',
-        payload
-      )
-      return data
-    },
-  })
+  return useMutation<QuestionCreateResponse, AxiosError, QuestionCreateRequest>(
+    {
+      mutationFn: async (payload) => {
+        const { data } = await api.post<QuestionCreateResponse>(
+          '/qna/questions/',
+          payload
+        )
+        return data
+      },
+    }
+  )
 }

--- a/src/features/qna/question-write/queries.ts
+++ b/src/features/qna/question-write/queries.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { QuestionCreateRequest, QuestionCreateResponse } from './types'
+
+export function useCreateQuestion() {
+  return useMutation({
+    mutationFn: async (payload: QuestionCreateRequest) => {
+      const { data } = await api.post<QuestionCreateResponse>(
+        '/api/v1/qna/questions/',
+        payload
+      )
+      return data
+    },
+  })
+}

--- a/src/features/qna/question-write/types.ts
+++ b/src/features/qna/question-write/types.ts
@@ -1,0 +1,10 @@
+export interface QuestionCreateRequest {
+  category_id: number
+  title: string
+  content: string
+}
+
+export interface QuestionCreateResponse {
+  message: string
+  question_id: number
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,8 +1,11 @@
 import { http, HttpResponse } from 'msw'
+import { categoriesHandler } from '@/features/qna/categories'
+import { questionWriteHandler } from '@/features/qna/question-write'
 
 export const handlers = [
-  // 예시 핸들러 — 실제 API에 맞게 수정하세요
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' })
   }),
+  ...categoriesHandler,
+  ...questionWriteHandler,
 ]

--- a/src/pages/qna/QnaWritePage.tsx
+++ b/src/pages/qna/QnaWritePage.tsx
@@ -2,7 +2,7 @@
  * @figma 질문 등록페이지 (내용O)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-9533&m=dev
  * @figma 질문 등록페이지 (내용X)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-9690&m=dev
  */
-import { Suspense, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import MDEditor from '@uiw/react-md-editor'
 import { Button, Dropdown, Input, AlertModal } from '@/components'
@@ -11,6 +11,8 @@ import { useCreateQuestion } from '@/features/qna/question-write'
 import { ROUTES } from '@/constants/routes'
 
 const MIN_CONTENT_LENGTH = 5
+const MIN_TITLE_LENGTH = 3
+const MAX_TITLE_LENGTH = 100
 
 function QnaWriteForm() {
   const navigate = useNavigate()
@@ -20,7 +22,7 @@ function QnaWriteForm() {
   const [largeCategoryId, setLargeCategoryId] = useState<string>('')
   const [mediumCategoryId, setMediumCategoryId] = useState<string>('')
   const [title, setTitle] = useState('')
-  const [content, setContent] = useState<string | undefined>('')
+  const [content, setContent] = useState('')
   const [alertMessage, setAlertMessage] = useState('')
   const [isAlertOpen, setIsAlertOpen] = useState(false)
 
@@ -39,17 +41,34 @@ function QnaWriteForm() {
       label: child.name,
     })) ?? []
 
+  const hasChildren = mediumOptions.length > 0
+  // 대분류 변경/카테고리 refetch 시 mediumCategoryId가 orphan이 되는 경우를 렌더 타임에 파생
+  const isMediumValid = mediumOptions.some((o) => o.value === mediumCategoryId)
+  const validMediumCategoryId = isMediumValid ? mediumCategoryId : ''
+
   const handleLargeChange = (value: string) => {
     setLargeCategoryId(value)
     setMediumCategoryId('')
   }
 
+  const isDirty = title.trim().length > 0 || content.length > 0
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [isDirty])
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
-    const isCategoryMissing = !largeCategoryId || !mediumCategoryId
-    const isContentInvalid =
-      !content || content.trim().length < MIN_CONTENT_LENGTH
+    const isCategoryMissing =
+      !largeCategoryId || (hasChildren && !validMediumCategoryId)
+    const isTitleInvalid = title.trim().length < MIN_TITLE_LENGTH
+    const isContentInvalid = content.trim().length < MIN_CONTENT_LENGTH
 
     if (isCategoryMissing) {
       setAlertMessage('카테고리를 선택해 주세요.')
@@ -61,15 +80,24 @@ function QnaWriteForm() {
       setIsAlertOpen(true)
       return
     }
+    if (isTitleInvalid) {
+      setAlertMessage(`제목을 ${MIN_TITLE_LENGTH}자 이상 입력해 주세요.`)
+      setIsAlertOpen(true)
+      return
+    }
     if (isContentInvalid) {
       setAlertMessage(`내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`)
       setIsAlertOpen(true)
       return
     }
 
+    const categoryId = hasChildren
+      ? Number(validMediumCategoryId)
+      : Number(largeCategoryId)
+
     createQuestion(
       {
-        category_id: Number(mediumCategoryId),
+        category_id: categoryId,
         title: title.trim(),
         content: content.trim(),
       },
@@ -104,24 +132,26 @@ function QnaWriteForm() {
               placeholder="대분류 선택"
               className="flex-1"
             />
-            <Dropdown
-              options={mediumOptions}
-              value={mediumCategoryId}
-              onChange={setMediumCategoryId}
-              placeholder="중분류 선택"
-              disabled={!largeCategoryId}
-              className="flex-1"
-            />
+            {hasChildren && (
+              <Dropdown
+                options={mediumOptions}
+                value={validMediumCategoryId}
+                onChange={setMediumCategoryId}
+                placeholder="중분류 선택"
+                disabled={!largeCategoryId}
+                className="flex-1"
+              />
+            )}
           </div>
         </div>
 
         {/* 제목 */}
         <Input
           label="제목"
-          placeholder="제목을 입력해 주세요. (3~100자)"
+          placeholder={`제목을 입력해 주세요. (${MIN_TITLE_LENGTH}~${MAX_TITLE_LENGTH}자)`}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          maxLength={100}
+          maxLength={MAX_TITLE_LENGTH}
         />
 
         {/* 내용 */}
@@ -133,7 +163,7 @@ function QnaWriteForm() {
           <div data-color-mode="light">
             <MDEditor
               value={content}
-              onChange={setContent}
+              onChange={(v) => setContent(v ?? '')}
               height={400}
               preview="live"
               visibleDragbar={false}

--- a/src/pages/qna/QnaWritePage.tsx
+++ b/src/pages/qna/QnaWritePage.tsx
@@ -2,6 +2,183 @@
  * @figma 질문 등록페이지 (내용O)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-9533&m=dev
  * @figma 질문 등록페이지 (내용X)  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-9690&m=dev
  */
+import { Suspense, useState } from 'react'
+import { useNavigate } from 'react-router'
+import MDEditor from '@uiw/react-md-editor'
+import { Button, Dropdown, Input, AlertModal } from '@/components'
+import { useQnaCategories } from '@/features/qna/categories'
+import { useCreateQuestion } from '@/features/qna/question-write'
+import { ROUTES } from '@/constants/routes'
+
+const MIN_CONTENT_LENGTH = 5
+
+function QnaWriteForm() {
+  const navigate = useNavigate()
+  const { data: categories } = useQnaCategories()
+  const { mutate: createQuestion, isPending } = useCreateQuestion()
+
+  const [largeCategoryId, setLargeCategoryId] = useState<string>('')
+  const [mediumCategoryId, setMediumCategoryId] = useState<string>('')
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState<string | undefined>('')
+  const [alertMessage, setAlertMessage] = useState('')
+  const [isAlertOpen, setIsAlertOpen] = useState(false)
+
+  const largeOptions = categories.map((cat) => ({
+    value: String(cat.id),
+    label: cat.name,
+  }))
+
+  const selectedLarge = categories.find(
+    (cat) => String(cat.id) === largeCategoryId
+  )
+
+  const mediumOptions =
+    selectedLarge?.children.map((child) => ({
+      value: String(child.id),
+      label: child.name,
+    })) ?? []
+
+  const handleLargeChange = (value: string) => {
+    setLargeCategoryId(value)
+    setMediumCategoryId('')
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const isCategoryMissing = !largeCategoryId || !mediumCategoryId
+    const isContentInvalid =
+      !content || content.trim().length < MIN_CONTENT_LENGTH
+
+    if (isCategoryMissing) {
+      setAlertMessage('카테고리를 선택해 주세요.')
+      setIsAlertOpen(true)
+      return
+    }
+    if (!title.trim()) {
+      setAlertMessage('제목을 입력해 주세요.')
+      setIsAlertOpen(true)
+      return
+    }
+    if (isContentInvalid) {
+      setAlertMessage(`내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`)
+      setIsAlertOpen(true)
+      return
+    }
+
+    createQuestion(
+      {
+        category_id: Number(mediumCategoryId),
+        title: title.trim(),
+        content: content.trim(),
+      },
+      {
+        onSuccess: (data) => {
+          navigate(
+            ROUTES.QNA.DETAIL.replace(':questionId', String(data.question_id))
+          )
+        },
+        onError: () => {
+          setAlertMessage('질문 등록에 실패했습니다. 다시 시도해 주세요.')
+          setIsAlertOpen(true)
+        },
+      }
+    )
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        {/* 카테고리 선택 */}
+        <div className="flex flex-col gap-3">
+          <label className="text-text-heading text-sm font-medium">
+            카테고리
+            <span className="text-error ml-1">*</span>
+          </label>
+          <div className="flex gap-3">
+            <Dropdown
+              options={largeOptions}
+              value={largeCategoryId}
+              onChange={handleLargeChange}
+              placeholder="대분류 선택"
+              className="flex-1"
+            />
+            <Dropdown
+              options={mediumOptions}
+              value={mediumCategoryId}
+              onChange={setMediumCategoryId}
+              placeholder="중분류 선택"
+              disabled={!largeCategoryId}
+              className="flex-1"
+            />
+          </div>
+        </div>
+
+        {/* 제목 */}
+        <Input
+          label="제목"
+          placeholder="제목을 입력해 주세요. (3~100자)"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={100}
+        />
+
+        {/* 내용 */}
+        <div className="flex flex-col gap-3">
+          <label className="text-text-heading text-sm font-medium">
+            내용
+            <span className="text-error ml-1">*</span>
+          </label>
+          <div data-color-mode="light">
+            <MDEditor
+              value={content}
+              onChange={setContent}
+              height={400}
+              preview="live"
+              visibleDragbar={false}
+            />
+          </div>
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex justify-end gap-3">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => navigate(ROUTES.QNA.LIST)}
+            disabled={isPending}
+          >
+            취소
+          </Button>
+          <Button type="submit" variant="primary" loading={isPending}>
+            등록하기
+          </Button>
+        </div>
+      </form>
+
+      <AlertModal
+        isOpen={isAlertOpen}
+        onClose={() => setIsAlertOpen(false)}
+        message={alertMessage}
+      />
+    </>
+  )
+}
+
 export function QnaWritePage() {
-  return <div>질문 등록</div>
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10">
+      <h1 className="text-text-heading mb-8 text-2xl font-bold">질문 등록</h1>
+      <Suspense
+        fallback={
+          <div className="text-text-muted flex h-40 items-center justify-center">
+            로딩 중...
+          </div>
+        }
+      >
+        <QnaWriteForm />
+      </Suspense>
+    </div>
+  )
 }


### PR DESCRIPTION
## 관련 이슈

- closes #2

## 작업 내용

- `src/features/qna/question-write/` — 질문 등록 API 연동 (types, queries, handler, index)
- `src/features/qna/categories/` — 카테고리 목록 API 연동 (types, queries, handler, index)
- `src/mocks/handlers.ts` — MSW 핸들러 등록
- `src/pages/qna/QnaWritePage.tsx` — 질문 등록 페이지 구현

## 변경 사항

**기본 기능**
- 대분류/중분류 Dropdown 카테고리 선택 (대분류 선택 시 중분류 동적 필터링)
- 제목 Input 입력
- `@uiw/react-md-editor` 마크다운 에디터 (live preview 모드)
- 미입력 시 AlertModal 팝업 표시
- 등록 성공 시 질문 상세 페이지로 navigate

**Critical 버그 수정 (리뷰 반영)**
- 제목 최소 글자수(3자) 검증 추가 — placeholder 안내와 실제 검증 일치
- 중분류 orphan id 버그 수정 — `validMediumCategoryId` 렌더 타임 파생값으로 교체 (useEffect setState 패턴 대신)
- children 없는 대분류 dead-end 처리 — `hasChildren` 분기, 대분류 id 폴백

**Minor 개선 (리뷰 반영)**
- `content` 타입 `string | undefined` → `string` 통일 (`onChange={(v) => setContent(v ?? '')}`)
- `beforeunload` 이탈 방지 추가 — 작성 중 탭 닫기/새로고침 시 경고
- `useCreateQuestion` useMutation 에러 타입 명시 (`AxiosError`)

**MSW 핸들러 URL 수정**
- axios `baseURL`이 이미 `/api/v1` 포함 → 핸들러/쿼리 URL 중복 제거
  - `categories/queries.ts`: `/api/v1/qna/categories/` → `/qna/categories/`
  - `question-write/queries.ts`: `/api/v1/qna/questions/` → `/qna/questions/`
  - handler URL을 `import.meta.env.VITE_API_BASE_URL` 기반으로 통일

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다