### PR TITLE
feat: 질문 상세 조회 페이지 구현 (#4)

### DIFF
--- a/src/features/qna/answer-accept/handler.ts
+++ b/src/features/qna/answer-accept/handler.ts
@@ -6,14 +6,17 @@ import {
 } from '@/features/qna/answers/handler'
 
 export const answerAcceptHandlers = [
-  http.post('/api/v1/qna/answers/:id/accept', ({ params }) => {
-    const answerId = Number(params.id)
-    markAnswerAdopted(answerId)
-    const response: AcceptAnswerResponse = {
-      question_id: getQuestionIdByAnswer(answerId),
-      answer_id: answerId,
-      is_adopted: true,
+  http.post(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/answers/:id/accept`,
+    ({ params }) => {
+      const answerId = Number(params.id)
+      markAnswerAdopted(answerId)
+      const response: AcceptAnswerResponse = {
+        question_id: getQuestionIdByAnswer(answerId),
+        answer_id: answerId,
+        is_adopted: true,
+      }
+      return HttpResponse.json(response, { status: 200 })
     }
-    return HttpResponse.json(response, { status: 200 })
-  }),
+  ),
 ]

--- a/src/features/qna/answer-accept/queries.ts
+++ b/src/features/qna/answer-accept/queries.ts
@@ -9,7 +9,7 @@ export function useAcceptAnswer(questionId: number) {
   return useMutation<AcceptAnswerResponse, AxiosError, number>({
     mutationFn: (answerId: number) =>
       api
-        .post<AcceptAnswerResponse>(`/api/v1/qna/answers/${answerId}/accept`)
+        .post<AcceptAnswerResponse>(`/qna/answers/${answerId}/accept`)
         .then((res) => res.data),
     onSuccess: () => {
       // TanStack Query가 두 호출을 내부적으로 병렬 처리한다

--- a/src/features/qna/answer-comments/handler.ts
+++ b/src/features/qna/answer-comments/handler.ts
@@ -1,0 +1,13 @@
+import { http, HttpResponse } from 'msw'
+import type { PostCommentResponse } from './types'
+
+export const answerCommentsHandlers = [
+  http.post('/api/v1/qna/answers/:answer_id/comments', ({ params }) => {
+    const response: PostCommentResponse = {
+      id: Date.now(),
+      answer_id: Number(params.answer_id),
+      created_at: new Date().toISOString(),
+    }
+    return HttpResponse.json(response, { status: 201 })
+  }),
+]

--- a/src/features/qna/answer-comments/handler.ts
+++ b/src/features/qna/answer-comments/handler.ts
@@ -2,12 +2,15 @@ import { http, HttpResponse } from 'msw'
 import type { PostCommentResponse } from './types'
 
 export const answerCommentsHandlers = [
-  http.post('/api/v1/qna/answers/:answer_id/comments', ({ params }) => {
-    const response: PostCommentResponse = {
-      id: Date.now(),
-      answer_id: Number(params.answer_id),
-      created_at: new Date().toISOString(),
+  http.post(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/answers/:answer_id/comments`,
+    ({ params }) => {
+      const response: PostCommentResponse = {
+        id: Date.now(),
+        answer_id: Number(params.answer_id),
+        created_at: new Date().toISOString(),
+      }
+      return HttpResponse.json(response, { status: 201 })
     }
-    return HttpResponse.json(response, { status: 201 })
-  }),
+  ),
 ]

--- a/src/features/qna/answer-comments/index.ts
+++ b/src/features/qna/answer-comments/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './queries'
+export * from './handler'

--- a/src/features/qna/answer-comments/queries.ts
+++ b/src/features/qna/answer-comments/queries.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '@/api/instance'
+import type { PostCommentRequest, PostCommentResponse } from './types'
+
+export function usePostComment(answerId: number, questionId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: PostCommentRequest) =>
+      api
+        .post<PostCommentResponse>(
+          `/api/v1/qna/answers/${answerId}/comments`,
+          data
+        )
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+    },
+  })
+}

--- a/src/features/qna/answer-comments/queries.ts
+++ b/src/features/qna/answer-comments/queries.ts
@@ -8,13 +8,13 @@ export function usePostComment(answerId: number, questionId: number) {
   return useMutation({
     mutationFn: (data: PostCommentRequest) =>
       api
-        .post<PostCommentResponse>(
-          `/api/v1/qna/answers/${answerId}/comments`,
-          data
-        )
+        .post<PostCommentResponse>(`/qna/answers/${answerId}/comments`, data)
         .then((res) => res.data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+      queryClient.invalidateQueries({
+        queryKey: ['question-detail', questionId],
+      })
     },
   })
 }

