### PR TITLE
feat: 질문 목록 조회 페이지 구현 (#3)

### DIFF
--- a/.claude/scripts/rules/frontend-design-guide.checklist.js
+++ b/.claude/scripts/rules/frontend-design-guide.checklist.js
@@ -21,6 +21,7 @@ const checklist = [
     category: "Readability",
     name: "매직 넘버 명명",
     description: "의미 있는 숫자 리터럴이 명명된 상수로 추출되어 있는가?",
+    // MIN_CONTENT_LENGTH=5, MIN_TITLE_LENGTH=3, MAX_TITLE_LENGTH=100 모두 상수로 추출됨
     status: "O",
     violations: [],
   },
@@ -29,6 +30,7 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인증/권한)",
     description: "인증 체크, 권한 검사 등 공통 로직이 래퍼/가드 컴포넌트로 분리되어 있는가?",
+    // 인증/권한 체크 패턴 없음
     status: "N/A",
     violations: [],
   },
@@ -37,7 +39,8 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인터랙션)",
     description: "다이얼로그/오버레이 등 복잡한 인터랙션이 전용 컴포넌트로 추출되어 있는가?",
-    status: "N/A",
+    // AlertModal 컴포넌트로 추출되어 있음
+    status: "O",
     violations: [],
   },
   {
@@ -45,7 +48,8 @@ const checklist = [
     category: "Readability",
     name: "조건부 렌더링 분리",
     description: "역할/상태에 따라 크게 다른 UI/로직이 별도 컴포넌트로 분리되어 있는가?",
-    status: "O",
+    // {hasChildren && <Dropdown />} — 단순 조건부 노출, 역할 기반 대형 분기 아님
+    status: "N/A",
     violations: [],
   },
   {
@@ -53,6 +57,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 삼항 연산자 단순화",
     description: "중첩 삼항 연산자가 if/else 또는 IIFE로 대체되어 있는가?",
+    // categoryId = hasChildren ? ... : ... — 단순 1단계 삼항, 중첩 없음
     status: "O",
     violations: [],
   },
@@ -61,6 +66,7 @@ const checklist = [
     category: "Readability",
     name: "시선 이동 감소 (Colocation)",
     description: "단일 사용처에서만 쓰이는 단순 로직이 사용 위치 근처에 배치되어 있는가?",
+    // QnaWriteForm은 QnaWritePage와 동일 파일에 배치 (Suspense 경계 패턴)
     status: "O",
     violations: [],
   },
@@ -69,6 +75,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 조건에 이름 붙이기",
     description: "2개 이상 조합된 boolean 표현식이 의미 있는 변수명으로 추출되어 있는가?",
+    // isCategoryMissing, isTitleInvalid, isContentInvalid, isDirty 모두 명명됨
     status: "O",
     violations: [],
   },
@@ -79,6 +86,7 @@ const checklist = [
     category: "Predictability",
     name: "API 훅 반환 타입 표준화",
     description: "유사한 API 훅들이 일관된 반환 타입(UseQueryResult 등)을 사용하는가?",
+    // useQnaCategories(useSuspenseQuery), useCreateQuestion(useMutation<Response,AxiosError,Request>) 훅 결과 객체 반환
     status: "O",
     violations: [],
   },
@@ -87,6 +95,7 @@ const checklist = [
     category: "Predictability",
     name: "검증 함수 반환 타입 표준화",
     description: "검증 함수들이 일관된 Discriminated Union 타입을 반환하는가?",
+    // 별도 검증 함수 없음 (인라인 처리)
     status: "N/A",
     violations: [],
   },
@@ -95,6 +104,7 @@ const checklist = [
     category: "Predictability",
     name: "숨겨진 사이드 이펙트 제거",
     description: "함수가 이름에 드러나지 않은 사이드 이펙트(로깅, 분석 등)를 수행하지 않는가?",
+    // beforeunload useEffect는 명시적 등록/cleanup — 숨겨진 사이드 이펙트 없음
     status: "O",
     violations: [],
   },
@@ -103,6 +113,7 @@ const checklist = [
     category: "Predictability",
     name: "고유하고 설명적인 네이밍",
     description: "표준 라이브러리 래퍼가 원본과 구분되는 고유한 이름을 가지는가?",
+    // 표준 라이브러리 래퍼 신규 생성 없음
     status: "N/A",
     violations: [],
   },
@@ -113,6 +124,7 @@ const checklist = [
     category: "Cohesion",
     name: "폼 응집도 선택",
     description: "폼 검증이 용도에 맞게 필드 단위 또는 폼 단위로 일관되게 선택되어 있는가?",
+    // handleSubmit에서 폼 단위 검증 일관 처리
     status: "O",
     violations: [],
   },
@@ -121,6 +133,7 @@ const checklist = [
     category: "Cohesion",
     name: "도메인별 디렉토리 구조",
     description: "기능/도메인 관련 코드가 도메인 폴더에 묶여 있는가?",
+    // features/qna/categories/, features/qna/question-write/ 도메인 폴더 구조 준수
     status: "O",
     violations: [],
   },
