### PR TITLE
style: QnaListPage 피그마 디자인 반영 (#23)

### DIFF
--- a/src/components/qna/CategoryFilter/CategoryFilter.tsx
+++ b/src/components/qna/CategoryFilter/CategoryFilter.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react'
+import { Dropdown, Button } from '@/components'
+import { useQnaCategories } from '@/features/qna/categories'
+import type { UserCategory } from '@/features/qna/categories'
+
+function findCategoryPath(
+  categories: UserCategory[],
+  targetId: number | undefined
+): { large: string; medium: string; small: string } {
+  if (!targetId) return { large: '', medium: '', small: '' }
+  for (const large of categories) {
+    if (large.id === targetId)
+      return { large: String(large.id), medium: '', small: '' }
+    for (const medium of large.children) {
+      if (medium.id === targetId)
+        return { large: String(large.id), medium: String(medium.id), small: '' }
+      for (const small of medium.children) {
+        if (small.id === targetId)
+          return {
+            large: String(large.id),
+            medium: String(medium.id),
+            small: String(small.id),
+          }
+      }
+    }
+  }
+  return { large: '', medium: '', small: '' }
+}
+
+export function CategoryFilter({
+  initialCategoryId,
+  onApply,
+  onClose,
+}: {
+  initialCategoryId?: number
+  onApply: (id: number | undefined) => void
+  onClose: () => void
+}) {
+  const { data: categories } = useQnaCategories()
+
+  const initialPath = findCategoryPath(categories, initialCategoryId)
+  const [largeCategoryId, setLargeCategoryId] = useState(initialPath.large)
+  const [mediumCategoryId, setMediumCategoryId] = useState(initialPath.medium)
+  const [smallCategoryId, setSmallCategoryId] = useState(initialPath.small)
+
+  const largeOptions = categories.map((cat: UserCategory) => ({
+    value: String(cat.id),
+    label: cat.name,
+  }))
+
+  const selectedLarge = categories.find(
+    (cat: UserCategory) => String(cat.id) === largeCategoryId
+  )
+
+  const mediumOptions =
+    selectedLarge?.children.map((child: UserCategory) => ({
+      value: String(child.id),
+      label: child.name,
+    })) ?? []
+
+  const hasMedium = mediumOptions.length > 0
+  const isMediumValid = mediumOptions.some((o) => o.value === mediumCategoryId)
+  const validMediumCategoryId = isMediumValid ? mediumCategoryId : ''
+
+  const selectedMedium = selectedLarge?.children.find(
+    (c: UserCategory) => String(c.id) === validMediumCategoryId
+  )
+
+  const smallOptions =
+    selectedMedium?.children.map((child: UserCategory) => ({
+      value: String(child.id),
+      label: child.name,
+    })) ?? []
+
+  const hasSmall = smallOptions.length > 0
+  const isSmallValid = smallOptions.some((o) => o.value === smallCategoryId)
+  const validSmallCategoryId = isSmallValid ? smallCategoryId : ''
+
+  const handleLargeChange = (value: string) => {
+    setLargeCategoryId(value)
+    setMediumCategoryId('')
+    setSmallCategoryId('')
+  }
+
+  const handleMediumChange = (value: string) => {
+    setMediumCategoryId(value)
+    setSmallCategoryId('')
+  }
+
+  const handleSmallChange = (value: string) => {
+    setSmallCategoryId(value)
+  }
+
+  const handleReset = () => {
+    setLargeCategoryId('')
+    setMediumCategoryId('')
+    setSmallCategoryId('')
+  }
+
+  const handleApply = () => {
+    const leafId =
+      validSmallCategoryId || validMediumCategoryId || largeCategoryId
+    onApply(leafId ? Number(leafId) : undefined)
+    onClose()
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        <Dropdown
+          options={largeOptions}
+          value={largeCategoryId}
+          onChange={handleLargeChange}
+          placeholder="대분류 선택"
+        />
+        <Dropdown
+          options={mediumOptions}
+          value={validMediumCategoryId}
+          onChange={handleMediumChange}
+          placeholder="중분류 선택"
+          disabled={!largeCategoryId || !hasMedium}
+        />
+        <Dropdown
+          options={smallOptions}
+          value={validSmallCategoryId}
+          onChange={handleSmallChange}
+          placeholder="소분류 선택"
+          disabled={!validMediumCategoryId || !hasSmall}
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-3 pt-1">
+        <Button variant="ghost" size="sm" onClick={handleReset}>
+          선택 초기화
+        </Button>
+        <Button variant="primary" size="sm" onClick={handleApply}>
+          필터 적용하기
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/qna/CategoryFilter/index.ts
+++ b/src/components/qna/CategoryFilter/index.ts
@@ -1,0 +1,1 @@
+export { CategoryFilter } from './CategoryFilter'

--- a/src/components/qna/QuestionCard/QuestionCard.tsx
+++ b/src/components/qna/QuestionCard/QuestionCard.tsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router'
+import type { QuestionListItem } from '@/features/qna/questions'
+import { formatDate } from '@/utils/formatDate'
+import { ROUTES } from '@/constants/routes'
+
+export function QuestionCard({ question }: { question: QuestionListItem }) {
+  const detailPath = ROUTES.QNA.DETAIL.replace(
+    ':questionId',
+    String(question.id)
+  )
+  const categoryPath = question.category.names.join(' > ')
+  const isAnswered = question.answer_count > 0
+
+  return (
+    <li>
+      <Link
+        to={detailPath}
+        className="border-border-base bg-bg-base hover:border-primary block rounded-lg border p-5 transition-colors duration-150"
+      >
+        <div className="flex">
+          {/* 텍스트 영역 */}
+          <div className="min-w-0 flex-1 pr-4">
+            <div className="mb-2 flex items-center gap-2">
+              <span className="text-text-muted truncate text-xs">
+                {categoryPath}
+              </span>
+            </div>
+
+            <h2 className="text-text-heading mb-1 truncate text-base font-semibold">
+              {question.title}
+            </h2>
+
+            <p className="text-text-body mb-3 line-clamp-2 text-sm">
+              {question.content_preview}
+            </p>
+
+            {/* 하단: A 마크 + 조회수 / 작성자 + 날짜 */}
+            <div className="flex items-center justify-between text-xs">
+              <div className="flex items-center gap-3">
+                <span className="flex items-center gap-1.5">
+                  <span
+                    className={[
+                      'inline-flex h-5 w-5 items-center justify-center rounded text-[11px] font-bold',
+                      isAnswered
+                        ? 'bg-success text-white'
+                        : 'text-text-muted bg-gray-100',
+                    ].join(' ')}
+                  >
+                    A
+                  </span>
+                  <span
+                    className={
+                      isAnswered
+                        ? 'text-success font-medium'
+                        : 'text-text-muted'
+                    }
+                  >
+                    {question.answer_count}
+                  </span>
+                </span>
+                <span className="text-text-muted">
+                  조회 {question.view_count}
+                </span>
+              </div>
+              <div className="text-text-muted flex items-center gap-1.5">
+                <span>{question.author.nickname}</span>
+                {question.author.course_name && (
+                  <>
+                    <span>·</span>
+                    <span>{question.author.course_name}</span>
+                  </>
+                )}
+                <span>·</span>
+                <time dateTime={question.created_at}>
+                  {formatDate(question.created_at)}
+                </time>
+              </div>
+            </div>
+          </div>
+
+          {/* 구분선 + 썸네일 (우측) */}
+          {question.thumbnail_img_url && (
+            <div className="border-border-base flex shrink-0 items-center border-l pl-4">
+              <img
+                src={question.thumbnail_img_url}
+                alt={`${question.title} 썸네일`}
+                loading="lazy"
+                decoding="async"
+                width={80}
+                height={80}
+                className="h-20 w-20 rounded-md object-cover"
+              />
+            </div>
+          )}
+        </div>
+      </Link>
+    </li>
+  )
+}

--- a/src/components/qna/QuestionCard/index.ts
+++ b/src/components/qna/QuestionCard/index.ts
@@ -1,0 +1,1 @@
+export { QuestionCard } from './QuestionCard'

--- a/src/components/qna/index.ts
+++ b/src/components/qna/index.ts
@@ -1,2 +1,4 @@
 export * from './MarkdownEditor'
 export * from './AnswerForm'
+export * from './QuestionCard'
+export * from './CategoryFilter'

--- a/src/features/qna/questions/handler.ts
+++ b/src/features/qna/questions/handler.ts
@@ -309,8 +309,11 @@ export const questionsHandler = [
         filtered = filtered.filter((q) => q.answer_count === 0)
       }
 
-      if (sort === 'views') {
-        filtered = [...filtered].sort((a, b) => b.view_count - a.view_count)
+      if (sort === 'oldest') {
+        filtered = [...filtered].sort(
+          (a, b) =>
+            new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        )
       }
 
       const count = filtered.length

--- a/src/features/qna/questions/types.ts
+++ b/src/features/qna/questions/types.ts
@@ -37,5 +37,5 @@ export interface QuestionsListParams {
   search_keyword?: string
   category_id?: number
   answer_status?: 'answered' | 'unanswered'
-  sort?: 'latest' | 'views'
+  sort?: 'latest' | 'oldest'
 }

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Suspense, useState, useEffect, useCallback } from 'react'
-import { useSearchParams, useNavigate, Link } from 'react-router'
+import { useSearchParams, useNavigate } from 'react-router'
 import {
   Tabs,
   TabList,
@@ -12,17 +12,15 @@ import {
   Modal,
   Button,
   Spinner,
-  Dropdown,
 } from '@/components'
+import { QuestionCard } from '@/components/qna/QuestionCard'
+import { CategoryFilter } from '@/components/qna/CategoryFilter'
 import { useQnaQuestions } from '@/features/qna/questions'
-import { useQnaCategories } from '@/features/qna/categories'
-import type { UserCategory } from '@/features/qna/categories'
-import type { QuestionListItem } from '@/features/qna/questions'
-import { formatDate } from '@/utils/formatDate'
+import type { QuestionsListParams } from '@/features/qna/questions'
 import { ROUTES } from '@/constants/routes'
 
 type AnswerStatus = 'all' | 'answered' | 'unanswered'
-type SortOption = 'latest' | 'oldest'
+type SortOption = NonNullable<QuestionsListParams['sort']>
 
 const ANSWER_STATUSES = ['all', 'answered', 'unanswered'] as const
 const SORT_OPTIONS = ['latest', 'oldest'] as const
@@ -33,245 +31,6 @@ const SEARCH_DEBOUNCE_MS = 300
 const SORT_LABEL: Record<SortOption, string> = {
   latest: '최신순',
   oldest: '오래된순',
-}
-
-function findCategoryPath(
-  categories: UserCategory[],
-  targetId: number | undefined
-): { large: string; medium: string; small: string } {
-  if (!targetId) return { large: '', medium: '', small: '' }
-  for (const large of categories) {
-    if (large.id === targetId)
-      return { large: String(large.id), medium: '', small: '' }
-    for (const medium of large.children) {
-      if (medium.id === targetId)
-        return { large: String(large.id), medium: String(medium.id), small: '' }
-      for (const small of medium.children) {
-        if (small.id === targetId)
-          return {
-            large: String(large.id),
-            medium: String(medium.id),
-            small: String(small.id),
-          }
-      }
-    }
-  }
-  return { large: '', medium: '', small: '' }
-}
-
-// ── 카테고리 필터 모달 콘텐츠 ─────────────────────────────────────────
-
-function CategoryFilterModalContent({
-  initialCategoryId,
-  onApply,
-  onClose,
-}: {
-  initialCategoryId?: number
-  onApply: (id: number | undefined) => void
-  onClose: () => void
-}) {
-  const { data: categories } = useQnaCategories()
-
-  const initialPath = findCategoryPath(categories, initialCategoryId)
-  const [largeCategoryId, setLargeCategoryId] = useState(initialPath.large)
-  const [mediumCategoryId, setMediumCategoryId] = useState(initialPath.medium)
-  const [smallCategoryId, setSmallCategoryId] = useState(initialPath.small)
-
-  const largeOptions = categories.map((cat: UserCategory) => ({
-    value: String(cat.id),
-    label: cat.name,
-  }))
-
-  const selectedLarge = categories.find(
-    (cat: UserCategory) => String(cat.id) === largeCategoryId
-  )
-
-  const mediumOptions =
-    selectedLarge?.children.map((child: UserCategory) => ({
-      value: String(child.id),
-      label: child.name,
-    })) ?? []
-
-  const hasMedium = mediumOptions.length > 0
-  const isMediumValid = mediumOptions.some((o) => o.value === mediumCategoryId)
-  const validMediumCategoryId = isMediumValid ? mediumCategoryId : ''
-
-  const selectedMedium = selectedLarge?.children.find(
-    (c: UserCategory) => String(c.id) === validMediumCategoryId
-  )
-
-  const smallOptions =
-    selectedMedium?.children.map((child: UserCategory) => ({
-      value: String(child.id),
-      label: child.name,
-    })) ?? []
-
-  const hasSmall = smallOptions.length > 0
-  const isSmallValid = smallOptions.some((o) => o.value === smallCategoryId)
-  const validSmallCategoryId = isSmallValid ? smallCategoryId : ''
-
-  const handleLargeChange = (value: string) => {
-    setLargeCategoryId(value)
-    setMediumCategoryId('')
-    setSmallCategoryId('')
-  }
-
-  const handleMediumChange = (value: string) => {
-    setMediumCategoryId(value)
-    setSmallCategoryId('')
-  }
-
-  const handleSmallChange = (value: string) => {
-    setSmallCategoryId(value)
-  }
-
-  const handleReset = () => {
-    setLargeCategoryId('')
-    setMediumCategoryId('')
-    setSmallCategoryId('')
-  }
-
-  const handleApply = () => {
-    const leafId =
-      validSmallCategoryId || validMediumCategoryId || largeCategoryId
-    onApply(leafId ? Number(leafId) : undefined)
-    onClose()
-  }
-
-  return (
-    <div className="flex flex-col gap-5">
-      <div className="flex flex-col gap-3">
-        <Dropdown
-          options={largeOptions}
-          value={largeCategoryId}
-          onChange={handleLargeChange}
-          placeholder="대분류 선택"
-        />
-        <Dropdown
-          options={mediumOptions}
-          value={validMediumCategoryId}
-          onChange={handleMediumChange}
-          placeholder="중분류 선택"
-          disabled={!largeCategoryId || !hasMedium}
-        />
-        <Dropdown
-          options={smallOptions}
-          value={validSmallCategoryId}
-          onChange={handleSmallChange}
-          placeholder="소분류 선택"
-          disabled={!validMediumCategoryId || !hasSmall}
-        />
-      </div>
-
-      <div className="flex items-center justify-between gap-3 pt-1">
-        <Button variant="ghost" size="sm" onClick={handleReset}>
-          선택 초기화
-        </Button>
-        <Button variant="primary" size="sm" onClick={handleApply}>
-          필터 적용하기
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-// ── 질문 카드 ────────────────────────────────────────────────────────
-
-function QuestionCard({ question }: { question: QuestionListItem }) {
-  const detailPath = ROUTES.QNA.DETAIL.replace(
-    ':questionId',
-    String(question.id)
-  )
-  const categoryPath = question.category.names.join(' > ')
-  const isAnswered = question.answer_count > 0
-
-  return (
-    <li>
-      <Link
-        to={detailPath}
-        className="border-border-base bg-bg-base hover:border-primary block rounded-lg border p-5 transition-colors duration-150"
-      >
-        <div className="flex">
-          {/* 텍스트 영역 */}
-          <div className="min-w-0 flex-1 pr-4">
-            <div className="mb-2 flex items-center gap-2">
-              <span className="text-text-muted truncate text-xs">
-                {categoryPath}
-              </span>
-            </div>
-
-            <h2 className="text-text-heading mb-1 truncate text-base font-semibold">
-              {question.title}
-            </h2>
-
-            <p className="text-text-body mb-3 line-clamp-2 text-sm">
-              {question.content_preview}
-            </p>
-
-            {/* 하단: A 마크 + 조회수 / 작성자 + 날짜 */}
-            <div className="flex items-center justify-between text-xs">
-              <div className="flex items-center gap-3">
-                <span className="flex items-center gap-1.5">
-                  <span
-                    className={[
-                      'inline-flex h-5 w-5 items-center justify-center rounded text-[11px] font-bold',
-                      isAnswered
-                        ? 'bg-success text-white'
-                        : 'text-text-muted bg-gray-100',
-                    ].join(' ')}
-                  >
-                    A
-                  </span>
-                  <span
-                    className={
-                      isAnswered
-                        ? 'text-success font-medium'
-                        : 'text-text-muted'
-                    }
-                  >
-                    {question.answer_count}
-                  </span>
-                </span>
-                <span className="text-text-muted">
-                  조회 {question.view_count}
-                </span>
-              </div>
-              <div className="text-text-muted flex items-center gap-1.5">
-                <span>{question.author.nickname}</span>
-                {question.author.course_name && (
-                  <>
-                    <span>·</span>
-                    <span>{question.author.course_name}</span>
-                  </>
-                )}
-                <span>·</span>
-                <time dateTime={question.created_at}>
-                  {formatDate(question.created_at)}
-                </time>
-              </div>
-            </div>
-          </div>
-
-          {/* 구분선 + 썸네일 (우측) */}
-          <div className="border-border-base flex shrink-0 items-center border-l pl-4">
-            <div className="h-20 w-20">
-              {question.thumbnail_img_url && (
-                <img
-                  src={question.thumbnail_img_url}
-                  alt={`${question.title} 썸네일`}
-                  loading="lazy"
-                  decoding="async"
-                  width={80}
-                  height={80}
-                  className="h-20 w-20 rounded-md object-cover"
-                />
-              )}
-            </div>
-          </div>
-        </div>
-      </Link>
-    </li>
-  )
 }
 
 // ── 페이지네이션 ──────────────────────────────────────────────────────
@@ -637,7 +396,7 @@ export function QnaListPage() {
             </div>
           }
         >
-          <CategoryFilterModalContent
+          <CategoryFilter
             initialCategoryId={categoryId}
             onApply={(id) =>
               updateParam('category_id', id != null ? String(id) : null)

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -12,6 +12,7 @@ import {
   Modal,
   Button,
   Spinner,
+  Dropdown,
 } from '@/components'
 import { useQnaQuestions } from '@/features/qna/questions'
 import { useQnaCategories } from '@/features/qna/categories'
@@ -21,59 +22,160 @@ import { formatDate } from '@/utils/formatDate'
 import { ROUTES } from '@/constants/routes'
 
 type AnswerStatus = 'all' | 'answered' | 'unanswered'
-type SortOption = 'latest' | 'views'
+type SortOption = 'latest' | 'oldest'
 
 const ANSWER_STATUSES = ['all', 'answered', 'unanswered'] as const
-const SORT_OPTIONS = ['latest', 'views'] as const
+const SORT_OPTIONS = ['latest', 'oldest'] as const
 
 const PAGE_SIZE = 10
+const SEARCH_DEBOUNCE_MS = 300
 
-function CategoryFilterContent({
-  selectedId,
-  onSelect,
+const SORT_LABEL: Record<SortOption, string> = {
+  latest: '최신순',
+  oldest: '오래된순',
+}
+
+function findCategoryPath(
+  categories: UserCategory[],
+  targetId: number | undefined
+): { large: string; medium: string; small: string } {
+  if (!targetId) return { large: '', medium: '', small: '' }
+  for (const large of categories) {
+    if (large.id === targetId)
+      return { large: String(large.id), medium: '', small: '' }
+    for (const medium of large.children) {
+      if (medium.id === targetId)
+        return { large: String(large.id), medium: String(medium.id), small: '' }
+      for (const small of medium.children) {
+        if (small.id === targetId)
+          return {
+            large: String(large.id),
+            medium: String(medium.id),
+            small: String(small.id),
+          }
+      }
+    }
+  }
+  return { large: '', medium: '', small: '' }
+}
+
+// ── 카테고리 필터 모달 콘텐츠 ─────────────────────────────────────────
+
+function CategoryFilterModalContent({
+  initialCategoryId,
+  onApply,
+  onClose,
 }: {
-  selectedId: number | undefined
-  onSelect: (id: number | undefined) => void
+  initialCategoryId?: number
+  onApply: (id: number | undefined) => void
+  onClose: () => void
 }) {
   const { data: categories } = useQnaCategories()
 
+  const initialPath = findCategoryPath(categories, initialCategoryId)
+  const [largeCategoryId, setLargeCategoryId] = useState(initialPath.large)
+  const [mediumCategoryId, setMediumCategoryId] = useState(initialPath.medium)
+  const [smallCategoryId, setSmallCategoryId] = useState(initialPath.small)
+
+  const largeOptions = categories.map((cat: UserCategory) => ({
+    value: String(cat.id),
+    label: cat.name,
+  }))
+
+  const selectedLarge = categories.find(
+    (cat: UserCategory) => String(cat.id) === largeCategoryId
+  )
+
+  const mediumOptions =
+    selectedLarge?.children.map((child: UserCategory) => ({
+      value: String(child.id),
+      label: child.name,
+    })) ?? []
+
+  const hasMedium = mediumOptions.length > 0
+  const isMediumValid = mediumOptions.some((o) => o.value === mediumCategoryId)
+  const validMediumCategoryId = isMediumValid ? mediumCategoryId : ''
+
+  const selectedMedium = selectedLarge?.children.find(
+    (c: UserCategory) => String(c.id) === validMediumCategoryId
+  )
+
+  const smallOptions =
+    selectedMedium?.children.map((child: UserCategory) => ({
+      value: String(child.id),
+      label: child.name,
+    })) ?? []
+
+  const hasSmall = smallOptions.length > 0
+  const isSmallValid = smallOptions.some((o) => o.value === smallCategoryId)
+  const validSmallCategoryId = isSmallValid ? smallCategoryId : ''
+
+  const handleLargeChange = (value: string) => {
+    setLargeCategoryId(value)
+    setMediumCategoryId('')
+    setSmallCategoryId('')
+  }
+
+  const handleMediumChange = (value: string) => {
+    setMediumCategoryId(value)
+    setSmallCategoryId('')
+  }
+
+  const handleSmallChange = (value: string) => {
+    setSmallCategoryId(value)
+  }
+
+  const handleReset = () => {
+    setLargeCategoryId('')
+    setMediumCategoryId('')
+    setSmallCategoryId('')
+  }
+
+  const handleApply = () => {
+    const leafId =
+      validSmallCategoryId || validMediumCategoryId || largeCategoryId
+    onApply(leafId ? Number(leafId) : undefined)
+    onClose()
+  }
+
   return (
-    <div className="space-y-3">
-      <button
-        onClick={() => onSelect(undefined)}
-        className={[
-          'w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
-          selectedId == null
-            ? 'bg-primary-100 text-primary font-medium'
-            : 'text-text-body hover:bg-bg-muted',
-        ].join(' ')}
-      >
-        전체
-      </button>
-      {categories.map((cat: UserCategory) => (
-        <div key={cat.id}>
-          <p className="text-text-muted px-3 py-1 text-xs font-semibold tracking-wide">
-            {cat.name}
-          </p>
-          {cat.children.map((child: UserCategory) => (
-            <button
-              key={child.id}
-              onClick={() => onSelect(child.id)}
-              className={[
-                'w-full rounded-md px-3 py-2 text-left text-sm transition-colors',
-                selectedId === child.id
-                  ? 'bg-primary-100 text-primary font-medium'
-                  : 'text-text-body hover:bg-bg-muted',
-              ].join(' ')}
-            >
-              {child.name}
-            </button>
-          ))}
-        </div>
-      ))}
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        <Dropdown
+          options={largeOptions}
+          value={largeCategoryId}
+          onChange={handleLargeChange}
+          placeholder="대분류 선택"
+        />
+        <Dropdown
+          options={mediumOptions}
+          value={validMediumCategoryId}
+          onChange={handleMediumChange}
+          placeholder="중분류 선택"
+          disabled={!largeCategoryId || !hasMedium}
+        />
+        <Dropdown
+          options={smallOptions}
+          value={validSmallCategoryId}
+          onChange={handleSmallChange}
+          placeholder="소분류 선택"
+          disabled={!validMediumCategoryId || !hasSmall}
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-3 pt-1">
+        <Button variant="ghost" size="sm" onClick={handleReset}>
+          선택 초기화
+        </Button>
+        <Button variant="primary" size="sm" onClick={handleApply}>
+          필터 적용하기
+        </Button>
+      </div>
     </div>
   )
 }
+
+// ── 질문 카드 ────────────────────────────────────────────────────────
 
 function QuestionCard({ question }: { question: QuestionListItem }) {
   const detailPath = ROUTES.QNA.DETAIL.replace(
@@ -89,50 +191,128 @@ function QuestionCard({ question }: { question: QuestionListItem }) {
         to={detailPath}
         className="border-border-base bg-bg-base hover:border-primary block rounded-lg border p-5 transition-colors duration-150"
       >
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <span className="text-text-muted truncate text-xs">
-            {categoryPath}
-          </span>
-          <span
-            className={[
-              'shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium',
-              isAnswered
-                ? 'bg-success-bg text-success'
-                : 'bg-warning-bg text-warning',
-            ].join(' ')}
-          >
-            {isAnswered ? '답변완료' : '답변 대기중'}
-          </span>
-        </div>
+        <div className="flex">
+          {/* 텍스트 영역 */}
+          <div className="min-w-0 flex-1 pr-4">
+            <div className="mb-2 flex items-center gap-2">
+              <span className="text-text-muted truncate text-xs">
+                {categoryPath}
+              </span>
+            </div>
 
-        <h2 className="text-text-heading mb-1 truncate text-base font-semibold">
-          {question.title}
-        </h2>
+            <h2 className="text-text-heading mb-1 truncate text-base font-semibold">
+              {question.title}
+            </h2>
 
-        <p className="text-text-body mb-3 line-clamp-2 text-sm">
-          {question.content_preview}
-        </p>
+            <p className="text-text-body mb-3 line-clamp-2 text-sm">
+              {question.content_preview}
+            </p>
 
-        <div className="text-text-muted flex items-center justify-between text-xs">
-          <div className="flex items-center gap-2">
-            <span>{question.author.nickname}</span>
-            {question.author.course_name && (
-              <>
+            {/* 하단: A 마크 + 조회수 / 작성자 + 날짜 */}
+            <div className="flex items-center justify-between text-xs">
+              <div className="flex items-center gap-3">
+                <span className="flex items-center gap-1.5">
+                  <span
+                    className={[
+                      'inline-flex h-5 w-5 items-center justify-center rounded text-[11px] font-bold',
+                      isAnswered
+                        ? 'bg-success text-white'
+                        : 'text-text-muted bg-gray-100',
+                    ].join(' ')}
+                  >
+                    A
+                  </span>
+                  <span
+                    className={
+                      isAnswered
+                        ? 'text-success font-medium'
+                        : 'text-text-muted'
+                    }
+                  >
+                    {question.answer_count}
+                  </span>
+                </span>
+                <span className="text-text-muted">
+                  조회 {question.view_count}
+                </span>
+              </div>
+              <div className="text-text-muted flex items-center gap-1.5">
+                <span>{question.author.nickname}</span>
+                {question.author.course_name && (
+                  <>
+                    <span>·</span>
+                    <span>{question.author.course_name}</span>
+                  </>
+                )}
                 <span>·</span>
-                <span>{question.author.course_name}</span>
-              </>
-            )}
+                <time dateTime={question.created_at}>
+                  {formatDate(question.created_at)}
+                </time>
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-3">
-            <span>답변 {question.answer_count}</span>
-            <span>조회 {question.view_count}</span>
-            <time dateTime={question.created_at}>
-              {formatDate(question.created_at)}
-            </time>
+
+          {/* 구분선 + 썸네일 (우측) */}
+          <div className="border-border-base flex shrink-0 items-center border-l pl-4">
+            <div className="h-20 w-20">
+              {question.thumbnail_img_url && (
+                <img
+                  src={question.thumbnail_img_url}
+                  alt={`${question.title} 썸네일`}
+                  loading="lazy"
+                  decoding="async"
+                  width={80}
+                  height={80}
+                  className="h-20 w-20 rounded-md object-cover"
+                />
+              )}
+            </div>
           </div>
         </div>
       </Link>
     </li>
+  )
+}
+
+// ── 페이지네이션 ──────────────────────────────────────────────────────
+
+function ChevronLeft() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M10 12L6 8L10 4"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function ChevronRight() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M6 4L10 8L6 12"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   )
 }
 
@@ -154,15 +334,15 @@ function Pagination({
   return (
     <nav
       aria-label="페이지 이동"
-      className="mt-6 flex items-center justify-center gap-1"
+      className="mt-8 flex items-center justify-center gap-1"
     >
       <button
         onClick={() => onChange(current - 1)}
         disabled={current === 1}
         aria-label="이전 페이지"
-        className="text-text-muted hover:bg-bg-muted disabled:text-disable rounded-md px-3 py-2 text-sm transition-colors disabled:cursor-not-allowed"
+        className="text-text-muted hover:text-text-heading flex h-9 w-9 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:text-gray-300"
       >
-        이전
+        <ChevronLeft />
       </button>
 
       {pages.map((p) => (
@@ -171,9 +351,9 @@ function Pagination({
           onClick={() => onChange(p)}
           aria-current={p === current ? 'page' : undefined}
           className={[
-            'h-9 min-w-9 rounded-md px-3 text-sm transition-colors',
+            'h-9 w-9 rounded-full text-sm font-medium transition-colors',
             p === current
-              ? 'bg-primary text-text-inverse font-medium'
+              ? 'bg-primary text-text-inverse'
               : 'text-text-body hover:bg-bg-muted',
           ].join(' ')}
         >
@@ -185,13 +365,15 @@ function Pagination({
         onClick={() => onChange(current + 1)}
         disabled={current === total}
         aria-label="다음 페이지"
-        className="text-text-muted hover:bg-bg-muted disabled:text-disable rounded-md px-3 py-2 text-sm transition-colors disabled:cursor-not-allowed"
+        className="text-text-muted hover:text-text-heading flex h-9 w-9 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:text-gray-300"
       >
-        다음
+        <ChevronRight />
       </button>
     </nav>
   )
 }
+
+// ── QnaListPage ───────────────────────────────────────────────────
 
 export function QnaListPage() {
   const navigate = useNavigate()
@@ -248,7 +430,7 @@ export function QnaListPage() {
         },
         { replace: true }
       )
-    }, 300)
+    }, SEARCH_DEBOUNCE_MS)
     return () => clearTimeout(timer)
   }, [inputValue, searchKeyword, setSearchParams])
 
@@ -262,6 +444,19 @@ export function QnaListPage() {
   })
 
   const totalPages = data ? Math.ceil(data.count / PAGE_SIZE) : 0
+
+  useEffect(() => {
+    if (totalPages > 0 && page > totalPages) {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          next.delete('page')
+          return next
+        },
+        { replace: true }
+      )
+    }
+  }, [page, totalPages, setSearchParams])
 
   const updateParam = useCallback(
     (key: string, value: string | null) => {
@@ -311,16 +506,23 @@ export function QnaListPage() {
     [setSearchParams]
   )
 
-  const categoryName = searchParams.get('category_id')
-    ? '필터 적용됨'
-    : '카테고리'
+  const hasFilter = categoryId != null
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-text-heading text-2xl font-bold">질의응답</h1>
+      <h1 className="text-text-heading mb-6 text-2xl font-bold">질의응답</h1>
+
+      {/* 검색바 + 질문하기 버튼 — 탭 위 */}
+      <div className="mb-4 flex items-center gap-3">
+        <SearchInput
+          value={inputValue}
+          onValueChange={setInputValue}
+          placeholder="질문 검색"
+          className="flex-1"
+          aria-label="질문 검색"
+        />
         <Button size="sm" onClick={() => navigate(ROUTES.QNA.WRITE)}>
-          질문 등록
+          질문하기
         </Button>
       </div>
 
@@ -332,37 +534,47 @@ export function QnaListPage() {
         </TabList>
 
         <div className="mt-4">
-          {/* 검색 + 필터 영역 */}
-          <div className="mb-4 flex flex-wrap items-center gap-3">
-            <SearchInput
-              value={inputValue}
-              onValueChange={setInputValue}
-              placeholder="질문 검색"
-              className="flex-1"
-              aria-label="질문 검색"
-            />
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setShowCategoryModal(true)}
-            >
-              {categoryName}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setShowSortModal(true)}
-            >
-              {sort === 'views' ? '조회수순' : '최신순'}
-            </Button>
+          {/* 총 결과수 + 정렬·카테고리 우측 배치 */}
+          <div className="mb-4 flex items-center justify-between">
+            {!isLoading && data ? (
+              <p className="text-text-muted text-sm">
+                총 {data.count.toLocaleString()}개의 질문
+              </p>
+            ) : (
+              <span />
+            )}
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowSortModal(true)}
+              >
+                {SORT_LABEL[sort]}
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M3 4.5L6 7.5L9 4.5"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </Button>
+              <Button
+                variant={hasFilter ? 'outline' : 'ghost'}
+                size="sm"
+                onClick={() => setShowCategoryModal(true)}
+              >
+                {hasFilter ? '필터 적용됨' : '카테고리'}
+              </Button>
+            </div>
           </div>
-
-          {/* 총 결과 수 */}
-          {!isLoading && data && (
-            <p className="text-text-muted mb-3 text-sm">
-              총 {data.count.toLocaleString()}개의 질문
-            </p>
-          )}
 
           {/* 질문 목록 */}
           {isLoading && (
@@ -425,12 +637,12 @@ export function QnaListPage() {
             </div>
           }
         >
-          <CategoryFilterContent
-            selectedId={categoryId}
-            onSelect={(id) => {
+          <CategoryFilterModalContent
+            initialCategoryId={categoryId}
+            onApply={(id) =>
               updateParam('category_id', id != null ? String(id) : null)
-              setShowCategoryModal(false)
-            }}
+            }
+            onClose={() => setShowCategoryModal(false)}
           />
         </Suspense>
       </Modal>
@@ -443,7 +655,7 @@ export function QnaListPage() {
         maxWidth="max-w-xs"
       >
         <div className="space-y-1">
-          {(['latest', 'views'] as SortOption[]).map((opt) => (
+          {SORT_OPTIONS.map((opt) => (
             <button
               key={opt}
               onClick={() => {
@@ -457,7 +669,7 @@ export function QnaListPage() {
                   : 'text-text-body hover:bg-bg-muted',
               ].join(' ')}
             >
-              {opt === 'latest' ? '최신순' : '조회수순'}
+              {SORT_LABEL[opt]}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## 관련 이슈

- closes #23

## 작업 내용

- QnaListPage UI를 피그마 디자인 스펙에 맞게 전면 수정

## 변경 사항

- **정렬 옵션 변경**: `views`(조회수순) → `oldest`(오래된순), MSW 핸들러·API 타입 동기화
- **레이아웃 재배치**: 검색바·질문하기 버튼을 탭 위로 이동
- **버튼 배치 조정**: 정렬 버튼 → 카테고리 버튼 순서로 변경, 둘 다 `ghost` 스타일 적용 (필터 적용 시 카테고리만 `outline`)
- **QuestionCard 개선**:
  - 좌(텍스트) / 우(썸네일) 영역을 `border-l` 구분선으로 분리
  - 카드 하단 좌측에 초록 A 마크 + 답변 수 배지 추가 (답변 없을 시 회색)
  - 하단 우측에 작성자·날짜 배치

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다