--- a/src/features/qna/answer-comments/types.ts
+++ b/src/features/qna/answer-comments/types.ts
@@ -1,0 +1,23 @@
+export interface CommentAuthor {
+  id: number
+  nickname: string
+  profile_image_url: string | null
+}
+
+export interface AnswerComment {
+  id: number
+  author: CommentAuthor
+  content: string
+  created_at: string
+  updated_at: string
+}
+
+export interface PostCommentRequest {
+  content: string
+}
+
+export interface PostCommentResponse {
+  id: number
+  answer_id: number
+  created_at: string
+}

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -24,66 +24,75 @@ export function getQuestionIdByAnswer(answerId: number): number {
 }
 
 export const answersHandlers = [
-  http.get('/api/v1/qna/questions/:question_id/answers', ({ params }) => {
-    // GET 시점에 매핑 초기화 — POST answer 이전 채택 시나리오도 커버
-    _answerQuestionMap.set(MOCK_ANSWER_ID, Number(params.question_id))
-    const response: GetAnswersResponse = [
-      {
-        id: MOCK_ANSWER_ID,
-        author: {
-          id: MOCK_AUTHOR_ID,
-          nickname: '테스트유저',
-          profile_image_url: null,
-          course_name: 'OZ 코딩스쿨',
-          cohort_name: '8기',
-        },
-        content: '기존 답변 내용입니다.\n\n마크다운으로 작성된 답변입니다.',
-        is_adopted: _adoptedAnswerIds.has(MOCK_ANSWER_ID),
-        images: [],
-        comments: [
-          {
-            id: 1001,
-            author: { id: 301, nickname: '댓글러', profile_image_url: null },
-            content: '도움이 많이 되었습니다. 감사해요!',
-            created_at: new Date(Date.now() - 3600000).toISOString(),
-            updated_at: new Date(Date.now() - 3600000).toISOString(),
+  http.get(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:question_id/answers`,
+    ({ params }) => {
+      // GET 시점에 매핑 초기화 — POST answer 이전 채택 시나리오도 커버
+      _answerQuestionMap.set(MOCK_ANSWER_ID, Number(params.question_id))
+      const response: GetAnswersResponse = [
+        {
+          id: MOCK_ANSWER_ID,
+          author: {
+            id: MOCK_AUTHOR_ID,
+            nickname: '테스트유저',
+            profile_image_url: null,
+            course_name: 'OZ 코딩스쿨',
+            cohort_name: '8기',
           },
-          {
-            id: 1002,
-            author: {
-              id: 302,
-              nickname: '개발공부중',
-              profile_image_url: null,
+          content: '기존 답변 내용입니다.\n\n마크다운으로 작성된 답변입니다.',
+          is_adopted: _adoptedAnswerIds.has(MOCK_ANSWER_ID),
+          images: [],
+          comments: [
+            {
+              id: 1001,
+              author: { id: 301, nickname: '댓글러', profile_image_url: null },
+              content: '도움이 많이 되었습니다. 감사해요!',
+              created_at: new Date(Date.now() - 3600000).toISOString(),
+              updated_at: new Date(Date.now() - 3600000).toISOString(),
             },
-            content: '저도 같은 문제로 고민했는데 덕분에 해결했어요.',
-            created_at: new Date(Date.now() - 1800000).toISOString(),
-            updated_at: new Date(Date.now() - 1800000).toISOString(),
-          },
-        ],
+            {
+              id: 1002,
+              author: {
+                id: 302,
+                nickname: '개발공부중',
+                profile_image_url: null,
+              },
+              content: '저도 같은 문제로 고민했는데 덕분에 해결했어요.',
+              created_at: new Date(Date.now() - 1800000).toISOString(),
+              updated_at: new Date(Date.now() - 1800000).toISOString(),
+            },
+          ],
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ]
+      return HttpResponse.json(response, { status: 200 })
+    }
+  ),
+
+  http.post(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:question_id/answers`,
+    ({ params }) => {
+      const questionId = Number(params.question_id)
+      _answerQuestionMap.set(MOCK_ANSWER_ID, questionId)
+      const response: PostAnswerResponse = {
+        answer_id: MOCK_ANSWER_ID,
+        question_id: questionId,
+        author_id: MOCK_AUTHOR_ID,
         created_at: new Date().toISOString(),
+      }
+      return HttpResponse.json(response, { status: 201 })
+    }
+  ),
+
+  http.put(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/answers/:id`,
+    ({ params }) => {
+      const response: PutAnswerResponse = {
+        answer_id: Number(params.id),
         updated_at: new Date().toISOString(),
-      },
-    ]
-    return HttpResponse.json(response, { status: 200 })
-  }),
-
-  http.post('/api/v1/qna/questions/:question_id/answers', ({ params }) => {
-    const questionId = Number(params.question_id)
-    _answerQuestionMap.set(MOCK_ANSWER_ID, questionId)
-    const response: PostAnswerResponse = {
-      answer_id: MOCK_ANSWER_ID,
-      question_id: questionId,
-      author_id: MOCK_AUTHOR_ID,
-      created_at: new Date().toISOString(),
+      }
+      return HttpResponse.json(response, { status: 200 })
     }
-    return HttpResponse.json(response, { status: 201 })
-  }),
-
-  http.put('/api/v1/qna/answers/:id', ({ params }) => {
-    const response: PutAnswerResponse = {
-      answer_id: Number(params.id),
-      updated_at: new Date().toISOString(),
-    }
-    return HttpResponse.json(response, { status: 200 })
-  }),
+  ),
 ]

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -40,7 +40,26 @@ export const answersHandlers = [
         content: '기존 답변 내용입니다.\n\n마크다운으로 작성된 답변입니다.',
         is_adopted: _adoptedAnswerIds.has(MOCK_ANSWER_ID),
         images: [],
-        comments: [],
+        comments: [
+          {
+            id: 1001,
+            author: { id: 301, nickname: '댓글러', profile_image_url: null },
+            content: '도움이 많이 되었습니다. 감사해요!',
+            created_at: new Date(Date.now() - 3600000).toISOString(),
+            updated_at: new Date(Date.now() - 3600000).toISOString(),
+          },
+          {
+            id: 1002,
+            author: {
+              id: 302,
+              nickname: '개발공부중',
+              profile_image_url: null,
+            },
+            content: '저도 같은 문제로 고민했는데 덕분에 해결했어요.',
+            created_at: new Date(Date.now() - 1800000).toISOString(),
+            updated_at: new Date(Date.now() - 1800000).toISOString(),
+          },
+        ],
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       },

--- a/src/features/qna/answers/queries.ts
+++ b/src/features/qna/answers/queries.ts
@@ -15,10 +15,7 @@ export function usePostAnswer(questionId: number) {
   return useMutation({
     mutationFn: (data: PostAnswerRequest) =>
       api
-        .post<PostAnswerResponse>(
-          `/api/v1/qna/questions/${questionId}/answers`,
-          data
-        )
+        .post<PostAnswerResponse>(`/qna/questions/${questionId}/answers`, data)
         .then((res) => res.data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
@@ -31,7 +28,7 @@ export function useGetAnswers(questionId: number) {
     queryKey: ['answers', questionId],
     queryFn: () =>
       api
-        .get<GetAnswersResponse>(`/api/v1/qna/questions/${questionId}/answers`)
+        .get<GetAnswersResponse>(`/qna/questions/${questionId}/answers`)
         .then((res) => res.data),
     staleTime: 60_000,
     retry: 1,
@@ -46,7 +43,7 @@ export function usePutAnswer(answerId: number | undefined, questionId: number) {
     mutationFn: async (data: PutAnswerRequest) => {
       if (answerId === undefined) throw new Error('answerId is required')
       const res = await api.put<PutAnswerResponse>(
-        `/api/v1/qna/answers/${answerId}`,
+        `/qna/answers/${answerId}`,
         data
       )
       return res.data

--- a/src/features/qna/answers/types.ts
+++ b/src/features/qna/answers/types.ts
@@ -1,3 +1,5 @@
+import type { AnswerComment } from '../answer-comments/types'
+
 export interface PostAnswerRequest {
   content: string
   img_urls: string[]
@@ -29,7 +31,7 @@ export interface GetAnswerItem {
   content: string
   is_adopted: boolean
   images: AnswerImage[]
-  comments: unknown[]
+  comments: AnswerComment[]
   created_at: string
   updated_at: string
 }

--- a/src/features/qna/presigned-url/handler.ts
+++ b/src/features/qna/presigned-url/handler.ts
@@ -2,17 +2,20 @@ import { http, HttpResponse } from 'msw'
 import type { GetPresignedUrlResponse } from './types'
 
 export const presignedUrlHandlers = [
-  http.put('/api/v1/qna/answers/presigned-url', async ({ request }) => {
-    const body = (await request.json()) as { file_name: string }
-    const uuid = crypto.randomUUID()
-    const key = `uploads/images/answers/${uuid}-${body.file_name}`
-    const baseUrl = `https://mock-bucket.s3.ap-northeast-2.amazonaws.com/${key}`
+  http.put(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/answers/presigned-url`,
+    async ({ request }) => {
+      const body = (await request.json()) as { file_name: string }
+      const uuid = crypto.randomUUID()
+      const key = `uploads/images/answers/${uuid}-${body.file_name}`
+      const baseUrl = `https://mock-bucket.s3.ap-northeast-2.amazonaws.com/${key}`
 
-    const response: GetPresignedUrlResponse = {
-      presigned_url: `${baseUrl}?AWSAccessKeyId=mock&Signature=mock`,
-      img_url: baseUrl,
-      key,
+      const response: GetPresignedUrlResponse = {
+        presigned_url: `${baseUrl}?AWSAccessKeyId=mock&Signature=mock`,
+        img_url: baseUrl,
+        key,
+      }
+      return HttpResponse.json(response, { status: 200 })
     }
-    return HttpResponse.json(response, { status: 200 })
-  }),
+  ),
 ]

--- a/src/features/qna/presigned-url/queries.ts
+++ b/src/features/qna/presigned-url/queries.ts
@@ -6,7 +6,7 @@ export function useGetPresignedUrl() {
   return useMutation({
     mutationFn: (data: GetPresignedUrlRequest) =>
       api
-        .put<GetPresignedUrlResponse>('/api/v1/qna/answers/presigned-url', data)
+        .put<GetPresignedUrlResponse>('/qna/answers/presigned-url', data)
         .then((res) => res.data),
   })
 }

--- a/src/features/qna/question-detail/handler.ts
+++ b/src/features/qna/question-detail/handler.ts
@@ -2,26 +2,29 @@ import { http, HttpResponse } from 'msw'
 import type { GetQuestionDetailResponse } from './types'
 
 export const questionDetailHandler = [
-  http.get('/api/v1/qna/questions/:question_id/', ({ params }) => {
-    const response: GetQuestionDetailResponse = {
-      id: Number(params.question_id),
-      title: '[MSW] Django ORM에서 역참조 관계를 설정하는 방법이 궁금합니다',
-      content:
-        'related_name을 사용하면 된다고 알고 있는데, 구체적인 사용법을 알고 싶습니다.',
-      category: { id: 1, name: 'Django' },
-      images: [],
-      view_count: 42,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      author: {
-        id: 100,
-        nickname: '질문자',
-        profile_image_url: null,
-        course_name: 'OZ 코딩스쿨',
-        cohort_name: '8기',
-      },
-      answers: [],
+  http.get(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:question_id/`,
+    ({ params }) => {
+      const response: GetQuestionDetailResponse = {
+        id: Number(params.question_id),
+        title: '[MSW] Django ORM에서 역참조 관계를 설정하는 방법이 궁금합니다',
+        content:
+          'related_name을 사용하면 된다고 알고 있는데, 구체적인 사용법을 알고 싶습니다.',
+        category: { id: 1, name: 'Django' },
+        images: [],
+        view_count: 42,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        author: {
+          id: 100,
+          nickname: '질문자',
+          profile_image_url: null,
+          course_name: 'OZ 코딩스쿨',
+          cohort_name: '8기',
+        },
+        answers: [],
+      }
+      return HttpResponse.json(response, { status: 200 })
     }
-    return HttpResponse.json(response, { status: 200 })
-  }),
+  ),
 ]

--- a/src/features/qna/question-detail/queries.ts
+++ b/src/features/qna/question-detail/queries.ts
@@ -7,7 +7,7 @@ export function useGetQuestionDetail(questionId: number) {
     queryKey: ['question-detail', questionId],
     queryFn: () =>
       api
-        .get<GetQuestionDetailResponse>(`/api/v1/qna/questions/${questionId}/`)
+        .get<GetQuestionDetailResponse>(`/qna/questions/${questionId}/`)
         .then((res) => res.data),
     staleTime: 60_000,
     retry: 1,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -6,6 +6,7 @@ import { categoriesHandler } from '@/features/qna/categories'
 import { questionsHandler } from '@/features/qna/questions'
 import { questionWriteHandler } from '@/features/qna/question-write'
 import { questionDetailHandler } from '@/features/qna/question-detail'
+import { answerCommentsHandlers } from '@/features/qna/answer-comments'
 
 export const handlers = [
   http.get('/api/health', () => {
@@ -13,6 +14,7 @@ export const handlers = [
   }),
   ...answersHandlers,
   ...answerAcceptHandlers,
+  ...answerCommentsHandlers,
   ...presignedUrlHandlers,
   ...categoriesHandler,
   ...questionsHandler,

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -51,6 +51,7 @@ function CommentForm({
         value={content}
         onChange={(e) => setContent(e.target.value)}
         placeholder="댓글을 입력하세요"
+        aria-label="댓글 입력"
         rows={2}
         disabled={isPending}
         className="border-border-base focus:border-primary flex-1 resize-none rounded-md border px-3 py-2 text-sm outline-none disabled:opacity-50"
@@ -152,9 +153,14 @@ export function QnaDetailPage() {
   const sortedAnswers = useMemo(
     () =>
       answers
-        ? [...answers].sort(
-            (a, b) => Number(b.is_adopted) - Number(a.is_adopted)
-          )
+        ? [...answers].sort((a, b) => {
+            const byAdopted = Number(b.is_adopted) - Number(a.is_adopted)
+            if (byAdopted !== 0) return byAdopted
+            return (
+              new Date(a.created_at).getTime() -
+              new Date(b.created_at).getTime()
+            )
+          })
         : [],
     [answers]
   )
@@ -318,7 +324,8 @@ export function QnaDetailPage() {
                       ROUTES.QNA.EDIT.replace(
                         ':questionId',
                         String(numericQuestionId)
-                      )
+                      ),
+                      { replace: true }
                     )
                   }
                 >
@@ -340,11 +347,13 @@ export function QnaDetailPage() {
             {/* 첨부 이미지 */}
             {questionDetail.images.length > 0 && (
               <div className="mt-4 flex flex-wrap gap-2">
-                {questionDetail.images.map((img) => (
+                {questionDetail.images.map((img, idx) => (
                   <img
                     key={img.id}
                     src={img.img_url}
-                    alt="첨부 이미지"
+                    alt={`첨부 이미지 ${idx + 1}`}
+                    loading="lazy"
+                    decoding="async"
                     className="max-h-64 rounded-md object-contain"
                   />
                 ))}

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -3,11 +3,11 @@
  */
 
 import { useRef, useState, useMemo } from 'react'
-import { ConfirmModal } from '@/components/common/Modal'
 import { useParams, useNavigate, Navigate } from 'react-router'
 import rehypeSanitize from 'rehype-sanitize'
 import MDEditor from '@uiw/react-md-editor'
-import { Button } from '@/components/common/Button'
+import { Button, Spinner } from '@/components'
+import { ConfirmModal } from '@/components/common/Modal'
 import { Toast } from '@/components/common/Toast'
 import { AnswerForm } from '@/components/qna/AnswerForm'
 import type { AnswerFormHandle } from '@/components/qna/AnswerForm'
@@ -20,10 +20,88 @@ import {
 } from '@/features/qna/answers'
 import { useAcceptAnswer } from '@/features/qna/answer-accept'
 import { useGetQuestionDetail } from '@/features/qna/question-detail'
+import { usePostComment } from '@/features/qna/answer-comments'
+import type { AnswerComment } from '@/features/qna/answer-comments'
 import { useToast } from '@/hooks/useToast'
 import { formatDate } from '@/utils/formatDate'
 import { handleApiError } from '@/utils/handleApiError'
 import { ROUTES } from '@/constants/routes'
+
+// ── 댓글 폼 ──────────────────────────────────────────────────────────────────
+
+function CommentForm({
+  answerId,
+  questionId,
+}: {
+  answerId: number
+  questionId: number
+}) {
+  const [content, setContent] = useState('')
+  const { mutate, isPending } = usePostComment(answerId, questionId)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!content.trim()) return
+    mutate({ content: content.trim() }, { onSuccess: () => setContent('') })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-3 flex items-start gap-2">
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="댓글을 입력하세요"
+        rows={2}
+        disabled={isPending}
+        className="border-border-base focus:border-primary flex-1 resize-none rounded-md border px-3 py-2 text-sm outline-none disabled:opacity-50"
+      />
+      <Button
+        type="submit"
+        size="sm"
+        disabled={!content.trim() || isPending}
+        loading={isPending}
+      >
+        등록
+      </Button>
+    </form>
+  )
+}
+
+// ── 댓글 목록 ─────────────────────────────────────────────────────────────────
+
+function CommentList({ comments }: { comments: AnswerComment[] }) {
+  const sorted = useMemo(
+    () =>
+      [...comments].sort(
+        (a, b) =>
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+      ),
+    [comments]
+  )
+
+  if (sorted.length === 0) return null
+
+  return (
+    <ul className="border-border-base mt-4 space-y-2 border-t pt-4">
+      {sorted.map((comment) => (
+        <li key={comment.id} className="flex items-start gap-2 text-sm">
+          <span className="text-text-heading shrink-0 font-medium">
+            {comment.author.nickname}
+          </span>
+          <span className="text-text-body flex-1">{comment.content}</span>
+          <time
+            dateTime={comment.created_at}
+            className="text-text-muted shrink-0 text-xs"
+          >
+            {formatDate(comment.created_at)}
+          </time>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+// ── QnaDetailPage ─────────────────────────────────────────────────────────────
 
 export function QnaDetailPage() {
   const { questionId } = useParams<{ questionId: string }>()
@@ -31,7 +109,6 @@ export function QnaDetailPage() {
   const { isAuthenticated, user } = useAuthStore()
   const { toast, showToast, hideToast } = useToast()
 
-  // RBAC: 로그인 + 허용 role인 경우에만 답변 버튼 노출
   const canAnswer =
     isAuthenticated &&
     user?.role != null &&
@@ -43,21 +120,22 @@ export function QnaDetailPage() {
 
   const numericQuestionId = questionId ? Number(questionId) : 0
 
-  // ── hooks는 조건부 호출 불가 — early return은 아래에서 처리 ──────────────────
+  // ── hooks는 조건부 호출 불가 — early return은 아래에서 처리 ──────────────
   const {
     data: questionDetail,
     isLoading: isQuestionLoading,
     isError: isQuestionError,
   } = useGetQuestionDetail(numericQuestionId)
+
   const {
     data: answers,
     isLoading: isAnswersLoading,
     isError: isAnswersError,
   } = useGetAnswers(numericQuestionId)
+
   const { mutate: postAnswer, isPending: isPostPending } =
     usePostAnswer(numericQuestionId)
 
-  // 현재 로그인 유저가 작성한 답변 — usePutAnswer hook 인자로 필요해 hooks 앞에 위치
   const myAnswer = answers?.find(
     (a) => user?.id != null && a.author.id === user.id
   )
@@ -71,7 +149,6 @@ export function QnaDetailPage() {
     numericQuestionId
   )
 
-  // 채택 답변 상단 정렬 — 매 렌더링 sort 방지
   const sortedAnswers = useMemo(
     () =>
       answers
@@ -81,7 +158,7 @@ export function QnaDetailPage() {
         : [],
     [answers]
   )
-  // ─────────────────────────────────────────────────────────────────────────────
+  // ──────────────────────────────────────────────────────────────────────────
 
   if (
     !questionId ||
@@ -91,7 +168,6 @@ export function QnaDetailPage() {
     return <Navigate to={ROUTES.QNA.LIST} />
   }
 
-  // early return 이후에 위치 — questionId가 유효할 때만 의미 있는 값
   const questionTitle = questionDetail?.title ?? '질문 내용을 불러오는 중...'
   const anyAdopted = answers?.some((a) => a.is_adopted) ?? false
   const isQuestionOwner =
@@ -129,7 +205,6 @@ export function QnaDetailPage() {
 
   const handleEditSubmit = (content: string, imageUrls: string[]) => {
     if (!myAnswer) return
-
     putAnswer(
       { content, img_urls: imageUrls },
       {
@@ -163,7 +238,6 @@ export function QnaDetailPage() {
 
   const handleConfirmAccept = () => {
     if (confirmAcceptId === null) return
-
     acceptAnswer(confirmAcceptId, {
       onSuccess: () => {
         showToast('답변이 채택되었습니다.', 'success')
@@ -193,25 +267,99 @@ export function QnaDetailPage() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
-      {/* 질문 상세 영역 (추후 구현) */}
-      <div className="border-border-base bg-bg-base rounded-lg border p-6">
+      {/* 질문 상세 */}
+      <section className="border-border-base bg-bg-base rounded-lg border p-6">
         {isQuestionLoading && (
-          <p className="text-text-muted text-sm">질문을 불러오는 중...</p>
+          <div className="flex justify-center py-10">
+            <Spinner label="질문을 불러오는 중..." />
+          </div>
         )}
         {isQuestionError && (
           <p className="text-error text-sm">
             질문을 불러오지 못했습니다. 다시 시도해 주세요.
           </p>
         )}
-        {!isQuestionLoading && !isQuestionError && (
-          <p className="text-text-muted">질의응답 상세</p>
+        {questionDetail && (
+          <>
+            {/* 카테고리 */}
+            <span className="text-text-muted text-xs font-medium">
+              {questionDetail.category.name}
+            </span>
+
+            {/* 제목 */}
+            <h1 className="text-text-heading mt-1.5 text-xl leading-snug font-bold">
+              {questionDetail.title}
+            </h1>
+
+            {/* 메타 정보 */}
+            <div className="mt-3 flex items-center justify-between">
+              <div className="text-text-muted flex flex-wrap items-center gap-1.5 text-sm">
+                <span className="text-text-heading font-medium">
+                  {questionDetail.author.nickname}
+                </span>
+                <span>·</span>
+                <span>
+                  {questionDetail.author.course_name}{' '}
+                  {questionDetail.author.cohort_name}
+                </span>
+                <span>·</span>
+                <time dateTime={questionDetail.created_at}>
+                  {formatDate(questionDetail.created_at)}
+                </time>
+                <span>·</span>
+                <span>조회 {questionDetail.view_count.toLocaleString()}</span>
+              </div>
+              {isQuestionOwner && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    navigate(
+                      ROUTES.QNA.EDIT.replace(
+                        ':questionId',
+                        String(numericQuestionId)
+                      )
+                    )
+                  }
+                >
+                  수정
+                </Button>
+              )}
+            </div>
+
+            <hr className="border-border-base my-4" />
+
+            {/* 본문 — 마크다운 렌더링 */}
+            <div data-color-mode="light">
+              <MDEditor.Markdown
+                source={questionDetail.content}
+                rehypePlugins={[rehypeSanitize]}
+              />
+            </div>
+
+            {/* 첨부 이미지 */}
+            {questionDetail.images.length > 0 && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {questionDetail.images.map((img) => (
+                  <img
+                    key={img.id}
+                    src={img.img_url}
+                    alt="첨부 이미지"
+                    className="max-h-64 rounded-md object-contain"
+                  />
+                ))}
+              </div>
+            )}
+          </>
         )}
-      </div>
+      </section>
 
       {/* 답변 목록 */}
-      <section aria-labelledby="answers-heading" className="mt-6">
+      <section aria-labelledby="answers-heading" className="mt-8">
         {isAnswersLoading && (
-          <p className="text-text-muted text-sm">답변을 불러오는 중...</p>
+          <div className="flex justify-center py-10">
+            <Spinner label="답변을 불러오는 중..." />
+          </div>
         )}
         {isAnswersError && (
           <p className="text-error text-sm">
@@ -228,92 +376,104 @@ export function QnaDetailPage() {
             </h2>
 
             {sortedAnswers.length === 0 ? (
-              <p className="text-text-muted mt-4 text-center text-sm">
-                아직 등록된 답변이 없습니다.
-              </p>
+              <div className="text-text-muted mt-6 flex flex-col items-center py-12 text-center">
+                <p className="text-base font-medium">
+                  아직 등록된 답변이 없습니다.
+                </p>
+                <p className="mt-1 text-sm">첫 번째 답변을 작성해 보세요.</p>
+              </div>
             ) : (
               <div className="mt-4 space-y-6">
-                {sortedAnswers.map((answer) => {
-                  // 채택 배지(absolute)가 있는 경우에만 relative + 상단 여백 필요
-                  const wrapperClass = answer.is_adopted
-                    ? 'relative mt-4'
-                    : undefined
-                  const cardBorderClass = answer.is_adopted
-                    ? 'border-primary'
-                    : 'border-border-base'
-
-                  return (
-                    <div key={answer.id} className={wrapperClass}>
-                      {/* 질문자 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
-                      {answer.is_adopted && (
-                        <div
-                          role="status"
-                          aria-label="질문자가 채택한 답변"
-                          className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white"
-                        >
-                          질문자 채택
-                        </div>
-                      )}
-
-                      <article
-                        className={`bg-bg-base rounded-lg border p-6 ${cardBorderClass}`}
+                {sortedAnswers.map((answer) => (
+                  <div
+                    key={answer.id}
+                    className={answer.is_adopted ? 'relative mt-4' : undefined}
+                  >
+                    {/* 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
+                    {answer.is_adopted && (
+                      <div
+                        role="status"
+                        aria-label="질문자가 채택한 답변"
+                        className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white"
                       >
-                        {/* 작성자 정보 + 채택하기 버튼 + 수정 시각 */}
-                        <div className="mb-4 flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <span className="text-text-heading text-sm font-medium">
-                              {answer.author.nickname}
-                            </span>
-                            <span className="text-text-muted text-xs">
-                              {answer.author.course_name} ·{' '}
-                              {answer.author.cohort_name}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-3">
-                            <time
-                              dateTime={answer.updated_at}
-                              className="text-text-muted text-xs"
-                            >
-                              수정일: {formatDate(answer.updated_at)}
-                            </time>
-                            {/* 채택하기 버튼 — 질문 작성자 + 미채택 + 본인 답변 제외 */}
-                            {isQuestionOwner &&
-                              !anyAdopted &&
-                              answer.author.id !== user?.id && (
-                                <Button
-                                  size="sm"
-                                  type="button"
-                                  onClick={() => setConfirmAcceptId(answer.id)}
-                                  disabled={isAcceptPending}
-                                  loading={
-                                    isAcceptPending &&
-                                    confirmAcceptId === answer.id
-                                  }
-                                >
-                                  채택하기
-                                </Button>
-                              )}
-                          </div>
-                        </div>
+                        질문자 채택
+                      </div>
+                    )}
 
-                        {/* 답변 내용 (마크다운 렌더링) */}
-                        <div data-color-mode="light">
-                          <MDEditor.Markdown
-                            source={answer.content}
-                            rehypePlugins={[rehypeSanitize]}
-                          />
+                    <article
+                      className={[
+                        'bg-bg-base rounded-lg border p-6',
+                        answer.is_adopted
+                          ? 'border-primary'
+                          : 'border-border-base',
+                      ].join(' ')}
+                    >
+                      {/* 작성자 정보 + 채택하기 버튼 */}
+                      <div className="mb-4 flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <span className="text-text-heading text-sm font-medium">
+                            {answer.author.nickname}
+                          </span>
+                          <span className="text-text-muted text-xs">
+                            {answer.author.course_name} ·{' '}
+                            {answer.author.cohort_name}
+                          </span>
                         </div>
-                      </article>
-                    </div>
-                  )
-                })}
+                        <div className="flex items-center gap-3">
+                          <time
+                            dateTime={answer.updated_at}
+                            className="text-text-muted text-xs"
+                          >
+                            수정일: {formatDate(answer.updated_at)}
+                          </time>
+                          {/* 채택하기 — 질문 작성자 + 미채택 + 본인 답변 제외 */}
+                          {isQuestionOwner &&
+                            !anyAdopted &&
+                            answer.author.id !== user?.id && (
+                              <Button
+                                size="sm"
+                                type="button"
+                                onClick={() => setConfirmAcceptId(answer.id)}
+                                disabled={isAcceptPending}
+                                loading={
+                                  isAcceptPending &&
+                                  confirmAcceptId === answer.id
+                                }
+                              >
+                                채택하기
+                              </Button>
+                            )}
+                        </div>
+                      </div>
+
+                      {/* 답변 내용 — 마크다운 렌더링 */}
+                      <div data-color-mode="light">
+                        <MDEditor.Markdown
+                          source={answer.content}
+                          rehypePlugins={[rehypeSanitize]}
+                        />
+                      </div>
+
+                      {/* 댓글 목록 (오래된순 정렬) */}
+                      <CommentList comments={answer.comments} />
+
+                      {/* 댓글 폼 — 로그인 유저만 */}
+                      {isAuthenticated && (
+                        <CommentForm
+                          answerId={answer.id}
+                          questionId={numericQuestionId}
+                        />
+                      )}
+                    </article>
+                  </div>
+                ))}
               </div>
             )}
           </>
         )}
       </section>
 
-      {/* 답변 섹션 — 채택된 본인 답변은 수정 버튼 비활성 */}
+      {/* 답변 작성 / 수정 섹션 */}
       {canAnswer && !isAnswersLoading && !isAnswersError && (
         <div className="mt-6">
           {!showForm ? (


### PR DESCRIPTION
## 관련 이슈

- closes #4

## 작업 내용

이슈 #4 질문 상세 조회 페이지(REQ-QNA-003) 구현 및 코드 리뷰 반영

## 변경 사항

### 페이지 구현
- 질문 상세 정보 UI: 카테고리·제목·작성자·조회수·마크다운 본문·첨부 이미지
- 수정 버튼 조건부 렌더링 (질문 작성자 본인만)
- 채택하기 버튼 조건부 렌더링 (질문 작성자 + 미채택 + 타인 답변)
- 답변 목록: 채택 답변 상단 정렬(is_adopted → created_at secondary sort), 채택 배지 border-primary 구분
- 댓글 목록 (오래된순 정렬) + 댓글 폼 (로그인 유저 전용, aria-label 포함)
- 답변 0개 빈 상태 UI

### 신규 feature
- `answer-comments`: 타입·쿼리(`usePostComment`)·MSW 핸들러 구현
- `answers/types.ts`: `comments: unknown[]` → `comments: AnswerComment[]`

### API URL 정합성
- 전체 queries: `/api/v1/qna/` → `/qna/` (baseURL에 /api/v1 포함되어 중복)
- 전체 MSW 핸들러: 절대 경로 → `${VITE_API_BASE_URL}/qna/` 기반으로 통일

### 코드 리뷰 반영
- 댓글 등록 후 `question-detail` 캐시 invalidate 추가
- 첨부 이미지 alt 인덱스 기반 개선 + `loading=lazy` / `decoding=async` 추가
- 답변 정렬 secondary sort 추가 (`created_at` 오름차순)
- 댓글 textarea `aria-label="댓글 입력"` 추가
- 질문 수정 navigate `{ replace: true }` 추가

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다