### PR TITLE
fix: MSW 초기화 레이스 컨디션 수정 (#41)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,9 +24,11 @@ function renderApp() {
   )
 }
 
+// MSW 초기화 완료 후 렌더링 — 모킹 없이 API 호출되면 Vite가 HTML을 반환하여 크래시됨
 enableMocking()
-  .then(() => renderApp())
   .catch((error) => {
     console.error('MSW 초기화 실패:', error)
+  })
+  .finally(() => {
     renderApp()
   })


### PR DESCRIPTION
## 관련 이슈

- closes #41

## 작업 내용

- MSW 초기화 완료 전 `renderApp()`이 호출될 수 있는 Promise 체인 구조 수정

## 변경 사항

- `src/main.tsx`: `.then()/.catch()` 각각에서 `renderApp()` 호출 → `.catch().finally()`로 통합

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다