@@ -129,6 +142,7 @@ const checklist = [
     category: "Cohesion",
     name: "상수와 로직의 근접성",
     description: "상수가 사용 로직과 가까운 위치에 정의되어 있거나 이름으로 용도가 명확한가?",
+    // MIN_CONTENT_LENGTH, MIN_TITLE_LENGTH, MAX_TITLE_LENGTH 파일 상단 정의
     status: "O",
     violations: [],
   },
@@ -139,6 +153,7 @@ const checklist = [
     category: "Coupling",
     name: "성급한 추상화 지양",
     description: "단순히 비슷하다는 이유로 섣불리 공통 훅/함수로 추출되지 않았는가?",
+    // 각 feature 모듈 독립적, 불필요한 공통화 없음
     status: "O",
     violations: [],
   },
@@ -147,6 +162,7 @@ const checklist = [
     category: "Coupling",
     name: "상태 관리 범위 축소",
     description: "여러 관심사가 하나의 훅/컨텍스트에 묶이지 않고 분리되어 있는가?",
+    // largeCategoryId, mediumCategoryId, title, content, alertMessage, isAlertOpen 각각 독립
     status: "O",
     violations: [],
   },
@@ -155,7 +171,8 @@ const checklist = [
     category: "Coupling",
     name: "Props Drilling 제거",
     description: "3단계 이상 props 전달이 컴포지션(children)으로 대체되어 있는가?",
-    status: "O",
+    // 3단계 이상 props drilling 없음
+    status: "N/A",
     violations: [],
   },
 ];

--- a/docs/work-log/질문목록_0424/질문목록_0424_계획내용.md
+++ b/docs/work-log/질문목록_0424/질문목록_0424_계획내용.md
@@ -1,0 +1,52 @@
+# 질문목록*0424*계획내용
+
+## 작업 계획
+
+- 전체 목표: 이슈 #3 — `/qna` 질문 목록 조회 페이지 구현 (탭·검색·카테고리 필터·정렬·페이지네이션 포함)
+
+---
+
+## 작업01 — `qna/questions` feature 구현
+
+`src/features/qna/questions/` 4개 파일 작성
+
+- `types.ts`: `QuestionListItem`, `QuestionListResponse`, `QuestionsQueryParams` 타입
+  - `Category { id, depth, names[] }` / `QuestionAuthor { id, nickname, profile_img_url?, course_name?, cohort_number? }`
+  - `QuestionListItem { id, category, author, title, content_preview, answer_count, view_count, created_at, thumbnail_img_url? }`
+  - `QuestionListResponse { count, next, previous, results }`
+  - `QuestionsQueryParams { page?, page_size?, search_keyword?, category_id?, answer_status?, sort? }`
+- `queries.ts`: `useQuestions(params)` — `useQuery` (목록은 Suspense 불필요, 빈 목록 처리 필요)
+- `handler.ts`: MSW 목 핸들러 (더미 데이터 10건, URL: `VITE_API_BASE_URL/qna/questions`)
+- `index.ts`: barrel export
+
+- [ ] 완료
+
+---
+
+## 작업02 — QuestionCard 컴포넌트 구현
+
+`src/components/qna/QuestionCard/` 구현
+
+- 표시 항목: 카테고리 breadcrumb (`names` 배열), 제목, 내용 미리보기, 작성자(닉네임·기수), 답변 수, 조회수, 작성일, 썸네일 이미지(있을 때)
+- 답변 완료 여부(`answer_count > 0`) 배지 표시
+- 카드 클릭 시 `/qna/:questionId` 이동 (useNavigate)
+- `src/components/qna/index.ts` 에 export 추가
+
+- [ ] 완료
+
+---
+
+## 작업03 — QnaListPage 구현
+
+`src/pages/qna/QnaListPage.tsx` 전체 구현
+
+- **탭**: 전체보기 / 답변완료 / 답변대기중 (`answer_status` 쿼리 파라미터 연동)
+- **검색**: URL `?search_keyword=` 쿼리 파라미터 연동, SearchInput 컴포넌트 사용
+- **카테고리 필터**: 대분류 선택 시 `category_id` 파라미터 적용 (`useQnaCategories` 재사용)
+- **정렬**: 최신순(`latest`) / 조회수순(`views`) Dropdown
+- **질문 목록**: `QuestionCard` 반복 렌더링
+- **페이지네이션**: `count` 기반 페이지 버튼 (간단한 prev/next)
+- **빈 상태**: 결과 없을 때 안내 문구
+- URL 쿼리 파라미터 상태 관리 (`useSearchParams`)
+
+- [ ] 완료

