### PR TITLE
fix: 챗봇 위젯 접근성(a11y) 개선 (#54)

### DIFF
--- a/docs/work-log/접근성개선_0430/접근성개선_01단계_0430.md
+++ b/docs/work-log/접근성개선_0430/접근성개선_01단계_0430.md
@@ -1,0 +1,32 @@
+# 접근성개선\_01단계\_0430
+
+## 단계 요약
+
+- focus-trap-react 설치 + MessageList/ChatInput에 aria 접근성 속성 추가
+
+## 생성 파일
+
+- 없음
+
+## 수정 내역
+
+- `package.json` / `pnpm-lock.yaml`: `focus-trap-react@12.0.1` 의존성 추가
+- `src/components/chatbot/MessageList/MessageList.tsx`:
+  - 컨테이너에 `role="log"`, `aria-label="채팅 메시지 목록"`, `aria-live="polite"`, `aria-relevant="additions text"`, `aria-atomic={false}` 추가
+  - 각 메시지에 `role="article"`, `aria-label` 추가 (사용자/AI 구분)
+- `src/components/chatbot/ChatInput/ChatInput.tsx`:
+  - textarea에 `id="chatbot-message-input"`, `aria-label="메시지 입력"`, `aria-disabled`, `aria-describedby` 추가
+  - 전송 버튼에 `aria-label="메시지 전송"`, `aria-disabled` 추가
+  - notice에 `id="chatbot-input-notice"` 추가 (aria-describedby 연결)
+
+## 막혔던 것
+
+- 없음
+
+## 다음 단계 참고
+
+- ChatbotHeader에 id="chatbot-title"과 id="chatbot-close-button" 추가 필요 (Widget의 aria-labelledby와 FocusTrap initialFocus 대상)
+
+## 커밋
+
+- 미커밋

--- a/docs/work-log/접근성개선_0430/접근성개선_02단계_0430.md
+++ b/docs/work-log/접근성개선_0430/접근성개선_02단계_0430.md
@@ -1,0 +1,34 @@
+# 접근성개선\_02단계\_0430
+
+## 단계 요약
+
+- ChatbotHeader/ChatbotFab 접근성 속성 추가 + ChatbotWidget에 FocusTrap/dialog/ESC 핸들러 구현
+
+## 생성 파일
+
+- 없음
+
+## 수정 내역
+
+- `src/components/chatbot/ChatbotHeader/ChatbotHeader.tsx`:
+  - 제목(h2)에 `id="chatbot-title"` 추가 (Widget의 aria-labelledby 연결)
+  - 닫기 버튼에 `id="chatbot-close-button"` 추가 (FocusTrap initialFocus 대상)
+- `src/components/chatbot/ChatbotFab.tsx`:
+  - `aria-expanded={isOpen}` 추가
+  - `aria-controls={isOpen ? 'chatbot-widget' : undefined}` 추가
+- `src/components/chatbot/ChatbotWidget/ChatbotWidget.tsx`:
+  - `focus-trap-react` import + `<FocusTrap>` 감싸기 (initialFocus: close 버튼, fallbackFocus: widget, returnFocusOnDeactivate: true)
+  - 최상위 div에 `id="chatbot-widget"`, `role="dialog"`, `aria-modal="true"`, `aria-labelledby="chatbot-title"`, `tabIndex={-1}` 추가
+  - ESC 키 핸들러: `close()` 호출 (unmount → useSSEAbort cleanup으로 SSE 자동 abort)
+
+## 막혔던 것
+
+- SSE abort 연결 확인: `close()` → `isOpen: false` → Widget null → CsChatView/QnaChatView unmount → `useSSEAbort` cleanup이 `abort()` 실행. 별도 처리 불필요 확인 완료.
+
+## 다음 단계 참고
+
+- 빌드/린트 검증 필요
+
+## 커밋
+
+- 미커밋

--- a/docs/work-log/접근성개선_0430/접근성개선_03단계_0430.md
+++ b/docs/work-log/접근성개선_0430/접근성개선_03단계_0430.md
@@ -1,0 +1,30 @@
+# 접근성개선\_03단계\_0430
+
+## 단계 요약
+
+- pnpm build / pnpm lint 통과 확인
+
+## 생성 파일
+
+- 없음
+
+## 수정 내역
+
+- `src/components/chatbot/ChatbotWidget/ChatbotWidget.tsx`: `import FocusTrap from` → `import { FocusTrap } from` (verbatimModuleSyntax 호환 + deprecated default export 대응)
+
+## 막혔던 것
+
+- `verbatimModuleSyntax` 설정으로 default import가 타입 전용으로 처리됨 → named import `{ FocusTrap }`으로 변경하여 해결
+
+## 검증 결과
+
+- `pnpm build`: 통과 (3.18s)
+- `pnpm lint`: 통과 (에러/경고 없음)
+
+## 다음 단계 참고
+
+- 전체 작업 완료. 커밋 대기 상태.
+
+## 커밋
+
+- 미커밋

--- a/docs/work-log/접근성개선_0430/접근성개선_0430_계획내용.md
+++ b/docs/work-log/접근성개선_0430/접근성개선_0430_계획내용.md
@@ -1,0 +1,34 @@
+# 접근성개선*0430*계획내용
+
+## 작업 계획
+
+- 전체 목표: 챗봇 위젯 접근성(a11y) 개선 — aria 속성, focus trap, ESC 닫기, 키보드 접근성 (GitHub #54)
+
+## 작업01 — 패키지 설치 + MessageList/ChatInput 접근성 추가
+
+- [x] 완료
+
+### 상세
+
+- `pnpm add focus-trap-react`
+- MessageList: `role="log"`, `aria-label`, `aria-live="polite"`, `aria-relevant`, `aria-atomic`, 각 메시지에 `role="article"` + `aria-label`
+- ChatInput: textarea `aria-label`, 전송 버튼 `aria-label`, `aria-disabled`, notice `aria-describedby` 연결
+
+## 작업02 — ChatbotHeader/ChatbotFab 접근성 + ChatbotWidget dialog/FocusTrap/ESC
+
+- [x] 완료
+
+### 상세
+
+- ChatbotHeader: 제목에 `id="chatbot-title"`, 닫기 버튼에 `id="chatbot-close-button"`
+- ChatbotFab: `aria-expanded={isOpen}`, `aria-controls={isOpen ? 'chatbot-widget' : undefined}`
+- ChatbotWidget: `<FocusTrap>` 감싸기, `role="dialog"`, `aria-modal`, `aria-labelledby`, ESC 핸들러 (SSE abort 포함)
+- SSE abort 연결 확인: close() 시 abort가 실행되는지 검증, 안 되면 명시적 추가
+
+## 작업03 — 빌드/린트 검증
+
+- [x] 완료
+
+### 상세
+
+- `pnpm build` + `pnpm lint` 통과 확인

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.95.2",
     "@uiw/react-md-editor": "^4.1.0",
     "axios": "^1.13.6",
+    "focus-trap-react": "^12.0.1",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       axios:
         specifier: ^1.13.6
         version: 1.13.6
+      focus-trap-react:
+        specifier: ^12.0.1
+        version: 12.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
@@ -1147,6 +1150,17 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  focus-trap-react@12.0.1:
+    resolution: {integrity: sha512-MUlm5W4YP9qXZt6J7cRkdZtVekN7WQRqh5STvcRM8s2juTQWNFIz2BYlvaEddij9h04H/9SL8QcXkvqEEWUD6A==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  focus-trap@8.1.0:
+    resolution: {integrity: sha512-T65crff26CKV2CZ3csg5y05r+560srp0b8EbAif35euW58hzklVf/Gb4Q+/HCtB8e9III3QFEyk5BWV5XJuOyw==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -2289,6 +2303,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -3705,6 +3722,19 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  focus-trap-react@12.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      focus-trap: 8.1.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tabbable: 6.4.0
+
+  focus-trap@8.1.0:
+    dependencies:
+      tabbable: 6.4.0
 
   follow-redirects@1.15.11: {}
 
@@ -5214,6 +5244,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
 

--- a/src/components/chatbot/ChatInput/ChatInput.tsx
+++ b/src/components/chatbot/ChatInput/ChatInput.tsx
@@ -33,14 +33,22 @@ export function ChatInput({
 
   return (
     <div className="border-t border-gray-200 p-3">
-      {notice && <p className="text-text-muted mb-2 text-xs">{notice}</p>}
+      {notice && (
+        <p id="chatbot-input-notice" className="text-text-muted mb-2 text-xs">
+          {notice}
+        </p>
+      )}
       <div className="flex items-end gap-2">
         <textarea
+          id="chatbot-message-input"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={disabled}
+          aria-label="메시지 입력"
+          aria-disabled={disabled || undefined}
+          aria-describedby={notice ? 'chatbot-input-notice' : undefined}
           rows={1}
           className="focus:border-primary-400 disabled:text-text-muted flex-1 resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm transition-colors outline-none disabled:bg-gray-100"
         />
@@ -48,6 +56,8 @@ export function ChatInput({
           type="button"
           onClick={handleSend}
           disabled={disabled || !value.trim()}
+          aria-label="메시지 전송"
+          aria-disabled={disabled || !value.trim() || undefined}
           className="bg-primary text-text-inverse hover:bg-primary-700 disabled:text-text-muted flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition-colors disabled:bg-gray-200"
         >
           <svg

--- a/src/components/chatbot/ChatbotFab.tsx
+++ b/src/components/chatbot/ChatbotFab.tsx
@@ -11,6 +11,8 @@ export function ChatbotFab() {
     <button
       type="button"
       aria-label={isOpen ? 'AI 챗봇 닫기' : 'AI 챗봇 열기'}
+      aria-expanded={isOpen}
+      aria-controls={isOpen ? 'chatbot-widget' : undefined}
       onClick={toggle}
       className="fixed right-6 bottom-6 z-50 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-transform hover:scale-110 active:scale-95"
       style={{ backgroundColor: '#EDE9FE' }}

--- a/src/components/chatbot/ChatbotHeader/ChatbotHeader.tsx
+++ b/src/components/chatbot/ChatbotHeader/ChatbotHeader.tsx
@@ -49,13 +49,17 @@ export function ChatbotHeader({
       </div>
 
       {/* 중앙: 타이틀 */}
-      <h2 className="text-text-heading flex-1 text-center text-sm font-semibold">
+      <h2
+        id="chatbot-title"
+        className="text-text-heading flex-1 text-center text-sm font-semibold"
+      >
         {title}
       </h2>
 
       {/* 우: 닫기 */}
       <div className="w-8">
         <button
+          id="chatbot-close-button"
           type="button"
           onClick={handleClose}
           aria-label="닫기"

--- a/src/components/chatbot/ChatbotWidget/ChatbotWidget.tsx
+++ b/src/components/chatbot/ChatbotWidget/ChatbotWidget.tsx
@@ -1,23 +1,49 @@
+import { FocusTrap } from 'focus-trap-react'
 import { useChatbotStore } from '@/stores/chatbotStore'
 import { CsChatView } from '@/features/chatbot/cs'
 import { HubView } from '@/features/chatbot/hub'
 import { QnaChatView } from '@/features/chatbot/qna'
 
 export function ChatbotWidget() {
-  const { isOpen, currentView, activeQnaQuestionId } = useChatbotStore()
+  const { isOpen, currentView, activeQnaQuestionId, close } = useChatbotStore()
 
   if (!isOpen) return null
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation()
+      close()
+    }
+  }
+
   return (
-    <div className="bg-bg-base fixed right-6 bottom-24 z-50 flex h-[600px] w-96 flex-col overflow-hidden rounded-2xl border border-gray-200 shadow-xl">
-      {currentView === 'hub' && <HubView />}
-      {currentView === 'cs' && <CsChatView />}
-      {currentView === 'qna' && activeQnaQuestionId != null && (
-        <QnaChatView
-          key={activeQnaQuestionId}
-          questionId={activeQnaQuestionId}
-        />
-      )}
-    </div>
+    <FocusTrap
+      active={isOpen}
+      focusTrapOptions={{
+        initialFocus: '#chatbot-close-button',
+        fallbackFocus: '#chatbot-widget',
+        escapeDeactivates: false,
+        returnFocusOnDeactivate: true,
+      }}
+    >
+      <div
+        id="chatbot-widget"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="chatbot-title"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="bg-bg-base fixed right-6 bottom-24 z-50 flex h-[600px] w-96 flex-col overflow-hidden rounded-2xl border border-gray-200 shadow-xl"
+      >
+        {currentView === 'hub' && <HubView />}
+        {currentView === 'cs' && <CsChatView />}
+        {currentView === 'qna' && activeQnaQuestionId != null && (
+          <QnaChatView
+            key={activeQnaQuestionId}
+            questionId={activeQnaQuestionId}
+          />
+        )}
+      </div>
+    </FocusTrap>
   )
 }

--- a/src/components/chatbot/MessageList/MessageList.tsx
+++ b/src/components/chatbot/MessageList/MessageList.tsx
@@ -18,12 +18,21 @@ export function MessageList({ messages }: MessageListProps) {
   }, [messages])
 
   return (
-    <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4">
+    <div
+      role="log"
+      aria-label="채팅 메시지 목록"
+      aria-live="polite"
+      aria-relevant="additions text"
+      aria-atomic={false}
+      className="flex flex-1 flex-col gap-3 overflow-y-auto p-4"
+    >
       {messages.map((msg, idx) => {
         const isUser = msg.role === 'user'
         return (
           <div
             key={msg.id ?? idx}
+            role="article"
+            aria-label={isUser ? '사용자 메시지' : 'AI 답변'}
             className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
           >
             <div


### PR DESCRIPTION
## 관련 이슈

- closes #54

## 작업 내용

- 챗봇 위젯 컴포넌트에 aria 속성, focus trap, 키보드 접근성 추가
- `focus-trap-react@12.0.1` 패키지 추가

## 변경 사항

| 컴포넌트 | 추가된 접근성 |
|---------|------------|
| **MessageList** | `role="log"`, `aria-live="polite"`, `aria-relevant="additions text"`, `aria-atomic="false"`, 메시지별 `role="article"` + `aria-label` |
| **ChatInput** | textarea `aria-label="메시지 입력"`, 버튼 `aria-label="메시지 전송"`, `aria-disabled`, notice `aria-describedby` 연결 |
| **ChatbotWidget** | `role="dialog"`, `aria-modal="true"`, `aria-labelledby="chatbot-title"`, `<FocusTrap>` (포커스 가두기 + 닫힘 시 FAB 복귀), ESC 키 닫기 |
| **ChatbotHeader** | `id="chatbot-title"` (dialog label 연결), `id="chatbot-close-button"` (FocusTrap initialFocus) |
| **ChatbotFab** | `aria-expanded={isOpen}`, `aria-controls` |

## agent-browser 테스트 결과

| 항목 | 결과 |
|------|------|
| FAB `aria-expanded` | 열기=true, 닫기=false |
| Widget `role="dialog"` | dialog |
| Widget `aria-modal="true"` | true |
| Widget `aria-labelledby="chatbot-title"` | 연결됨 (텍스트: "AI OZ 시스템 챗봇") |
| `#chatbot-close-button` 존재 | 존재함 |
| MessageList `role="log"` | log |
| MessageList `aria-live="polite"` | polite |
| MessageList `aria-relevant` | "additions text" |
| MessageList `aria-atomic` | false |
| 메시지 `role="article"` | 확인 |
| ChatInput `aria-label="메시지 입력"` | 정상 |
| 전송 버튼 `aria-label="메시지 전송"` | 정상 (disabled 반영) |
| ESC 키로 닫기 | 정상 동작 |

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다