### PR TITLE
style: ChatbotFab 스타일 수정 및 QnaDetailPage 코드 리뷰 반영 (#30)

### DIFF
--- a/src/components/chatbot/ChatbotFab.tsx
+++ b/src/components/chatbot/ChatbotFab.tsx
@@ -1,0 +1,64 @@
+import { useNavigate } from 'react-router'
+import { ROUTES } from '@/constants/routes'
+
+export function ChatbotFab() {
+  const navigate = useNavigate()
+
+  return (
+    <button
+      type="button"
+      aria-label="AI 챗봇 열기"
+      onClick={() => navigate(ROUTES.CHATBOT.HOME)}
+      className="fixed right-6 bottom-6 z-50 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-transform hover:scale-110 active:scale-95"
+      style={{ backgroundColor: '#EDE9FE' }}
+    >
+      <svg
+        width="32"
+        height="32"
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M12 2v3"
+          stroke="#6201e0"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        />
+        <circle cx="12" cy="2" r="1" fill="#6201e0" />
+        <rect x="3" y="6" width="18" height="13" rx="3" fill="#DDD6FE" />
+        <rect
+          x="3"
+          y="6"
+          width="18"
+          height="13"
+          rx="3"
+          stroke="#7c35d9"
+          strokeWidth="1.5"
+        />
+        <circle cx="9" cy="12" r="2" fill="#6201e0" />
+        <circle cx="15" cy="12" r="2" fill="#6201e0" />
+        <circle cx="9.7" cy="11.3" r="0.6" fill="white" />
+        <circle cx="15.7" cy="11.3" r="0.6" fill="white" />
+        <path
+          d="M9 15.5h6"
+          stroke="#7c35d9"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M8 19l-1 2"
+          stroke="#7c35d9"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+        <path
+          d="M16 19l1 2"
+          stroke="#7c35d9"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    </button>
+  )
+}

--- a/src/components/chatbot/index.ts
+++ b/src/components/chatbot/index.ts
@@ -1,0 +1,1 @@
+export * from './ChatbotFab'

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router'
 import { Header } from './Header'
 import { Footer } from './Footer'
+import { ChatbotFab } from '@/components/chatbot'
 
 export function DefaultLayout() {
   return (
@@ -8,6 +9,7 @@ export function DefaultLayout() {
       <Header />
       <Outlet />
       <Footer />
+      <ChatbotFab />
     </div>
   )
 }

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -30,6 +30,10 @@ export const ROUTES = {
     EDIT: '/qna/:questionId/edit',
   },
 
+  CHATBOT: {
+    HOME: '/chatbot',
+  },
+
   COMMUNITY: {
     LIST: '',
     WRITE: '',

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useRef, useState, useMemo } from 'react'
-import { useParams, useNavigate, Navigate } from 'react-router'
+import { useParams, useNavigate, Navigate, Link } from 'react-router'
 import rehypeSanitize from 'rehype-sanitize'
 import MDEditor from '@uiw/react-md-editor'
 import { Button, Spinner } from '@/components'
@@ -27,7 +27,79 @@ import { formatDate } from '@/utils/formatDate'
 import { handleApiError } from '@/utils/handleApiError'
 import { ROUTES } from '@/constants/routes'
 
-// ── 댓글 폼 ──────────────────────────────────────────────────────────────────
+// ── 아이콘 ────────────────────────────────────────────────────────────────────
+
+function LinkIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function RobotIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <rect
+        x="3"
+        y="7"
+        width="18"
+        height="13"
+        rx="3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <circle cx="9" cy="13" r="1.5" fill="currentColor" />
+      <circle cx="15" cy="13" r="1.5" fill="currentColor" />
+      <path
+        d="M9 4h6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12 4v3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M7 20l1 2h8l1-2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+// ── 댓글 폼 ───────────────────────────────────────────────────────────────────
 
 function CommentForm({
   answerId,
@@ -45,60 +117,115 @@ function CommentForm({
     mutate({ content: content.trim() }, { onSuccess: () => setContent('') })
   }
 
+  const hasContent = content.trim().length > 0
+
   return (
     <form onSubmit={handleSubmit} className="mt-3 flex items-start gap-2">
       <textarea
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        placeholder="댓글을 입력하세요"
+        placeholder="개인정보를 공유 및 요청하거나, 명예 훼손, 무단 광고, 불법 정보 유포시 모니터링 후 삭제될 수 있습니다."
         aria-label="댓글 입력"
         rows={2}
         disabled={isPending}
         className="border-border-base focus:border-primary flex-1 resize-none rounded-md border px-3 py-2 text-sm outline-none disabled:opacity-50"
       />
-      <Button
+      <button
         type="submit"
-        size="sm"
-        disabled={!content.trim() || isPending}
-        loading={isPending}
+        disabled={!hasContent || isPending}
+        aria-busy={isPending}
+        className={[
+          'h-9 shrink-0 rounded-sm px-3 text-sm font-medium transition-colors',
+          hasContent && !isPending
+            ? 'bg-primary hover:bg-primary-700 text-white'
+            : 'bg-disable text-text-muted cursor-not-allowed',
+        ].join(' ')}
       >
-        등록
-      </Button>
+        {isPending ? '등록 중...' : '등록'}
+      </button>
     </form>
   )
 }
 
 // ── 댓글 목록 ─────────────────────────────────────────────────────────────────
 
-function CommentList({ comments }: { comments: AnswerComment[] }) {
-  const sorted = useMemo(
-    () =>
-      [...comments].sort(
-        (a, b) =>
-          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-      ),
-    [comments]
-  )
+type SortOrder = 'oldest' | 'latest'
 
-  if (sorted.length === 0) return null
+function CommentList({ comments }: { comments: AnswerComment[] }) {
+  const [sortOrder, setSortOrder] = useState<SortOrder>('oldest')
+  const [isSortOpen, setIsSortOpen] = useState(false)
+  const sortRef = useRef<HTMLDivElement>(null)
+
+  const sorted = useMemo(() => {
+    const copy = [...comments]
+    if (sortOrder === 'latest') {
+      return copy.sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      )
+    }
+    return copy.sort(
+      (a, b) =>
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    )
+  }, [comments, sortOrder])
+
+  if (comments.length === 0) return null
+
+  const sortLabel = sortOrder === 'latest' ? '최신순' : '오래된순'
 
   return (
-    <ul className="border-border-base mt-4 space-y-2 border-t pt-4">
-      {sorted.map((comment) => (
-        <li key={comment.id} className="flex items-start gap-2 text-sm">
-          <span className="text-text-heading shrink-0 font-medium">
-            {comment.author.nickname}
-          </span>
-          <span className="text-text-body flex-1">{comment.content}</span>
-          <time
-            dateTime={comment.created_at}
-            className="text-text-muted shrink-0 text-xs"
-          >
-            {formatDate(comment.created_at)}
-          </time>
-        </li>
-      ))}
-    </ul>
+    <div className="border-border-base mt-4 border-t pt-4">
+      {/* 정렬 버튼 */}
+      <div className="relative mb-3 flex justify-end" ref={sortRef}>
+        <button
+          type="button"
+          onClick={() => setIsSortOpen((v) => !v)}
+          className="text-text-muted hover:text-text-body flex items-center gap-1 text-xs"
+        >
+          {sortLabel} ↕
+        </button>
+        {isSortOpen && (
+          <div className="border-border-base bg-bg-base absolute top-6 right-0 z-10 min-w-[100px] rounded-md border shadow-md">
+            {(['oldest', 'latest'] as const).map((order) => (
+              <button
+                key={order}
+                type="button"
+                onClick={() => {
+                  setSortOrder(order)
+                  setIsSortOpen(false)
+                }}
+                className={[
+                  'hover:bg-bg-muted block w-full px-3 py-2 text-left text-xs',
+                  sortOrder === order
+                    ? 'text-primary font-semibold'
+                    : 'text-text-body',
+                ].join(' ')}
+              >
+                {order === 'oldest' ? '오래된순' : '최신순'}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ul className="space-y-2">
+        {sorted.map((comment) => (
+          <li key={comment.id} className="flex items-start gap-2 text-sm">
+            <span className="text-text-heading shrink-0 font-medium">
+              {comment.author.nickname}
+            </span>
+            <span className="text-text-body flex-1">{comment.content}</span>
+            <time
+              dateTime={comment.created_at}
+              className="text-text-muted shrink-0 text-xs"
+            >
+              {formatDate(comment.created_at)}
+            </time>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }
 
@@ -121,7 +248,6 @@ export function QnaDetailPage() {
 
   const numericQuestionId = questionId ? Number(questionId) : 0
 
-  // ── hooks는 조건부 호출 불가 — early return은 아래에서 처리 ──────────────
   const {
     data: questionDetail,
     isLoading: isQuestionLoading,
@@ -164,7 +290,6 @@ export function QnaDetailPage() {
         : [],
     [answers]
   )
-  // ──────────────────────────────────────────────────────────────────────────
 
   if (
     !questionId ||
@@ -273,6 +398,25 @@ export function QnaDetailPage() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
+      {/* Breadcrumb */}
+      {questionDetail && (
+        <nav
+          aria-label="breadcrumb"
+          className="mb-4 flex items-center gap-1.5 text-sm"
+        >
+          <Link
+            to={ROUTES.QNA.LIST}
+            className="text-text-muted hover:text-primary transition-colors"
+          >
+            Q&amp;A
+          </Link>
+          <span className="text-text-muted">›</span>
+          <span className="text-text-body font-medium">
+            {questionDetail.category.name}
+          </span>
+        </nav>
+      )}
+
       {/* 질문 상세 */}
       <section className="border-border-base bg-bg-base rounded-lg border p-6">
         {isQuestionLoading && (
@@ -287,51 +431,87 @@ export function QnaDetailPage() {
         )}
         {questionDetail && (
           <>
-            {/* 카테고리 */}
-            <span className="text-text-muted text-xs font-medium">
-              {questionDetail.category.name}
-            </span>
+            {/* 제목 행: Q아이콘 + 제목 + 작성자 프로필 */}
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex items-start gap-2">
+                <span className="bg-primary mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white">
+                  Q
+                </span>
+                <h1 className="text-text-heading text-xl leading-snug font-bold">
+                  {questionDetail.title}
+                </h1>
+              </div>
 
-            {/* 제목 */}
-            <h1 className="text-text-heading mt-1.5 text-xl leading-snug font-bold">
-              {questionDetail.title}
-            </h1>
+              {/* 작성자 프로필 — 우측 */}
+              <div className="flex shrink-0 items-center gap-2">
+                {questionDetail.author.profile_image_url ? (
+                  <img
+                    src={questionDetail.author.profile_image_url}
+                    alt={questionDetail.author.nickname}
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="bg-bg-subtle text-text-body flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold">
+                    {[...questionDetail.author.nickname][0] ?? '?'}
+                  </div>
+                )}
+                <div className="text-right">
+                  <p className="text-text-heading text-sm leading-tight font-medium">
+                    {questionDetail.author.nickname}
+                  </p>
+                  <p className="text-text-muted text-xs">
+                    {questionDetail.author.course_name} ·{' '}
+                    {questionDetail.author.cohort_name}
+                  </p>
+                </div>
+              </div>
+            </div>
 
-            {/* 메타 정보 */}
-            <div className="mt-3 flex items-center justify-between">
+            {/* 메타 정보 행: 조회수 · 시간 좌측 / 버튼 우측 */}
+            <div className="mt-2 flex items-center justify-between">
               <div className="text-text-muted flex flex-wrap items-center gap-1.5 text-sm">
-                <span className="text-text-heading font-medium">
-                  {questionDetail.author.nickname}
-                </span>
-                <span>·</span>
-                <span>
-                  {questionDetail.author.course_name}{' '}
-                  {questionDetail.author.cohort_name}
-                </span>
+                <span>조회 {questionDetail.view_count.toLocaleString()}</span>
                 <span>·</span>
                 <time dateTime={questionDetail.created_at}>
                   {formatDate(questionDetail.created_at)}
                 </time>
-                <span>·</span>
-                <span>조회 {questionDetail.view_count.toLocaleString()}</span>
               </div>
-              {isQuestionOwner && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() =>
-                    navigate(
-                      ROUTES.QNA.EDIT.replace(
-                        ':questionId',
-                        String(numericQuestionId)
-                      ),
-                      { replace: true }
-                    )
-                  }
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    navigator.clipboard
+                      .writeText(window.location.href)
+                      .then(() =>
+                        showToast('링크가 복사되었습니다.', 'success')
+                      )
+                      .catch(() =>
+                        showToast('링크 복사에 실패했습니다.', 'error')
+                      )
+                  }}
+                  className="text-text-muted hover:text-primary flex items-center gap-1 text-sm transition-colors"
                 >
-                  수정
-                </Button>
-              )}
+                  <LinkIcon />
+                  공유하기
+                </button>
+                {isQuestionOwner && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      navigate(
+                        ROUTES.QNA.EDIT.replace(
+                          ':questionId',
+                          String(numericQuestionId)
+                        ),
+                        { replace: true }
+                      )
+                    }
+                  >
+                    수정
+                  </Button>
+                )}
+              </div>
             </div>
 
             <hr className="border-border-base my-4" />
@@ -359,141 +539,46 @@ export function QnaDetailPage() {
                 ))}
               </div>
             )}
+
+            {/* AI 챗봇 답변 미리보기 박스 */}
+            <div className="bg-primary-50 border-primary-200 mt-6 flex items-center justify-between rounded-lg border px-4 py-3">
+              <div className="flex items-center gap-2">
+                <span className="text-primary">
+                  <RobotIcon />
+                </span>
+                <span className="text-primary text-sm font-medium">
+                  질문에 대한 AI 질의응답 챗봇 답변 보기
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => navigate(ROUTES.CHATBOT.HOME)}
+                className="text-primary text-sm font-semibold"
+              >
+                ▼
+              </button>
+            </div>
           </>
         )}
       </section>
 
-      {/* 답변 목록 */}
-      <section aria-labelledby="answers-heading" className="mt-8">
-        {isAnswersLoading && (
-          <div className="flex justify-center py-10">
-            <Spinner label="답변을 불러오는 중..." />
-          </div>
-        )}
-        {isAnswersError && (
-          <p className="text-error text-sm">
-            답변을 불러오지 못했습니다. 다시 시도해 주세요.
-          </p>
-        )}
-        {!isAnswersLoading && !isAnswersError && answers && (
-          <>
-            <h2
-              id="answers-heading"
-              className="text-text-heading text-base font-semibold"
-            >
-              답변 {sortedAnswers.length}개
-            </h2>
+      {/* 답변하기 버튼 */}
+      {canAnswer && !isAnswersLoading && !isAnswersError && !showForm && (
+        <div className="mt-4 flex justify-end">
+          <Button
+            type="button"
+            onClick={() => setShowForm(true)}
+            disabled={anyAdopted}
+          >
+            {isEdit ? '답변 수정하기' : '답변하기'}
+          </Button>
+        </div>
+      )}
 
-            {sortedAnswers.length === 0 ? (
-              <div className="text-text-muted mt-6 flex flex-col items-center py-12 text-center">
-                <p className="text-base font-medium">
-                  아직 등록된 답변이 없습니다.
-                </p>
-                <p className="mt-1 text-sm">첫 번째 답변을 작성해 보세요.</p>
-              </div>
-            ) : (
-              <div className="mt-4 space-y-6">
-                {sortedAnswers.map((answer) => (
-                  <div
-                    key={answer.id}
-                    className={answer.is_adopted ? 'relative mt-4' : undefined}
-                  >
-                    {/* 채택 배지 — 카드 상단 테두리에 반 걸쳐서 표시 */}
-                    {answer.is_adopted && (
-                      <div
-                        role="status"
-                        aria-label="질문자가 채택한 답변"
-                        className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1.5 text-xs font-bold text-white"
-                      >
-                        질문자 채택
-                      </div>
-                    )}
-
-                    <article
-                      className={[
-                        'bg-bg-base rounded-lg border p-6',
-                        answer.is_adopted
-                          ? 'border-primary'
-                          : 'border-border-base',
-                      ].join(' ')}
-                    >
-                      {/* 작성자 정보 + 채택하기 버튼 */}
-                      <div className="mb-4 flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="text-text-heading text-sm font-medium">
-                            {answer.author.nickname}
-                          </span>
-                          <span className="text-text-muted text-xs">
-                            {answer.author.course_name} ·{' '}
-                            {answer.author.cohort_name}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          <time
-                            dateTime={answer.updated_at}
-                            className="text-text-muted text-xs"
-                          >
-                            수정일: {formatDate(answer.updated_at)}
-                          </time>
-                          {/* 채택하기 — 질문 작성자 + 미채택 + 본인 답변 제외 */}
-                          {isQuestionOwner &&
-                            !anyAdopted &&
-                            answer.author.id !== user?.id && (
-                              <Button
-                                size="sm"
-                                type="button"
-                                onClick={() => setConfirmAcceptId(answer.id)}
-                                disabled={isAcceptPending}
-                                loading={
-                                  isAcceptPending &&
-                                  confirmAcceptId === answer.id
-                                }
-                              >
-                                채택하기
-                              </Button>
-                            )}
-                        </div>
-                      </div>
-
-                      {/* 답변 내용 — 마크다운 렌더링 */}
-                      <div data-color-mode="light">
-                        <MDEditor.Markdown
-                          source={answer.content}
-                          rehypePlugins={[rehypeSanitize]}
-                        />
-                      </div>
-
-                      {/* 댓글 목록 (오래된순 정렬) */}
-                      <CommentList comments={answer.comments} />
-
-                      {/* 댓글 폼 — 로그인 유저만 */}
-                      {isAuthenticated && (
-                        <CommentForm
-                          answerId={answer.id}
-                          questionId={numericQuestionId}
-                        />
-                      )}
-                    </article>
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
-        )}
-      </section>
-
-      {/* 답변 작성 / 수정 섹션 */}
-      {canAnswer && !isAnswersLoading && !isAnswersError && (
-        <div className="mt-6">
-          {!showForm ? (
-            <Button
-              type="button"
-              onClick={() => setShowForm(true)}
-              disabled={isEdit && !!myAnswer?.is_adopted}
-            >
-              {isEdit ? '답변 수정하기' : '답변하기'}
-            </Button>
-          ) : isEdit ? (
+      {/* 답변 작성 / 수정 폼 */}
+      {canAnswer && !isAnswersLoading && !isAnswersError && showForm && (
+        <div className="mt-4">
+          {isEdit ? (
             <AnswerForm
               ref={answerFormRef}
               questionTitle={questionTitle}
@@ -516,6 +601,139 @@ export function QnaDetailPage() {
           )}
         </div>
       )}
+
+      {/* 답변 목록 */}
+      <section aria-labelledby="answers-heading" className="mt-8">
+        {isAnswersLoading && (
+          <div className="flex justify-center py-10">
+            <Spinner label="답변을 불러오는 중..." />
+          </div>
+        )}
+        {isAnswersError && (
+          <p className="text-error text-sm">
+            답변을 불러오지 못했습니다. 다시 시도해 주세요.
+          </p>
+        )}
+        {!isAnswersLoading && !isAnswersError && answers && (
+          <>
+            {/* A 아이콘 + 답변 수 */}
+            <div className="flex items-center gap-2">
+              <span className="bg-primary flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold text-white">
+                A
+              </span>
+              <h2
+                id="answers-heading"
+                className="text-text-heading text-base font-semibold"
+              >
+                {sortedAnswers.length}개의 답변이 있어요
+              </h2>
+            </div>
+
+            {sortedAnswers.length === 0 ? (
+              <div className="text-text-muted mt-6 flex flex-col items-center py-12 text-center">
+                <p className="text-base font-medium">
+                  아직 등록된 답변이 없습니다.
+                </p>
+                <p className="mt-1 text-sm">첫 번째 답변을 작성해 보세요.</p>
+              </div>
+            ) : (
+              <div className="mt-4 space-y-6">
+                {sortedAnswers.map((answer) => (
+                  <div
+                    key={answer.id}
+                    className={answer.is_adopted ? 'relative mt-4' : undefined}
+                  >
+                    {answer.is_adopted && (
+                      <div
+                        aria-label="질문자가 채택한 답변"
+                        className="bg-primary absolute top-0 left-3 -translate-y-1/2 rounded-full px-3 py-1 text-xs font-bold text-white"
+                      >
+                        질문자 채택
+                      </div>
+                    )}
+
+                    <article
+                      className={[
+                        'bg-bg-base rounded-lg border p-6',
+                        answer.is_adopted
+                          ? 'border-primary'
+                          : 'border-border-base',
+                      ].join(' ')}
+                    >
+                      {/* 카드 헤더: 프로필 좌측 / 채택 버튼 우측 */}
+                      <div className="mb-4 flex items-start justify-between">
+                        <div className="flex items-center gap-2">
+                          {answer.author.profile_image_url ? (
+                            <img
+                              src={answer.author.profile_image_url}
+                              alt={answer.author.nickname}
+                              className="h-8 w-8 rounded-full object-cover"
+                            />
+                          ) : (
+                            <div className="bg-bg-subtle flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold">
+                              {[...answer.author.nickname][0] ?? '?'}
+                            </div>
+                          )}
+                          <div>
+                            <span className="text-text-heading text-sm font-medium">
+                              {answer.author.nickname}
+                            </span>
+                            <span className="text-text-muted ml-1 text-xs">
+                              {answer.author.course_name} ·{' '}
+                              {answer.author.cohort_name}
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                          <time
+                            dateTime={answer.updated_at}
+                            className="text-text-muted text-xs"
+                          >
+                            수정일: {formatDate(answer.updated_at)}
+                          </time>
+                          {isQuestionOwner &&
+                            !anyAdopted &&
+                            answer.author.id !== user?.id && (
+                              <Button
+                                size="sm"
+                                type="button"
+                                onClick={() => setConfirmAcceptId(answer.id)}
+                                disabled={isAcceptPending}
+                                loading={
+                                  isAcceptPending &&
+                                  confirmAcceptId === answer.id
+                                }
+                              >
+                                채택하기
+                              </Button>
+                            )}
+                        </div>
+                      </div>
+
+                      <div data-color-mode="light">
+                        <MDEditor.Markdown
+                          source={answer.content}
+                          rehypePlugins={[rehypeSanitize]}
+                        />
+                      </div>
+
+                      <CommentList comments={answer.comments} />
+
+                      {isAuthenticated && (
+                        <CommentForm
+                          answerId={answer.id}
+                          questionId={numericQuestionId}
+                        />
+                      )}
+                    </article>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </section>
 
       {/* 채택 확인 모달 */}
       <ConfirmModal


### PR DESCRIPTION
## Summary

- `ChatbotFab` 배경색을 피그마 디자인 스펙(`#EDE9FE` 연보라)으로 변경, SVG 로봇 아이콘 보라색 계열 적용
- `ROUTES.CHATBOT.HOME` 상수 추가로 `/chatbot` 하드코딩 제거 (`ChatbotFab`, `QnaDetailPage` 공통 적용)
- 코드 리뷰 반영 (Critical 2건 + Warning 3건)

## Changes

### `src/constants/routes.ts`
- `ROUTES.CHATBOT.HOME: '/chatbot'` 상수 추가

### `src/components/chatbot/ChatbotFab.tsx`
- 배경색: `accent-gradient` → `#EDE9FE`
- SVG 아이콘 색상: 흰색 → 보라색 계열 (`#6201e0`, `#7c35d9`)
- `navigate('/chatbot')` → `navigate(ROUTES.CHATBOT.HOME)`

### `src/pages/qna/QnaDetailPage.tsx`
- `clipboard.writeText` Promise `.then().catch()` 처리 추가 (권한 거부 시 에러 토스트)
- 채택 후 답변 버튼 `disabled` 조건을 `anyAdopted`로 단순화 (다른 사람 답변 채택 시에도 비활성화)
- `nickname[0]` → `[...nickname][0] ?? '?'` (이모지/빈 문자열 대응)
- AI 챗봇 박스 이모지 `🤖` 제거 (`RobotIcon`과 중복)
- `navigate('/chatbot')` → `navigate(ROUTES.CHATBOT.HOME)`

## Test plan

- [ ] ChatbotFab 버튼 배경색이 연보라(#EDE9FE)로 표시되는지 확인
- [ ] ChatbotFab 클릭 시 챗봇 페이지로 이동하는지 확인
- [ ] QnA 상세 페이지에서 링크 복사 버튼 동작 확인 (성공/실패 토스트)
- [ ] 다른 사람의 답변이 채택된 상태에서 "답변하기" 버튼이 비활성화되는지 확인
- [ ] 이모지/특수문자 닉네임을 가진 사용자의 아바타 첫 글자 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)