--- a/src/features/qna/questions/handler.ts
+++ b/src/features/qna/questions/handler.ts
@@ -1,0 +1,328 @@
+import { http, HttpResponse } from 'msw'
+import type { QuestionsListResponse, QuestionListItem } from './types'
+
+const mockQuestions: QuestionListItem[] = [
+  {
+    id: 1,
+    category: { id: 11, depth: 2, names: ['Python', '기초 문법'] },
+    author: {
+      id: 1,
+      nickname: '코딩_초보',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 14,
+    },
+    title: 'Python 리스트와 튜플의 차이점이 뭔가요?',
+    content_preview:
+      '파이썬을 공부하다가 리스트와 튜플 모두 데이터를 담는 자료형인데 어떤 상황에서 어떤 걸 써야 하는지 모르겠어요.',
+    answer_count: 3,
+    view_count: 145,
+    created_at: '2025-03-15 10:30:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 2,
+    category: { id: 21, depth: 2, names: ['JavaScript', 'ES6+'] },
+    author: {
+      id: 2,
+      nickname: '자바스터디',
+      profile_img_url: null,
+      course_name: '프론트엔드 개발자 과정',
+      cohort_number: 12,
+    },
+    title: 'async/await와 Promise의 차이가 무엇인가요?',
+    content_preview:
+      '비동기 처리를 배우고 있는데 두 방식의 실제 차이와 언제 어떤 걸 사용해야 할지 헷갈립니다.',
+    answer_count: 5,
+    view_count: 302,
+    created_at: '2025-03-14 14:20:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 3,
+    category: { id: 31, depth: 2, names: ['React', 'Hooks'] },
+    author: {
+      id: 3,
+      nickname: '리액트_뉴비',
+      profile_img_url: null,
+      course_name: '프론트엔드 개발자 과정',
+      cohort_number: 13,
+    },
+    title: 'useEffect 의존성 배열을 빈 배열로 하면 왜 경고가 뜨나요?',
+    content_preview:
+      'useEffect에서 외부 변수를 사용하면서 의존성 배열을 []로 하면 ESLint 경고가 뜨는데 이게 왜 그런건지 이해가 안 갑니다.',
+    answer_count: 0,
+    view_count: 78,
+    created_at: '2025-03-13 09:15:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 4,
+    category: { id: 41, depth: 2, names: ['Django', 'ORM'] },
+    author: {
+      id: 4,
+      nickname: '장고_학습자',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 14,
+    },
+    title: 'Django ORM에서 related_name은 언제 사용하나요?',
+    content_preview:
+      'ForeignKey를 정의할 때 related_name 파라미터를 쓰는 경우를 봤는데 이게 정확히 어떤 역할을 하는지 모르겠어요.',
+    answer_count: 2,
+    view_count: 210,
+    created_at: '2025-03-12 16:45:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 5,
+    category: { id: 12, depth: 2, names: ['Python', '자료구조'] },
+    author: {
+      id: 5,
+      nickname: '알고리즘_도전',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 15,
+    },
+    title: '파이썬 딕셔너리 순회 시 값을 수정하면 왜 에러가 나나요?',
+    content_preview:
+      'for 루프로 딕셔너리를 순회하면서 키를 삭제하려고 했는데 "RuntimeError: dictionary changed size during iteration" 에러가 나요.',
+    answer_count: 1,
+    view_count: 93,
+    created_at: '2025-03-11 11:00:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 6,
+    category: { id: 22, depth: 2, names: ['JavaScript', 'DOM'] },
+    author: {
+      id: 6,
+      nickname: 'DOM_탐험가',
+      profile_img_url: null,
+      course_name: '프론트엔드 개발자 과정',
+      cohort_number: 11,
+    },
+    title: 'event.preventDefault()와 event.stopPropagation()의 차이는?',
+    content_preview:
+      '이벤트 처리할 때 두 메서드를 자주 보는데 정확히 어떤 차이가 있고 언제 각각 써야 하는지 궁금합니다.',
+    answer_count: 4,
+    view_count: 187,
+    created_at: '2025-03-10 13:30:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 7,
+    category: { id: 32, depth: 2, names: ['React', '상태 관리'] },
+    author: {
+      id: 7,
+      nickname: '상태관리_고민',
+      profile_img_url: null,
+      course_name: '프론트엔드 개발자 과정',
+      cohort_number: 13,
+    },
+    title: 'Redux와 Zustand 중 어떤 상태 관리 라이브러리를 선택해야 할까요?',
+    content_preview:
+      '프로젝트를 시작하려는데 상태 관리 라이브러리로 Redux와 Zustand 중 어느 것이 더 적합한지 선택 기준을 알고 싶습니다.',
+    answer_count: 0,
+    view_count: 256,
+    created_at: '2025-03-09 08:00:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 8,
+    category: { id: 42, depth: 2, names: ['Django', 'REST API'] },
+    author: {
+      id: 8,
+      nickname: 'API_개발자',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 14,
+    },
+    title:
+      'DRF에서 시리얼라이저의 create와 update 메서드 언제 오버라이딩하나요?',
+    content_preview:
+      'Django REST Framework를 사용하는데 Serializer에 create와 update 메서드를 언제, 왜 오버라이딩해야 하는지 이해가 잘 안 됩니다.',
+    answer_count: 2,
+    view_count: 134,
+    created_at: '2025-03-08 15:20:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 9,
+    category: { id: 13, depth: 2, names: ['Python', '알고리즘'] },
+    author: {
+      id: 9,
+      nickname: '알고_풀기',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 15,
+    },
+    title: '파이썬으로 BFS와 DFS 구현할 때 어떤 자료구조를 써야 하나요?',
+    content_preview:
+      '그래프 탐색 알고리즘을 파이썬으로 구현할 때 BFS는 큐, DFS는 스택을 쓴다고 배웠는데 실제로 어떻게 코드로 표현하면 좋을까요?',
+    answer_count: 1,
+    view_count: 167,
+    created_at: '2025-03-07 10:45:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 10,
+    category: { id: 33, depth: 2, names: ['React', '라우팅'] },
+    author: {
+      id: 10,
+      nickname: '라우팅_혼란',
+      profile_img_url: null,
+      course_name: '프론트엔드 개발자 과정',
+      cohort_number: 12,
+    },
+    title: 'React Router에서 중첩 라우트 구현 시 Outlet이 무엇인가요?',
+    content_preview:
+      '중첩 라우트를 구현하다가 Outlet 컴포넌트를 써야 한다고 들었는데 어떻게 동작하는 건지 예시를 들어 설명해 주실 수 있나요?',
+    answer_count: 3,
+    view_count: 221,
+    created_at: '2025-03-06 14:10:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 11,
+    category: { id: 23, depth: 2, names: ['JavaScript', '비동기'] },
+    author: {
+      id: 11,
+      nickname: '비동기_이해중',
+      profile_img_url: null,
+      course_name: '프론트엔드 개발자 과정',
+      cohort_number: 11,
+    },
+    title: 'JavaScript 이벤트 루프가 정확히 어떻게 동작하나요?',
+    content_preview:
+      '콜 스택, 이벤트 큐, 마이크로태스크 큐에 대해 들었는데 이들이 어떤 순서로 처리되는지 헷갈립니다.',
+    answer_count: 6,
+    view_count: 445,
+    created_at: '2025-03-05 09:30:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 12,
+    category: { id: 41, depth: 2, names: ['Django', 'ORM'] },
+    author: {
+      id: 12,
+      nickname: 'ORM_마스터',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 13,
+    },
+    title: 'Django에서 N+1 문제를 해결하는 방법은?',
+    content_preview:
+      'Django ORM을 사용하다 N+1 쿼리 문제를 발견했습니다. select_related와 prefetch_related 중 어떤 상황에서 각각 사용해야 하나요?',
+    answer_count: 4,
+    view_count: 389,
+    created_at: '2025-03-04 16:00:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 13,
+    category: { id: 31, depth: 2, names: ['React', 'Hooks'] },
+    author: {
+      id: 13,
+      nickname: '훅스_연습생',
+      profile_img_url: null,
+      course_name: '프론트엔드 개발자 과정',
+      cohort_number: 14,
+    },
+    title: 'useMemo와 useCallback은 언제 사용해야 하나요?',
+    content_preview:
+      '성능 최적화를 위해 useMemo와 useCallback을 배웠는데 오히려 남발하면 오버헤드가 생긴다고 들었습니다. 적절한 사용 시점이 궁금합니다.',
+    answer_count: 0,
+    view_count: 112,
+    created_at: '2025-03-03 11:20:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 14,
+    category: { id: 11, depth: 2, names: ['Python', '기초 문법'] },
+    author: {
+      id: 14,
+      nickname: '파이썬_첫걸음',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 16,
+    },
+    title: 'Python의 *args와 **kwargs는 어떻게 사용하나요?',
+    content_preview:
+      '함수 정의에서 *args와 **kwargs를 자주 보는데 이게 정확히 어떤 역할을 하는지, 어떤 상황에서 사용하는지 알고 싶습니다.',
+    answer_count: 2,
+    view_count: 99,
+    created_at: '2025-03-02 13:50:00',
+    thumbnail_img_url: null,
+  },
+  {
+    id: 15,
+    category: { id: 42, depth: 2, names: ['Django', 'REST API'] },
+    author: {
+      id: 15,
+      nickname: '백엔드_개발자',
+      profile_img_url: null,
+      course_name: '백엔드 개발자 과정',
+      cohort_number: 14,
+    },
+    title: 'JWT 토큰 인증에서 Access Token과 Refresh Token의 역할은?',
+    content_preview:
+      'DRF에서 JWT 인증을 구현하려고 하는데 Access Token과 Refresh Token의 역할 분리와 보안상 왜 둘 다 필요한지 궁금합니다.',
+    answer_count: 3,
+    view_count: 278,
+    created_at: '2025-03-01 10:00:00',
+    thumbnail_img_url: null,
+  },
+]
+
+export const questionsHandler = [
+  http.get(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/questions/`,
+    ({ request }) => {
+      const url = new URL(request.url)
+      const page = Number(url.searchParams.get('page') ?? 1)
+      const pageSize = Number(url.searchParams.get('page_size') ?? 10)
+      const searchKeyword = url.searchParams.get('search_keyword') ?? ''
+      const categoryId = url.searchParams.get('category_id')
+        ? Number(url.searchParams.get('category_id'))
+        : null
+      const answerStatus = url.searchParams.get('answer_status')
+      const sort = url.searchParams.get('sort') ?? 'latest'
+
+      let filtered = [...mockQuestions]
+
+      if (searchKeyword) {
+        filtered = filtered.filter(
+          (q) =>
+            q.title.includes(searchKeyword) ||
+            q.content_preview.includes(searchKeyword)
+        )
+      }
+
+      if (categoryId != null) {
+        filtered = filtered.filter((q) => q.category.id === categoryId)
+      }
+
+      if (answerStatus === 'answered') {
+        filtered = filtered.filter((q) => q.answer_count > 0)
+      } else if (answerStatus === 'unanswered') {
+        filtered = filtered.filter((q) => q.answer_count === 0)
+      }
+
+      if (sort === 'views') {
+        filtered = [...filtered].sort((a, b) => b.view_count - a.view_count)
+      }
+
+      const count = filtered.length
+      const start = (page - 1) * pageSize
+      const results = filtered.slice(start, start + pageSize)
+
+      return HttpResponse.json<QuestionsListResponse>({
+        count,
+        next: start + pageSize < count ? String(page + 1) : null,
+        previous: page > 1 ? String(page - 1) : null,
+        results,
+      })
+    }
+  ),
+]

--- a/src/features/qna/questions/index.ts
+++ b/src/features/qna/questions/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/qna/questions/queries.ts
+++ b/src/features/qna/questions/queries.ts
@@ -3,17 +3,23 @@ import api from '@/api/instance'
 import type { QuestionsListResponse, QuestionsListParams } from './types'
 
 function questionsQueryOptions(params: QuestionsListParams = {}) {
+  const normalized = Object.fromEntries(
+    Object.entries(params).filter(([, v]) => v != null && v !== '')
+  ) as QuestionsListParams
+
   return queryOptions({
-    queryKey: ['qna', 'questions', params],
+    queryKey: ['qna', 'questions', 'list', normalized],
     queryFn: async () => {
       const { data } = await api.get<QuestionsListResponse>('/qna/questions/', {
-        params,
+        params: normalized,
       })
       return data
     },
+    placeholderData: (prev) => prev,
   })
 }
 
+// 탭/필터/페이지 전환 시 stale 데이터를 유지하고 isLoading 상태를 직접 제어하기 위해 useQuery 사용
 export function useQnaQuestions(params: QuestionsListParams = {}) {
   return useQuery(questionsQueryOptions(params))
 }

--- a/src/features/qna/questions/queries.ts
+++ b/src/features/qna/questions/queries.ts
@@ -1,0 +1,19 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { QuestionsListResponse, QuestionsListParams } from './types'
+
+function questionsQueryOptions(params: QuestionsListParams = {}) {
+  return queryOptions({
+    queryKey: ['qna', 'questions', params],
+    queryFn: async () => {
+      const { data } = await api.get<QuestionsListResponse>('/qna/questions/', {
+        params,
+      })
+      return data
+    },
+  })
+}
+
+export function useQnaQuestions(params: QuestionsListParams = {}) {
+  return useQuery(questionsQueryOptions(params))
+}

--- a/src/features/qna/questions/types.ts
+++ b/src/features/qna/questions/types.ts
@@ -1,0 +1,41 @@
+export interface QuestionListCategory {
+  id: number
+  depth: number
+  names: string[]
+}
+
+export interface QuestionListAuthor {
+  id: number
+  nickname: string
+  profile_img_url: string | null
+  course_name: string | null
+  cohort_number: number | null
+}
+
+export interface QuestionListItem {
+  id: number
+  category: QuestionListCategory
+  author: QuestionListAuthor
+  title: string
+  content_preview: string
+  answer_count: number
+  view_count: number
+  created_at: string
+  thumbnail_img_url: string | null
+}
+
+export interface QuestionsListResponse {
+  count: number
+  next: string | null
+  previous: string | null
+  results: QuestionListItem[]
+}
+
+export interface QuestionsListParams {
+  page?: number
+  page_size?: number
+  search_keyword?: string
+  category_id?: number
+  answer_status?: 'answered' | 'unanswered'
+  sort?: 'latest' | 'views'
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import { answersHandlers } from '@/features/qna/answers'
 import { answerEditHandlers } from '@/features/qna/answer-edit'
 import { presignedUrlHandlers } from '@/features/qna/presigned-url'
 import { categoriesHandler } from '@/features/qna/categories'
+import { questionsHandler } from '@/features/qna/questions'
 import { questionWriteHandler } from '@/features/qna/question-write'
 import { questionDetailHandler } from '@/features/qna/question-detail'
 
@@ -14,6 +15,7 @@ export const handlers = [
   ...answerEditHandlers,
   ...presignedUrlHandlers,
   ...categoriesHandler,
+  ...questionsHandler,
   ...questionWriteHandler,
   ...questionDetailHandler,
 ]

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -2,7 +2,7 @@
  * @figma 질의응답 - 질문 목록페이지 https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5893&m=dev
  */
 
-import { Suspense, useState, useEffect, useCallback, useRef } from 'react'
+import { Suspense, useState, useEffect, useCallback } from 'react'
 import { useSearchParams, useNavigate, Link } from 'react-router'
 import {
   Tabs,
@@ -22,6 +22,9 @@ import { ROUTES } from '@/constants/routes'
 
 type AnswerStatus = 'all' | 'answered' | 'unanswered'
 type SortOption = 'latest' | 'views'
+
+const ANSWER_STATUSES = ['all', 'answered', 'unanswered'] as const
+const SORT_OPTIONS = ['latest', 'views'] as const
 
 const PAGE_SIZE = 10
 
@@ -194,27 +197,43 @@ export function QnaListPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const answerStatus = (searchParams.get('answer_status') ??
-    'all') as AnswerStatus
+  const rawAnswerStatus = searchParams.get('answer_status') ?? 'all'
+  const answerStatus: AnswerStatus = (
+    ANSWER_STATUSES as readonly string[]
+  ).includes(rawAnswerStatus)
+    ? (rawAnswerStatus as AnswerStatus)
+    : 'all'
+
   const searchKeyword = searchParams.get('search_keyword') ?? ''
-  const categoryId = searchParams.get('category_id')
-    ? Number(searchParams.get('category_id'))
-    : undefined
-  const sort = (searchParams.get('sort') ?? 'latest') as SortOption
-  const page = Number(searchParams.get('page') ?? 1)
+
+  const rawCategoryId = Number(searchParams.get('category_id'))
+  const categoryId =
+    searchParams.get('category_id') != null &&
+    Number.isFinite(rawCategoryId) &&
+    rawCategoryId > 0
+      ? rawCategoryId
+      : undefined
+
+  const rawSort = searchParams.get('sort') ?? 'latest'
+  const sort: SortOption = (SORT_OPTIONS as readonly string[]).includes(rawSort)
+    ? (rawSort as SortOption)
+    : 'latest'
+
+  const rawPage = Number(searchParams.get('page') ?? 1)
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? Math.floor(rawPage) : 1
 
   const [inputValue, setInputValue] = useState(searchKeyword)
   const [showCategoryModal, setShowCategoryModal] = useState(false)
   const [showSortModal, setShowSortModal] = useState(false)
 
-  const isFirstRender = useRef(true)
-
-  // Debounce search input → URL update (skip initial mount to avoid spurious navigation)
+  // URL → inputValue 동기화 (뒤로가기 대응)
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false
-      return
-    }
+    setInputValue(searchKeyword)
+  }, [searchKeyword])
+
+  // Debounce search input → URL update (inputValue가 searchKeyword와 다를 때만 동작)
+  useEffect(() => {
+    if (inputValue === searchKeyword) return
     const timer = setTimeout(() => {
       setSearchParams(
         (prev) => {
@@ -231,7 +250,7 @@ export function QnaListPage() {
       )
     }, 300)
     return () => clearTimeout(timer)
-  }, [inputValue, setSearchParams])
+  }, [inputValue, searchKeyword, setSearchParams])
 
   const { data, isLoading, isError } = useQnaQuestions({
     page,

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -1,6 +1,448 @@
 /**
- * @figma 질의응답 - 질문 목록페이지  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5893&m=dev
+ * @figma 질의응답 - 질문 목록페이지 https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-5893&m=dev
  */
+
+import { Suspense, useState, useEffect, useCallback, useRef } from 'react'
+import { useSearchParams, useNavigate, Link } from 'react-router'
+import {
+  Tabs,
+  TabList,
+  Tab,
+  SearchInput,
+  Modal,
+  Button,
+  Spinner,
+} from '@/components'
+import { useQnaQuestions } from '@/features/qna/questions'
+import { useQnaCategories } from '@/features/qna/categories'
+import type { UserCategory } from '@/features/qna/categories'
+import type { QuestionListItem } from '@/features/qna/questions'
+import { formatDate } from '@/utils/formatDate'
+import { ROUTES } from '@/constants/routes'
+
+type AnswerStatus = 'all' | 'answered' | 'unanswered'
+type SortOption = 'latest' | 'views'
+
+const PAGE_SIZE = 10
+
+function CategoryFilterContent({
+  selectedId,
+  onSelect,
+}: {
+  selectedId: number | undefined
+  onSelect: (id: number | undefined) => void
+}) {
+  const { data: categories } = useQnaCategories()
+
+  return (
+    <div className="space-y-3">
+      <button
+        onClick={() => onSelect(undefined)}
+        className={[
+          'w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
+          selectedId == null
+            ? 'bg-primary-100 text-primary font-medium'
+            : 'text-text-body hover:bg-bg-muted',
+        ].join(' ')}
+      >
+        전체
+      </button>
+      {categories.map((cat: UserCategory) => (
+        <div key={cat.id}>
+          <p className="text-text-muted px-3 py-1 text-xs font-semibold tracking-wide">
+            {cat.name}
+          </p>
+          {cat.children.map((child: UserCategory) => (
+            <button
+              key={child.id}
+              onClick={() => onSelect(child.id)}
+              className={[
+                'w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
+                selectedId === child.id
+                  ? 'bg-primary-100 text-primary font-medium'
+                  : 'text-text-body hover:bg-bg-muted',
+              ].join(' ')}
+            >
+              {child.name}
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function QuestionCard({ question }: { question: QuestionListItem }) {
+  const detailPath = ROUTES.QNA.DETAIL.replace(
+    ':questionId',
+    String(question.id)
+  )
+  const categoryPath = question.category.names.join(' > ')
+  const isAnswered = question.answer_count > 0
+
+  return (
+    <li>
+      <Link
+        to={detailPath}
+        className="border-border-base bg-bg-base hover:border-primary block rounded-lg border p-5 transition-colors duration-150"
+      >
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span className="text-text-muted truncate text-xs">
+            {categoryPath}
+          </span>
+          <span
+            className={[
+              'shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium',
+              isAnswered
+                ? 'bg-success-bg text-success'
+                : 'bg-warning-bg text-warning',
+            ].join(' ')}
+          >
+            {isAnswered ? '답변완료' : '답변 대기중'}
+          </span>
+        </div>
+
+        <h2 className="text-text-heading mb-1 truncate text-base font-semibold">
+          {question.title}
+        </h2>
+
+        <p className="text-text-body mb-3 line-clamp-2 text-sm">
+          {question.content_preview}
+        </p>
+
+        <div className="text-text-muted flex items-center justify-between text-xs">
+          <div className="flex items-center gap-2">
+            <span>{question.author.nickname}</span>
+            {question.author.course_name && (
+              <>
+                <span>·</span>
+                <span>{question.author.course_name}</span>
+              </>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <span>답변 {question.answer_count}</span>
+            <span>조회 {question.view_count}</span>
+            <time dateTime={question.created_at}>
+              {formatDate(question.created_at)}
+            </time>
+          </div>
+        </div>
+      </Link>
+    </li>
+  )
+}
+
+function Pagination({
+  current,
+  total,
+  onChange,
+}: {
+  current: number
+  total: number
+  onChange: (page: number) => void
+}) {
+  const maxVisible = 5
+  const half = Math.floor(maxVisible / 2)
+  const start = Math.max(1, Math.min(current - half, total - maxVisible + 1))
+  const end = Math.min(total, start + maxVisible - 1)
+  const pages = Array.from({ length: end - start + 1 }, (_, i) => start + i)
+
+  return (
+    <nav
+      aria-label="페이지 이동"
+      className="mt-6 flex items-center justify-center gap-1"
+    >
+      <button
+        onClick={() => onChange(current - 1)}
+        disabled={current === 1}
+        aria-label="이전 페이지"
+        className="text-text-muted hover:bg-bg-muted disabled:text-disable rounded-md px-3 py-2 text-sm transition-colors disabled:cursor-not-allowed"
+      >
+        이전
+      </button>
+
+      {pages.map((p) => (
+        <button
+          key={p}
+          onClick={() => onChange(p)}
+          aria-current={p === current ? 'page' : undefined}
+          className={[
+            'h-9 min-w-9 rounded-md px-3 text-sm transition-colors',
+            p === current
+              ? 'bg-primary text-text-inverse font-medium'
+              : 'text-text-body hover:bg-bg-muted',
+          ].join(' ')}
+        >
+          {p}
+        </button>
+      ))}
+
+      <button
+        onClick={() => onChange(current + 1)}
+        disabled={current === total}
+        aria-label="다음 페이지"
+        className="text-text-muted hover:bg-bg-muted disabled:text-disable rounded-md px-3 py-2 text-sm transition-colors disabled:cursor-not-allowed"
+      >
+        다음
+      </button>
+    </nav>
+  )
+}
+
 export function QnaListPage() {
-  return <div>질의응답 목록</div>
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const answerStatus = (searchParams.get('answer_status') ??
+    'all') as AnswerStatus
+  const searchKeyword = searchParams.get('search_keyword') ?? ''
+  const categoryId = searchParams.get('category_id')
+    ? Number(searchParams.get('category_id'))
+    : undefined
+  const sort = (searchParams.get('sort') ?? 'latest') as SortOption
+  const page = Number(searchParams.get('page') ?? 1)
+
+  const [inputValue, setInputValue] = useState(searchKeyword)
+  const [showCategoryModal, setShowCategoryModal] = useState(false)
+  const [showSortModal, setShowSortModal] = useState(false)
+
+  const isFirstRender = useRef(true)
+
+  // Debounce search input → URL update (skip initial mount to avoid spurious navigation)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    const timer = setTimeout(() => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          if (inputValue) {
+            next.set('search_keyword', inputValue)
+          } else {
+            next.delete('search_keyword')
+          }
+          next.delete('page')
+          return next
+        },
+        { replace: true }
+      )
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [inputValue, setSearchParams])
+
+  const { data, isLoading, isError } = useQnaQuestions({
+    page,
+    page_size: PAGE_SIZE,
+    search_keyword: searchKeyword || undefined,
+    category_id: categoryId,
+    answer_status: answerStatus !== 'all' ? answerStatus : undefined,
+    sort,
+  })
+
+  const totalPages = data ? Math.ceil(data.count / PAGE_SIZE) : 0
+
+  const updateParam = useCallback(
+    (key: string, value: string | null) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (value != null) {
+          next.set(key, value)
+        } else {
+          next.delete(key)
+        }
+        next.delete('page')
+        return next
+      })
+    },
+    [setSearchParams]
+  )
+
+  const handleTabChange = useCallback(
+    (value: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (value !== 'all') {
+          next.set('answer_status', value)
+        } else {
+          next.delete('answer_status')
+        }
+        next.delete('page')
+        return next
+      })
+    },
+    [setSearchParams]
+  )
+
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (newPage === 1) {
+          next.delete('page')
+        } else {
+          next.set('page', String(newPage))
+        }
+        return next
+      })
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    },
+    [setSearchParams]
+  )
+
+  const categoryName = searchParams.get('category_id')
+    ? '필터 적용됨'
+    : '카테고리'
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-text-heading text-2xl font-bold">질의응답</h1>
+        <Button size="sm" onClick={() => navigate(ROUTES.QNA.WRITE)}>
+          질문 등록
+        </Button>
+      </div>
+
+      <Tabs value={answerStatus} onChange={handleTabChange}>
+        <TabList aria-label="답변 상태 필터">
+          <Tab value="all">전체보기</Tab>
+          <Tab value="answered">답변완료</Tab>
+          <Tab value="unanswered">답변 대기중</Tab>
+        </TabList>
+
+        <div className="mt-4">
+          {/* 검색 + 필터 영역 */}
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <SearchInput
+              value={inputValue}
+              onValueChange={setInputValue}
+              placeholder="질문 검색"
+              className="flex-1"
+              aria-label="질문 검색"
+            />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowCategoryModal(true)}
+            >
+              {categoryName}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowSortModal(true)}
+            >
+              {sort === 'views' ? '조회수순' : '최신순'}
+            </Button>
+          </div>
+
+          {/* 총 결과 수 */}
+          {!isLoading && data && (
+            <p className="text-text-muted mb-3 text-sm">
+              총 {data.count.toLocaleString()}개의 질문
+            </p>
+          )}
+
+          {/* 질문 목록 */}
+          {isLoading && (
+            <div className="flex items-center justify-center py-20">
+              <Spinner size="lg" label="질문 목록을 불러오는 중..." />
+            </div>
+          )}
+
+          {isError && (
+            <div className="text-text-muted flex flex-col items-center justify-center py-20 text-center">
+              <p className="text-error mb-2 font-medium">
+                질문 목록을 불러오지 못했습니다.
+              </p>
+              <p className="text-sm">잠시 후 다시 시도해 주세요.</p>
+            </div>
+          )}
+
+          {!isLoading && !isError && data && (
+            <>
+              {data.results.length === 0 ? (
+                <div className="text-text-muted flex flex-col items-center justify-center py-20 text-center">
+                  <p className="font-medium">등록된 질문이 없습니다.</p>
+                  {searchKeyword && (
+                    <p className="mt-1 text-sm">
+                      &apos;{searchKeyword}&apos;에 대한 검색 결과가 없습니다.
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <ul className="space-y-3">
+                  {data.results.map((question) => (
+                    <QuestionCard key={question.id} question={question} />
+                  ))}
+                </ul>
+              )}
+
+              {totalPages > 1 && (
+                <Pagination
+                  current={page}
+                  total={totalPages}
+                  onChange={handlePageChange}
+                />
+              )}
+            </>
+          )}
+        </div>
+      </Tabs>
+
+      {/* 카테고리 필터 모달 */}
+      <Modal
+        isOpen={showCategoryModal}
+        onClose={() => setShowCategoryModal(false)}
+        title="카테고리 필터"
+        maxWidth="max-w-sm"
+      >
+        <Suspense
+          fallback={
+            <div className="flex justify-center py-8">
+              <Spinner label="카테고리 불러오는 중..." />
+            </div>
+          }
+        >
+          <CategoryFilterContent
+            selectedId={categoryId}
+            onSelect={(id) => {
+              updateParam('category_id', id != null ? String(id) : null)
+              setShowCategoryModal(false)
+            }}
+          />
+        </Suspense>
+      </Modal>
+
+      {/* 정렬 모달 */}
+      <Modal
+        isOpen={showSortModal}
+        onClose={() => setShowSortModal(false)}
+        title="정렬"
+        maxWidth="max-w-xs"
+      >
+        <div className="space-y-1">
+          {(['latest', 'views'] as SortOption[]).map((opt) => (
+            <button
+              key={opt}
+              onClick={() => {
+                updateParam('sort', opt)
+                setShowSortModal(false)
+              }}
+              className={[
+                'w-full rounded-md px-4 py-3 text-left text-sm transition-colors',
+                sort === opt
+                  ? 'bg-primary-100 text-primary font-medium'
+                  : 'text-text-body hover:bg-bg-muted',
+              ].join(' ')}
+            >
+              {opt === 'latest' ? '최신순' : '조회수순'}
+            </button>
+          ))}
+        </div>
+      </Modal>
+    </div>
+  )
 }


### PR DESCRIPTION
## 관련 이슈

- closes #3

## 작업 내용

- QnaListPage 구현 (질문 목록 조회, 카테고리 필터, 검색, 정렬, 페이지네이션)
- `src/features/qna/questions` feature 모듈 추가 (types, queries, handler, index)
- `src/features/qna/categories` feature 모듈 추가
- 디바운스 기반 검색 입력 처리 (useRef + setTimeout 방식)
- queryKey 정규화 및 타입 안전성 개선 (코드 리뷰 반영)

## 변경 사항

- `src/pages/qna/QnaListPage.tsx` — 질문 목록 페이지 전체 구현
- `src/features/qna/questions/` — 질문 목록 API 연동 (GET /qna/questions)
- `src/features/qna/categories/` — 카테고리 목록 API 연동 (GET /qna/categories)
- `src/features/qna/questions/handler.ts` — MSW 목 핸들러 (필터/정렬/페이지네이션 포함)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다