### PR TITLE
feat: REQ-QNA-007 답변 채택 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ settings.local.json
 playwright-report/
 test-results/
 superpowers/
+
+# 로컬 테스트 페이지 (커밋 제외)
+src/pages/**/*TestPage.tsx

--- a/src/features/qna/answer-accept/handler.ts
+++ b/src/features/qna/answer-accept/handler.ts
@@ -1,0 +1,13 @@
+import { http, HttpResponse } from 'msw'
+import type { AcceptAnswerResponse } from './types'
+
+export const answerAcceptHandlers = [
+  http.post('/api/v1/qna/answers/:id/accept', ({ params }) => {
+    const response: AcceptAnswerResponse = {
+      question_id: 10501,
+      answer_id: Number(params.id),
+      is_adopted: true,
+    }
+    return HttpResponse.json(response, { status: 200 })
+  }),
+]

--- a/src/features/qna/answer-accept/handler.ts
+++ b/src/features/qna/answer-accept/handler.ts
@@ -1,11 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import type { AcceptAnswerResponse } from './types'
+import { markAnswerAdopted } from '@/features/qna/answers/handler'
 
 export const answerAcceptHandlers = [
   http.post('/api/v1/qna/answers/:id/accept', ({ params }) => {
+    const answerId = Number(params.id)
+    markAnswerAdopted(answerId)
     const response: AcceptAnswerResponse = {
       question_id: 10501,
-      answer_id: Number(params.id),
+      answer_id: answerId,
       is_adopted: true,
     }
     return HttpResponse.json(response, { status: 200 })

--- a/src/features/qna/answer-accept/handler.ts
+++ b/src/features/qna/answer-accept/handler.ts
@@ -1,13 +1,16 @@
 import { http, HttpResponse } from 'msw'
 import type { AcceptAnswerResponse } from './types'
-import { markAnswerAdopted } from '@/features/qna/answers/handler'
+import {
+  markAnswerAdopted,
+  getQuestionIdByAnswer,
+} from '@/features/qna/answers/handler'
 
 export const answerAcceptHandlers = [
   http.post('/api/v1/qna/answers/:id/accept', ({ params }) => {
     const answerId = Number(params.id)
     markAnswerAdopted(answerId)
     const response: AcceptAnswerResponse = {
-      question_id: 10501,
+      question_id: getQuestionIdByAnswer(answerId),
       answer_id: answerId,
       is_adopted: true,
     }

--- a/src/features/qna/answer-accept/index.ts
+++ b/src/features/qna/answer-accept/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/qna/answer-accept/queries.ts
+++ b/src/features/qna/answer-accept/queries.ts
@@ -3,16 +3,19 @@ import type { AxiosError } from 'axios'
 import api from '@/api/instance'
 import type { AcceptAnswerResponse } from './types'
 
-export function useAcceptAnswer(answerId: number, questionId: number) {
+export function useAcceptAnswer(questionId: number) {
   const queryClient = useQueryClient()
 
-  return useMutation<AcceptAnswerResponse, AxiosError>({
-    mutationFn: () =>
+  return useMutation<AcceptAnswerResponse, AxiosError, number>({
+    mutationFn: (answerId: number) =>
       api
         .post<AcceptAnswerResponse>(`/api/v1/qna/answers/${answerId}/accept`)
         .then((res) => res.data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+      queryClient.invalidateQueries({
+        queryKey: ['question-detail', questionId],
+      })
     },
   })
 }

--- a/src/features/qna/answer-accept/queries.ts
+++ b/src/features/qna/answer-accept/queries.ts
@@ -12,6 +12,7 @@ export function useAcceptAnswer(questionId: number) {
         .post<AcceptAnswerResponse>(`/api/v1/qna/answers/${answerId}/accept`)
         .then((res) => res.data),
     onSuccess: () => {
+      // TanStack Query가 두 호출을 내부적으로 병렬 처리한다
       queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
       queryClient.invalidateQueries({
         queryKey: ['question-detail', questionId],

--- a/src/features/qna/answer-accept/queries.ts
+++ b/src/features/qna/answer-accept/queries.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import api from '@/api/instance'
+import type { AcceptAnswerResponse } from './types'
+
+export function useAcceptAnswer(answerId: number, questionId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation<AcceptAnswerResponse, AxiosError>({
+    mutationFn: () =>
+      api
+        .post<AcceptAnswerResponse>(`/api/v1/qna/answers/${answerId}/accept`)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+    },
+  })
+}

--- a/src/features/qna/answer-accept/types.ts
+++ b/src/features/qna/answer-accept/types.ts
@@ -1,0 +1,5 @@
+export interface AcceptAnswerResponse {
+  question_id: number
+  answer_id: number
+  is_adopted: boolean
+}

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -24,7 +24,9 @@ export function getQuestionIdByAnswer(answerId: number): number {
 }
 
 export const answersHandlers = [
-  http.get('/api/v1/qna/questions/:question_id/answers', () => {
+  http.get('/api/v1/qna/questions/:question_id/answers', ({ params }) => {
+    // GET 시점에 매핑 초기화 — POST answer 이전 채택 시나리오도 커버
+    _answerQuestionMap.set(MOCK_ANSWER_ID, Number(params.question_id))
     const response: GetAnswersResponse = [
       {
         id: MOCK_ANSWER_ID,

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -12,6 +12,13 @@ export function markAnswerAdopted(answerId: number) {
   _adoptedAnswerIds.add(answerId)
 }
 
+// answerId → questionId 매핑 — accept handler에서 dynamic question_id 반환에 사용
+const _answerQuestionMap = new Map<number, number>()
+
+export function getQuestionIdByAnswer(answerId: number): number {
+  return _answerQuestionMap.get(answerId) ?? 0
+}
+
 export const answersHandlers = [
   http.get('/api/v1/qna/questions/:question_id/answers', () => {
     const response: GetAnswersResponse = [
@@ -36,9 +43,11 @@ export const answersHandlers = [
   }),
 
   http.post('/api/v1/qna/questions/:question_id/answers', ({ params }) => {
+    const questionId = Number(params.question_id)
+    _answerQuestionMap.set(801, questionId)
     const response: PostAnswerResponse = {
       answer_id: 801,
-      question_id: Number(params.question_id),
+      question_id: questionId,
       author_id: 211,
       created_at: new Date().toISOString(),
     }

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -5,6 +5,10 @@ import type {
   PutAnswerResponse,
 } from './types'
 
+// MSW 픽스처 상수
+const MOCK_ANSWER_ID = 801
+const MOCK_AUTHOR_ID = 211
+
 // MSW 상태 — accept POST 후 GET 응답에 반영
 const _adoptedAnswerIds = new Set<number>()
 
@@ -23,16 +27,16 @@ export const answersHandlers = [
   http.get('/api/v1/qna/questions/:question_id/answers', () => {
     const response: GetAnswersResponse = [
       {
-        id: 801,
+        id: MOCK_ANSWER_ID,
         author: {
-          id: 211,
+          id: MOCK_AUTHOR_ID,
           nickname: '테스트유저',
           profile_image_url: null,
           course_name: 'OZ 코딩스쿨',
           cohort_name: '8기',
         },
         content: '기존 답변 내용입니다.\n\n마크다운으로 작성된 답변입니다.',
-        is_adopted: _adoptedAnswerIds.has(801),
+        is_adopted: _adoptedAnswerIds.has(MOCK_ANSWER_ID),
         images: [],
         comments: [],
         created_at: new Date().toISOString(),
@@ -44,11 +48,11 @@ export const answersHandlers = [
 
   http.post('/api/v1/qna/questions/:question_id/answers', ({ params }) => {
     const questionId = Number(params.question_id)
-    _answerQuestionMap.set(801, questionId)
+    _answerQuestionMap.set(MOCK_ANSWER_ID, questionId)
     const response: PostAnswerResponse = {
-      answer_id: 801,
+      answer_id: MOCK_ANSWER_ID,
       question_id: questionId,
-      author_id: 211,
+      author_id: MOCK_AUTHOR_ID,
       created_at: new Date().toISOString(),
     }
     return HttpResponse.json(response, { status: 201 })

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -5,6 +5,13 @@ import type {
   PutAnswerResponse,
 } from './types'
 
+// MSW 상태 — accept POST 후 GET 응답에 반영
+const _adoptedAnswerIds = new Set<number>()
+
+export function markAnswerAdopted(answerId: number) {
+  _adoptedAnswerIds.add(answerId)
+}
+
 export const answersHandlers = [
   http.get('/api/v1/qna/questions/:question_id/answers', () => {
     const response: GetAnswersResponse = [
@@ -18,7 +25,7 @@ export const answersHandlers = [
           cohort_name: '8기',
         },
         content: '기존 답변 내용입니다.\n\n마크다운으로 작성된 답변입니다.',
-        is_adopted: false,
+        is_adopted: _adoptedAnswerIds.has(801),
         images: [],
         comments: [],
         created_at: new Date().toISOString(),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import { answersHandlers } from '@/features/qna/answers'
+import { answerAcceptHandlers } from '@/features/qna/answer-accept'
 import { presignedUrlHandlers } from '@/features/qna/presigned-url'
 import { categoriesHandler } from '@/features/qna/categories'
 import { questionsHandler } from '@/features/qna/questions'
@@ -11,6 +12,7 @@ export const handlers = [
     return HttpResponse.json({ status: 'ok' })
   }),
   ...answersHandlers,
+  ...answerAcceptHandlers,
   ...presignedUrlHandlers,
   ...categoriesHandler,
   ...questionsHandler,

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -3,6 +3,8 @@
  */
 
 import { useRef, useState } from 'react'
+import { ConfirmModal } from '@/components/common/Modal'
+import { Badge } from '@/components/common/Badge'
 import { useParams, useNavigate, Navigate } from 'react-router'
 import axios from 'axios'
 import rehypeSanitize from 'rehype-sanitize'
@@ -18,6 +20,7 @@ import {
   useGetAnswers,
   usePutAnswer,
 } from '@/features/qna/answers'
+import { useAcceptAnswer } from '@/features/qna/answer-accept'
 import { useGetQuestionDetail } from '@/features/qna/question-detail'
 import { useToast } from '@/hooks/useToast'
 import { formatDate } from '@/utils/formatDate'
@@ -51,6 +54,7 @@ export function QnaDetailPage() {
     ANSWER_ALLOWED_ROLES.includes(user.role)
 
   const [showForm, setShowForm] = useState(false)
+  const [confirmAcceptId, setConfirmAcceptId] = useState<number | null>(null)
   const answerFormRef = useRef<AnswerFormHandle>(null)
 
   const numericQuestionId = questionId ? Number(questionId) : 0
@@ -71,11 +75,20 @@ export function QnaDetailPage() {
 
   const questionTitle = questionDetail?.title ?? '질문 내용을 불러오는 중...'
 
+  const anyAdopted = answers?.some((a) => a.is_adopted) ?? false
+  const isQuestionOwner =
+    user?.id != null && questionDetail?.author.id === user.id
+
   // 현재 로그인 유저가 작성한 답변 찾기
   const myAnswer = answers?.find(
     (a) => user?.id != null && a.author.id === user.id
   )
   const isEdit = !!myAnswer
+
+  const { mutate: acceptAnswer, isPending: isAcceptPending } = useAcceptAnswer(
+    confirmAcceptId ?? 0,
+    numericQuestionId
+  )
 
   const { mutate: putAnswer, isPending: isPutPending } = usePutAnswer(
     myAnswer?.id,
@@ -193,7 +206,7 @@ export function QnaDetailPage() {
                 {answers.map((answer) => (
                   <article
                     key={answer.id}
-                    className="border-border-base bg-bg-base rounded-lg border p-6"
+                    className={`bg-bg-base rounded-lg border p-6 ${answer.is_adopted ? 'border-success' : 'border-border-base'}`}
                   >
                     {/* 작성자 정보 + 수정 시각 */}
                     <div className="mb-4 flex items-center justify-between">
@@ -205,6 +218,9 @@ export function QnaDetailPage() {
                           {answer.author.course_name} ·{' '}
                           {answer.author.cohort_name}
                         </span>
+                        {answer.is_adopted && (
+                          <Badge variant="success">질문자 채택</Badge>
+                        )}
                       </div>
                       <time
                         dateTime={answer.updated_at}
@@ -221,6 +237,20 @@ export function QnaDetailPage() {
                         rehypePlugins={[rehypeSanitize]}
                       />
                     </div>
+
+                    {/* 채택하기 버튼 */}
+                    {isQuestionOwner && !anyAdopted && (
+                      <div className="mt-4">
+                        <Button
+                          onClick={() => setConfirmAcceptId(answer.id)}
+                          disabled={isAcceptPending}
+                        >
+                          {isAcceptPending && confirmAcceptId === answer.id
+                            ? '채택 중...'
+                            : '채택하기'}
+                        </Button>
+                      </div>
+                    )}
                   </article>
                 ))}
               </div>
@@ -259,6 +289,40 @@ export function QnaDetailPage() {
           )}
         </div>
       )}
+
+      {/* 채택 확인 모달 */}
+      <ConfirmModal
+        isOpen={confirmAcceptId !== null}
+        onClose={() => setConfirmAcceptId(null)}
+        message="이 답변을 채택하시겠습니까?"
+        confirmLabel="채택"
+        onConfirm={() => {
+          acceptAnswer(undefined, {
+            onSuccess: () => {
+              showToast('답변이 채택되었습니다.', 'success')
+              setConfirmAcceptId(null)
+            },
+            onError: (error) => {
+              const message = handleApiError(
+                error,
+                {
+                  400: '유효하지 않은 답변 채택 요청입니다.',
+                  401: '로그인한 사용자만 답변을 채택할 수 있습니다.',
+                  403: '본인이 작성한 질문의 답변만 채택할 수 있습니다.',
+                  404: '해당 질문 또는 답변을 찾을 수 없습니다.',
+                  409: '이미 채택된 답변이 존재합니다.',
+                },
+                {
+                  401: () => navigate(ROUTES.AUTH.LOGIN),
+                  404: () => navigate(ROUTES.QNA.LIST),
+                }
+              )
+              showToast(message, 'error')
+              setConfirmAcceptId(null)
+            },
+          })
+        }}
+      />
 
       {/* 토스트 알림 */}
       {toast.visible && (

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -4,7 +4,6 @@
 
 import { useRef, useState } from 'react'
 import { ConfirmModal } from '@/components/common/Modal'
-import { Badge } from '@/components/common/Badge'
 import { useParams, useNavigate, Navigate } from 'react-router'
 import axios from 'axios'
 import rehypeSanitize from 'rehype-sanitize'
@@ -95,7 +94,11 @@ export function QnaDetailPage() {
     numericQuestionId
   )
 
-  if (!questionId || Number.isNaN(numericQuestionId)) {
+  if (
+    !questionId ||
+    Number.isNaN(numericQuestionId) ||
+    numericQuestionId <= 0
+  ) {
     return <Navigate to={ROUTES.QNA.LIST} />
   }
 
@@ -202,68 +205,90 @@ export function QnaDetailPage() {
                 아직 등록된 답변이 없습니다.
               </p>
             ) : (
-              <div className="mt-4 space-y-4">
-                {answers.map((answer) => (
-                  <article
-                    key={answer.id}
-                    className={`bg-bg-base rounded-lg border p-6 ${answer.is_adopted ? 'border-success' : 'border-border-base'}`}
-                  >
-                    {/* 작성자 정보 + 수정 시각 */}
-                    <div className="mb-4 flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <span className="text-text-heading text-sm font-medium">
-                          {answer.author.nickname}
-                        </span>
-                        <span className="text-text-muted text-xs">
-                          {answer.author.course_name} ·{' '}
-                          {answer.author.cohort_name}
-                        </span>
-                        {answer.is_adopted && (
-                          <Badge variant="success">질문자 채택</Badge>
-                        )}
-                      </div>
-                      <time
-                        dateTime={answer.updated_at}
-                        className="text-text-muted text-xs"
+              <div className="mt-4 space-y-6">
+                {[...answers]
+                  .sort((a, b) => Number(b.is_adopted) - Number(a.is_adopted))
+                  .map((answer) => (
+                    // 채택된 답변은 배지가 카드 위로 올라오므로 상단 여백 추가
+                    <div
+                      key={answer.id}
+                      className={
+                        answer.is_adopted ? 'relative mt-4' : 'relative'
+                      }
+                    >
+                      {/* 질문자 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
+                      {answer.is_adopted && (
+                        <div className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white">
+                          질문자 채택
+                        </div>
+                      )}
+
+                      <article
+                        className={`bg-bg-base rounded-lg border p-6 ${
+                          answer.is_adopted
+                            ? 'border-primary'
+                            : 'border-border-base'
+                        }`}
                       >
-                        수정일: {formatDate(answer.updated_at)}
-                      </time>
-                    </div>
+                        {/* 작성자 정보 + 채택하기 버튼 + 수정 시각 */}
+                        <div className="mb-4 flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <span className="text-text-heading text-sm font-medium">
+                              {answer.author.nickname}
+                            </span>
+                            <span className="text-text-muted text-xs">
+                              {answer.author.course_name} ·{' '}
+                              {answer.author.cohort_name}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            <time
+                              dateTime={answer.updated_at}
+                              className="text-text-muted text-xs"
+                            >
+                              수정일: {formatDate(answer.updated_at)}
+                            </time>
+                            {/* 채택하기 버튼 — 질문 작성자 + 미채택 상태 */}
+                            {isQuestionOwner && !anyAdopted && (
+                              <Button
+                                size="sm"
+                                onClick={() => setConfirmAcceptId(answer.id)}
+                                disabled={isAcceptPending}
+                                loading={
+                                  isAcceptPending &&
+                                  confirmAcceptId === answer.id
+                                }
+                              >
+                                채택하기
+                              </Button>
+                            )}
+                          </div>
+                        </div>
 
-                    {/* 답변 내용 (마크다운 렌더링) */}
-                    <div data-color-mode="light">
-                      <MDEditor.Markdown
-                        source={answer.content}
-                        rehypePlugins={[rehypeSanitize]}
-                      />
+                        {/* 답변 내용 (마크다운 렌더링) */}
+                        <div data-color-mode="light">
+                          <MDEditor.Markdown
+                            source={answer.content}
+                            rehypePlugins={[rehypeSanitize]}
+                          />
+                        </div>
+                      </article>
                     </div>
-
-                    {/* 채택하기 버튼 */}
-                    {isQuestionOwner && !anyAdopted && (
-                      <div className="mt-4">
-                        <Button
-                          onClick={() => setConfirmAcceptId(answer.id)}
-                          disabled={isAcceptPending}
-                        >
-                          {isAcceptPending && confirmAcceptId === answer.id
-                            ? '채택 중...'
-                            : '채택하기'}
-                        </Button>
-                      </div>
-                    )}
-                  </article>
-                ))}
+                  ))}
               </div>
             )}
           </>
         )}
       </section>
 
-      {/* 답변 섹션 */}
-      {canAnswer && !isAnswersLoading && (
+      {/* 답변 섹션 — 채택된 본인 답변은 수정 버튼 비활성 */}
+      {canAnswer && !isAnswersLoading && !isAnswersError && (
         <div className="mt-6">
           {!showForm ? (
-            <Button onClick={() => setShowForm(true)}>
+            <Button
+              onClick={() => setShowForm(true)}
+              disabled={isEdit && myAnswer?.is_adopted}
+            >
               {isEdit ? '답변 수정하기' : '답변하기'}
             </Button>
           ) : isEdit ? (

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -2,10 +2,9 @@
  * @figma 질의응답 상세 페이지 - @https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-7744&m=dev
  */
 
-import { useRef, useState } from 'react'
+import { useRef, useState, useMemo } from 'react'
 import { ConfirmModal } from '@/components/common/Modal'
 import { useParams, useNavigate, Navigate } from 'react-router'
-import axios from 'axios'
 import rehypeSanitize from 'rehype-sanitize'
 import MDEditor from '@uiw/react-md-editor'
 import { Button } from '@/components/common/Button'
@@ -23,22 +22,8 @@ import { useAcceptAnswer } from '@/features/qna/answer-accept'
 import { useGetQuestionDetail } from '@/features/qna/question-detail'
 import { useToast } from '@/hooks/useToast'
 import { formatDate } from '@/utils/formatDate'
+import { handleApiError } from '@/utils/handleApiError'
 import { ROUTES } from '@/constants/routes'
-
-function handleApiError(
-  error: unknown,
-  messages: Partial<Record<number, string>>,
-  actions?: Partial<Record<number, () => void>>
-) {
-  if (axios.isAxiosError(error)) {
-    const status = error.response?.status
-    if (status != null && messages[status] != null) {
-      actions?.[status]?.()
-      return messages[status]!
-    }
-  }
-  return '일시적인 오류가 발생했습니다. 다시 시도해 주세요.'
-}
 
 export function QnaDetailPage() {
   const { questionId } = useParams<{ questionId: string }>()
@@ -84,14 +69,23 @@ export function QnaDetailPage() {
   )
   const isEdit = !!myAnswer
 
-  const { mutate: acceptAnswer, isPending: isAcceptPending } = useAcceptAnswer(
-    confirmAcceptId ?? 0,
-    numericQuestionId
-  )
+  const { mutate: acceptAnswer, isPending: isAcceptPending } =
+    useAcceptAnswer(numericQuestionId)
 
   const { mutate: putAnswer, isPending: isPutPending } = usePutAnswer(
     myAnswer?.id,
     numericQuestionId
+  )
+
+  // 채택 답변 상단 정렬 — 매 렌더링 sort 방지
+  const sortedAnswers = useMemo(
+    () =>
+      answers
+        ? [...answers].sort(
+            (a, b) => Number(b.is_adopted) - Number(a.is_adopted)
+          )
+        : [],
+    [answers]
   )
 
   if (
@@ -164,6 +158,35 @@ export function QnaDetailPage() {
     )
   }
 
+  const handleConfirmAccept = () => {
+    if (confirmAcceptId === null) return
+
+    acceptAnswer(confirmAcceptId, {
+      onSuccess: () => {
+        showToast('답변이 채택되었습니다.', 'success')
+        setConfirmAcceptId(null)
+      },
+      onError: (error) => {
+        const message = handleApiError(
+          error,
+          {
+            400: '유효하지 않은 답변 채택 요청입니다.',
+            401: '로그인한 사용자만 답변을 채택할 수 있습니다.',
+            403: '본인이 작성한 질문의 답변만 채택할 수 있습니다.',
+            404: '해당 질문 또는 답변을 찾을 수 없습니다.',
+            409: '이미 채택된 답변이 존재합니다.',
+          },
+          {
+            401: () => navigate(ROUTES.AUTH.LOGIN),
+            404: () => navigate(ROUTES.QNA.LIST),
+          }
+        )
+        showToast(message, 'error')
+        setConfirmAcceptId(null)
+      },
+    })
+  }
+
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
       {/* 질문 상세 영역 (추후 구현) */}
@@ -206,75 +229,75 @@ export function QnaDetailPage() {
               </p>
             ) : (
               <div className="mt-4 space-y-6">
-                {[...answers]
-                  .sort((a, b) => Number(b.is_adopted) - Number(a.is_adopted))
-                  .map((answer) => (
-                    // 채택된 답변은 배지가 카드 위로 올라오므로 상단 여백 추가
-                    <div
-                      key={answer.id}
-                      className={
-                        answer.is_adopted ? 'relative mt-4' : 'relative'
-                      }
-                    >
-                      {/* 질문자 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
-                      {answer.is_adopted && (
-                        <div className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white">
-                          질문자 채택
-                        </div>
-                      )}
-
-                      <article
-                        className={`bg-bg-base rounded-lg border p-6 ${
-                          answer.is_adopted
-                            ? 'border-primary'
-                            : 'border-border-base'
-                        }`}
+                {sortedAnswers.map((answer) => (
+                  // 채택된 답변은 배지가 카드 위로 올라오므로 상단 여백 추가
+                  <div
+                    key={answer.id}
+                    className={answer.is_adopted ? 'relative mt-4' : 'relative'}
+                  >
+                    {/* 질문자 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
+                    {answer.is_adopted && (
+                      <div
+                        role="status"
+                        aria-label="질문자가 채택한 답변"
+                        className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white"
                       >
-                        {/* 작성자 정보 + 채택하기 버튼 + 수정 시각 */}
-                        <div className="mb-4 flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <span className="text-text-heading text-sm font-medium">
-                              {answer.author.nickname}
-                            </span>
-                            <span className="text-text-muted text-xs">
-                              {answer.author.course_name} ·{' '}
-                              {answer.author.cohort_name}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <time
-                              dateTime={answer.updated_at}
-                              className="text-text-muted text-xs"
-                            >
-                              수정일: {formatDate(answer.updated_at)}
-                            </time>
-                            {/* 채택하기 버튼 — 질문 작성자 + 미채택 상태 */}
-                            {isQuestionOwner && !anyAdopted && (
-                              <Button
-                                size="sm"
-                                onClick={() => setConfirmAcceptId(answer.id)}
-                                disabled={isAcceptPending}
-                                loading={
-                                  isAcceptPending &&
-                                  confirmAcceptId === answer.id
-                                }
-                              >
-                                채택하기
-                              </Button>
-                            )}
-                          </div>
-                        </div>
+                        질문자 채택
+                      </div>
+                    )}
 
-                        {/* 답변 내용 (마크다운 렌더링) */}
-                        <div data-color-mode="light">
-                          <MDEditor.Markdown
-                            source={answer.content}
-                            rehypePlugins={[rehypeSanitize]}
-                          />
+                    <article
+                      className={`bg-bg-base rounded-lg border p-6 ${
+                        answer.is_adopted
+                          ? 'border-primary'
+                          : 'border-border-base'
+                      }`}
+                    >
+                      {/* 작성자 정보 + 채택하기 버튼 + 수정 시각 */}
+                      <div className="mb-4 flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-text-heading text-sm font-medium">
+                            {answer.author.nickname}
+                          </span>
+                          <span className="text-text-muted text-xs">
+                            {answer.author.course_name} ·{' '}
+                            {answer.author.cohort_name}
+                          </span>
                         </div>
-                      </article>
-                    </div>
-                  ))}
+                        <div className="flex items-center gap-3">
+                          <time
+                            dateTime={answer.updated_at}
+                            className="text-text-muted text-xs"
+                          >
+                            수정일: {formatDate(answer.updated_at)}
+                          </time>
+                          {/* 채택하기 버튼 — 질문 작성자 + 미채택 상태 */}
+                          {isQuestionOwner && !anyAdopted && (
+                            <Button
+                              size="sm"
+                              type="button"
+                              onClick={() => setConfirmAcceptId(answer.id)}
+                              disabled={isAcceptPending}
+                              loading={
+                                isAcceptPending && confirmAcceptId === answer.id
+                              }
+                            >
+                              채택하기
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* 답변 내용 (마크다운 렌더링) */}
+                      <div data-color-mode="light">
+                        <MDEditor.Markdown
+                          source={answer.content}
+                          rehypePlugins={[rehypeSanitize]}
+                        />
+                      </div>
+                    </article>
+                  </div>
+                ))}
               </div>
             )}
           </>
@@ -286,8 +309,9 @@ export function QnaDetailPage() {
         <div className="mt-6">
           {!showForm ? (
             <Button
+              type="button"
               onClick={() => setShowForm(true)}
-              disabled={isEdit && myAnswer?.is_adopted}
+              disabled={isEdit && !!myAnswer?.is_adopted}
             >
               {isEdit ? '답변 수정하기' : '답변하기'}
             </Button>
@@ -321,32 +345,7 @@ export function QnaDetailPage() {
         onClose={() => setConfirmAcceptId(null)}
         message="이 답변을 채택하시겠습니까?"
         confirmLabel="채택"
-        onConfirm={() => {
-          acceptAnswer(undefined, {
-            onSuccess: () => {
-              showToast('답변이 채택되었습니다.', 'success')
-              setConfirmAcceptId(null)
-            },
-            onError: (error) => {
-              const message = handleApiError(
-                error,
-                {
-                  400: '유효하지 않은 답변 채택 요청입니다.',
-                  401: '로그인한 사용자만 답변을 채택할 수 있습니다.',
-                  403: '본인이 작성한 질문의 답변만 채택할 수 있습니다.',
-                  404: '해당 질문 또는 답변을 찾을 수 없습니다.',
-                  409: '이미 채택된 답변이 존재합니다.',
-                },
-                {
-                  401: () => navigate(ROUTES.AUTH.LOGIN),
-                  404: () => navigate(ROUTES.QNA.LIST),
-                }
-              )
-              showToast(message, 'error')
-              setConfirmAcceptId(null)
-            },
-          })
-        }}
+        onConfirm={handleConfirmAccept}
       />
 
       {/* 토스트 알림 */}

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -184,9 +184,9 @@ export function QnaDetailPage() {
             404: () => navigate(ROUTES.QNA.LIST),
           }
         )
+        setConfirmAcceptId(null)
         showToast(message, 'error')
         action?.()
-        setConfirmAcceptId(null)
       },
     })
   }
@@ -224,10 +224,10 @@ export function QnaDetailPage() {
               id="answers-heading"
               className="text-text-heading text-base font-semibold"
             >
-              답변 {answers.length}개
+              답변 {sortedAnswers.length}개
             </h2>
 
-            {answers.length === 0 ? (
+            {sortedAnswers.length === 0 ? (
               <p className="text-text-muted mt-4 text-center text-sm">
                 아직 등록된 답변이 없습니다.
               </p>

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -43,7 +43,7 @@ export function QnaDetailPage() {
 
   const numericQuestionId = questionId ? Number(questionId) : 0
 
-  // hooks는 조건부 호출 불가 — questionId 없거나 NaN일 때 early return은 hooks 아래에서 처리
+  // ── hooks는 조건부 호출 불가 — early return은 아래에서 처리 ──────────────────
   const {
     data: questionDetail,
     isLoading: isQuestionLoading,
@@ -57,13 +57,7 @@ export function QnaDetailPage() {
   const { mutate: postAnswer, isPending: isPostPending } =
     usePostAnswer(numericQuestionId)
 
-  const questionTitle = questionDetail?.title ?? '질문 내용을 불러오는 중...'
-
-  const anyAdopted = answers?.some((a) => a.is_adopted) ?? false
-  const isQuestionOwner =
-    user?.id != null && questionDetail?.author.id === user.id
-
-  // 현재 로그인 유저가 작성한 답변 찾기
+  // 현재 로그인 유저가 작성한 답변 — usePutAnswer hook 인자로 필요해 hooks 앞에 위치
   const myAnswer = answers?.find(
     (a) => user?.id != null && a.author.id === user.id
   )
@@ -87,6 +81,7 @@ export function QnaDetailPage() {
         : [],
     [answers]
   )
+  // ─────────────────────────────────────────────────────────────────────────────
 
   if (
     !questionId ||
@@ -95,6 +90,12 @@ export function QnaDetailPage() {
   ) {
     return <Navigate to={ROUTES.QNA.LIST} />
   }
+
+  // early return 이후에 위치 — questionId가 유효할 때만 의미 있는 값
+  const questionTitle = questionDetail?.title ?? '질문 내용을 불러오는 중...'
+  const anyAdopted = answers?.some((a) => a.is_adopted) ?? false
+  const isQuestionOwner =
+    user?.id != null && questionDetail?.author.id === user.id
 
   const handleCreateSubmit = (content: string, imageUrls: string[]) => {
     postAnswer(
@@ -105,7 +106,7 @@ export function QnaDetailPage() {
           setShowForm(false)
         },
         onError: (error) => {
-          const message = handleApiError(
+          const { message, action } = handleApiError(
             error,
             {
               400: '유효하지 않은 답변 등록 요청입니다.',
@@ -120,6 +121,7 @@ export function QnaDetailPage() {
             }
           )
           showToast(message, 'error')
+          action?.()
         },
       }
     )
@@ -137,7 +139,7 @@ export function QnaDetailPage() {
           setShowForm(false)
         },
         onError: (error: unknown) => {
-          const message = handleApiError(
+          const { message, action } = handleApiError(
             error,
             {
               400: '유효하지 않은 답변 수정 요청입니다.',
@@ -153,6 +155,7 @@ export function QnaDetailPage() {
             }
           )
           showToast(message, 'error')
+          action?.()
         },
       }
     )
@@ -167,7 +170,7 @@ export function QnaDetailPage() {
         setConfirmAcceptId(null)
       },
       onError: (error) => {
-        const message = handleApiError(
+        const { message, action } = handleApiError(
           error,
           {
             400: '유효하지 않은 답변 채택 요청입니다.',
@@ -182,6 +185,7 @@ export function QnaDetailPage() {
           }
         )
         showToast(message, 'error')
+        action?.()
         setConfirmAcceptId(null)
       },
     })
@@ -229,78 +233,80 @@ export function QnaDetailPage() {
               </p>
             ) : (
               <div className="mt-4 space-y-6">
-                {sortedAnswers.map((answer) => (
-                  // 채택된 답변은 배지가 카드 위로 올라오므로 상단 여백 추가
-                  <div
-                    key={answer.id}
-                    className={answer.is_adopted ? 'relative mt-4' : 'relative'}
-                  >
-                    {/* 질문자 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
-                    {answer.is_adopted && (
-                      <div
-                        role="status"
-                        aria-label="질문자가 채택한 답변"
-                        className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white"
+                {sortedAnswers.map((answer) => {
+                  // 채택 배지(absolute)가 있는 경우에만 relative + 상단 여백 필요
+                  const wrapperClass = answer.is_adopted
+                    ? 'relative mt-4'
+                    : undefined
+                  const cardBorderClass = answer.is_adopted
+                    ? 'border-primary'
+                    : 'border-border-base'
+
+                  return (
+                    <div key={answer.id} className={wrapperClass}>
+                      {/* 질문자 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
+                      {answer.is_adopted && (
+                        <div
+                          role="status"
+                          aria-label="질문자가 채택한 답변"
+                          className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white"
+                        >
+                          질문자 채택
+                        </div>
+                      )}
+
+                      <article
+                        className={`bg-bg-base rounded-lg border p-6 ${cardBorderClass}`}
                       >
-                        질문자 채택
-                      </div>
-                    )}
-
-                    <article
-                      className={`bg-bg-base rounded-lg border p-6 ${
-                        answer.is_adopted
-                          ? 'border-primary'
-                          : 'border-border-base'
-                      }`}
-                    >
-                      {/* 작성자 정보 + 채택하기 버튼 + 수정 시각 */}
-                      <div className="mb-4 flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="text-text-heading text-sm font-medium">
-                            {answer.author.nickname}
-                          </span>
-                          <span className="text-text-muted text-xs">
-                            {answer.author.course_name} ·{' '}
-                            {answer.author.cohort_name}
-                          </span>
+                        {/* 작성자 정보 + 채택하기 버튼 + 수정 시각 */}
+                        <div className="mb-4 flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <span className="text-text-heading text-sm font-medium">
+                              {answer.author.nickname}
+                            </span>
+                            <span className="text-text-muted text-xs">
+                              {answer.author.course_name} ·{' '}
+                              {answer.author.cohort_name}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            <time
+                              dateTime={answer.updated_at}
+                              className="text-text-muted text-xs"
+                            >
+                              수정일: {formatDate(answer.updated_at)}
+                            </time>
+                            {/* 채택하기 버튼 — 질문 작성자 + 미채택 + 본인 답변 제외 */}
+                            {isQuestionOwner &&
+                              !anyAdopted &&
+                              answer.author.id !== user?.id && (
+                                <Button
+                                  size="sm"
+                                  type="button"
+                                  onClick={() => setConfirmAcceptId(answer.id)}
+                                  disabled={isAcceptPending}
+                                  loading={
+                                    isAcceptPending &&
+                                    confirmAcceptId === answer.id
+                                  }
+                                >
+                                  채택하기
+                                </Button>
+                              )}
+                          </div>
                         </div>
-                        <div className="flex items-center gap-3">
-                          <time
-                            dateTime={answer.updated_at}
-                            className="text-text-muted text-xs"
-                          >
-                            수정일: {formatDate(answer.updated_at)}
-                          </time>
-                          {/* 채택하기 버튼 — 질문 작성자 + 미채택 + 본인 답변 제외 */}
-                          {isQuestionOwner &&
-                            !anyAdopted &&
-                            answer.author.id !== user?.id && (
-                              <Button
-                                size="sm"
-                                type="button"
-                                onClick={() => setConfirmAcceptId(answer.id)}
-                                disabled={isAcceptPending}
-                                loading={
-                                  isAcceptPending &&
-                                  confirmAcceptId === answer.id
-                                }
-                              >
-                                채택하기
-                              </Button>
-                            )}
-                        </div>
-                      </div>
 
-                      {/* 답변 내용 (마크다운 렌더링) */}
-                      <div data-color-mode="light">
-                        <MDEditor.Markdown
-                          source={answer.content}
-                          rehypePlugins={[rehypeSanitize]}
-                        />
-                      </div>
-                    </article>
-                  </div>
-                ))}
+                        {/* 답변 내용 (마크다운 렌더링) */}
+                        <div data-color-mode="light">
+                          <MDEditor.Markdown
+                            source={answer.content}
+                            rehypePlugins={[rehypeSanitize]}
+                          />
+                        </div>
+                      </article>
+                    </div>
+                  )
+                })}
               </div>
             )}
           </>

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -271,20 +271,23 @@ export function QnaDetailPage() {
                           >
                             수정일: {formatDate(answer.updated_at)}
                           </time>
-                          {/* 채택하기 버튼 — 질문 작성자 + 미채택 상태 */}
-                          {isQuestionOwner && !anyAdopted && (
-                            <Button
-                              size="sm"
-                              type="button"
-                              onClick={() => setConfirmAcceptId(answer.id)}
-                              disabled={isAcceptPending}
-                              loading={
-                                isAcceptPending && confirmAcceptId === answer.id
-                              }
-                            >
-                              채택하기
-                            </Button>
-                          )}
+                          {/* 채택하기 버튼 — 질문 작성자 + 미채택 + 본인 답변 제외 */}
+                          {isQuestionOwner &&
+                            !anyAdopted &&
+                            answer.author.id !== user?.id && (
+                              <Button
+                                size="sm"
+                                type="button"
+                                onClick={() => setConfirmAcceptId(answer.id)}
+                                disabled={isAcceptPending}
+                                loading={
+                                  isAcceptPending &&
+                                  confirmAcceptId === answer.id
+                                }
+                              >
+                                채택하기
+                              </Button>
+                            )}
                         </div>
                       </div>
 

--- a/src/utils/handleApiError.ts
+++ b/src/utils/handleApiError.ts
@@ -1,0 +1,16 @@
+import axios from 'axios'
+
+export function handleApiError(
+  error: unknown,
+  messages: Partial<Record<number, string>>,
+  actions?: Partial<Record<number, () => void>>
+): string {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status
+    if (status != null && messages[status] != null) {
+      actions?.[status]?.()
+      return messages[status]!
+    }
+  }
+  return '일시적인 오류가 발생했습니다. 다시 시도해 주세요.'
+}

--- a/src/utils/handleApiError.ts
+++ b/src/utils/handleApiError.ts
@@ -1,16 +1,24 @@
 import axios from 'axios'
 
+interface ApiErrorResult {
+  message: string
+  action?: () => void
+}
+
+/**
+ * Axios 에러에서 상태 코드에 맞는 메시지와 사이드이펙트를 반환한다.
+ * action은 호출 측에서 showToast 이후에 실행해야 한다 (toast가 먼저 렌더링되도록).
+ */
 export function handleApiError(
   error: unknown,
   messages: Partial<Record<number, string>>,
   actions?: Partial<Record<number, () => void>>
-): string {
+): ApiErrorResult {
   if (axios.isAxiosError(error)) {
     const status = error.response?.status
     if (status != null && messages[status] != null) {
-      actions?.[status]?.()
-      return messages[status]!
+      return { message: messages[status]!, action: actions?.[status] }
     }
   }
-  return '일시적인 오류가 발생했습니다. 다시 시도해 주세요.'
+  return { message: '일시적인 오류가 발생했습니다. 다시 시도해 주세요.' }
 }


### PR DESCRIPTION
## 관련 이슈

- closes #8

## 작업 내용

- REQ-QNA-007 질의응답 답변 채택(Q&A) 기능 구현

## 변경 사항

### 신규 파일
- `src/features/qna/answer-accept/types.ts` — `AcceptAnswerResponse` 타입 정의
- `src/features/qna/answer-accept/queries.ts` — `useAcceptAnswer` mutation 훅 (POST `/api/v1/qna/answers/:id/accept`, invalidateQueries 연동)
- `src/features/qna/answer-accept/handler.ts` — MSW 핸들러 (채택 POST → `markAnswerAdopted` 호출로 GET 상태 동기화)
- `src/features/qna/answer-accept/index.ts` — barrel export

### 수정 파일
- `src/pages/qna/QnaDetailPage.tsx`
  - 채택 기능 연동 (`useAcceptAnswer`, `ConfirmModal`, `confirmAcceptId` 상태)
  - 화면정의서 디자인 반영: 채택 배지 카드 상단 플로팅, 채택하기 버튼 헤더 우측, `border-primary` 테두리, 채택 답변 상단 정렬
  - 버그 수정: `numericQuestionId <= 0` early return, 답변 에러 시 폼 미노출, 채택된 본인 답변 수정 버튼 비활성화
- `src/features/qna/answers/handler.ts` — MSW 상태 추가 (`_adoptedAnswerIds`, `markAnswerAdopted`) → 채택 후 GET 재조회 시 `is_adopted: true` 반영
- `src/mocks/handlers.ts` — `answerAcceptHandlers` 등록
- `.gitignore` — `src/pages/**/*TestPage.tsx` 제외 (로컬 테스트 페이지)

## 스크린샷 (선택)

| 기본 상태 | 채택 완료 |
|---|---|
| 채택하기 버튼 노출 (질문 작성자) | 배지 + 보라색 테두리, 버튼 사라짐 |

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다