### PR TITLE
fix: SSE 스트리밍 메모리 안전성 개선 — assistant 답변 100KB 초과 방어 (#55)

### DIFF
--- a/docs/work-log/메모리안전_0430/메모리안전_01단계_0430.md
+++ b/docs/work-log/메모리안전_0430/메모리안전_01단계_0430.md
@@ -1,0 +1,31 @@
+# 메모리안전\_01단계\_0430
+
+## 단계 요약
+
+- useCsChat에 assistant 누적 답변 100KB 초과 시 abort + 부분 응답 유지 + 에러 메시지 구현
+
+## 생성 파일
+
+- 없음
+
+## 수정 내역
+
+- `src/features/chatbot/cs/hooks/useCsChat.ts`:
+  - `SSE_MAX_BUFFER_SIZE` (100KB), `ERROR_BUFFER_TEXT` 상수 추가
+  - `bufferExceeded`, `assistantText` 로컬 변수 추가
+  - while 루프 내: `assistantText += parsed.message` → 길이 체크 → 초과 시 abort + break (setMessages 전에 수행)
+  - while 루프 직후: bufferExceeded 시 부분 응답 유지 + 에러 메시지 추가 + return (finally에서 setIsStreaming(false))
+  - catch AbortError: bufferExceeded 중복 방지 주석 갱신
+  - 외부 break 조건에 `bufferExceeded` 추가
+
+## 막혔던 것
+
+- 없음
+
+## 다음 단계 참고
+
+- useQnaChat에 동일 패턴 적용 필요, 429 분기와 완전 분리
+
+## 커밋
+
+- 미커밋

--- a/docs/work-log/메모리안전_0430/메모리안전_02단계_0430.md
+++ b/docs/work-log/메모리안전_0430/메모리안전_02단계_0430.md
@@ -1,0 +1,32 @@
+# 메모리안전\_02단계\_0430
+
+## 단계 요약
+
+- useQnaChat에 CS와 동일한 assistant 누적 답변 100KB 초과 방어 적용
+
+## 생성 파일
+
+- 없음
+
+## 수정 내역
+
+- `src/features/chatbot/qna/hooks/useQnaChat.ts`:
+  - `SSE_MAX_BUFFER_SIZE` (100KB), `ERROR_BUFFER_TEXT` 상수 추가
+  - `bufferExceeded`, `assistantText` 로컬 변수 추가
+  - while 루프 내: `assistantText += parsed.message` → 길이 체크 → 초과 시 abort + break (setMessages 전에 수행)
+  - while 루프 직후: bufferExceeded 시 부분 응답 유지 + `qna-error-` prefix 에러 메시지 추가 + return
+  - catch AbortError: bufferExceeded 중복 방지 주석 갱신
+  - 외부 break 조건에 `bufferExceeded` 추가
+  - 429 분기는 기존 그대로 유지 (bufferExceeded와 완전 분리)
+
+## 막혔던 것
+
+- 없음
+
+## 다음 단계 참고
+
+- 빌드/린트 검증 필요
+
+## 커밋
+
+- 미커밋

--- a/docs/work-log/메모리안전_0430/메모리안전_03단계_0430.md
+++ b/docs/work-log/메모리안전_0430/메모리안전_03단계_0430.md
@@ -1,0 +1,31 @@
+# 메모리안전\_03단계\_0430
+
+## 단계 요약
+
+- pnpm build / pnpm lint 통과 확인 + 린트 warning 2건 수정
+
+## 생성 파일
+
+- 없음
+
+## 수정 내역
+
+- `src/features/chatbot/cs/hooks/useCsChat.ts`: useCallback 의존성 배열에 `abort` 추가
+- `src/features/chatbot/qna/hooks/useQnaChat.ts`: useCallback 의존성 배열에 `abort` 추가
+
+## 막혔던 것
+
+- 린트 warning: `abort`를 while 루프 내에서 사용하지만 useCallback deps에 누락 → 두 파일 모두 추가하여 해결
+
+## 검증 결과
+
+- `pnpm build`: 통과 (2.70s)
+- `pnpm lint`: 통과 (에러/경고 없음)
+
+## 다음 단계 참고
+
+- 전체 작업 완료. 커밋 대기 상태.
+
+## 커밋
+
+- 미커밋

--- a/docs/work-log/메모리안전_0430/메모리안전_0430_계획내용.md
+++ b/docs/work-log/메모리안전_0430/메모리안전_0430_계획내용.md
@@ -1,0 +1,29 @@
+# 메모리안전*0430*계획내용
+
+## 작업 계획
+
+- 전체 목표: SSE 스트리밍 메모리 안전성 개선 — assistant 누적 답변 100KB 초과 시 abort + 부분 응답 유지 (GitHub #55)
+
+## 작업01 — useCsChat 버퍼 크기 제한 구현
+
+- [x] 완료
+
+### 상세
+
+- `SSE_MAX_BUFFER_SIZE` 상수 추가 (100KB)
+- `ERROR_BUFFER_TEXT` 상수 추가
+- `assistantText` 누적 추적 + `setMessages` 호출 전 체크 → 초과 시 abort + break
+- while 루프 직후 `bufferExceeded` 처리 (부분 응답 유지 + 에러 메시지)
+- catch AbortError에서 bufferExceeded 중복 방지
+
+## 작업02 — useQnaChat 동일 패턴 적용
+
+- [x] 완료
+
+### 상세
+
+- CS와 동일하게 적용, 429 분기는 완전 분리 유지
+
+## 작업03 — 빌드/린트 검증
+
+- [x] 완료

--- a/src/features/chatbot/cs/hooks/useCsChat.ts
+++ b/src/features/chatbot/cs/hooks/useCsChat.ts
@@ -14,6 +14,8 @@ const WELCOME_MESSAGE: ChatMessage = {
 }
 
 const ERROR_TEXT = '응답을 불러오지 못했습니다. 다시 시도해주세요.'
+const ERROR_BUFFER_TEXT = '응답이 너무 길어 중단되었습니다.'
+const SSE_MAX_BUFFER_SIZE = 100_000
 
 function mapHistoryToMessages(
   results: {
@@ -88,6 +90,8 @@ export function useCsChat() {
 
       let completed = false
       let hasReceivedChunk = false
+      let bufferExceeded = false
+      let assistantText = ''
 
       try {
         const signal = reset()
@@ -152,6 +156,14 @@ export function useCsChat() {
             }
             hasReceivedChunk = true
 
+            // assistant 누적 답변 길이 체크 (setMessages 전에 수행)
+            assistantText += parsed.message
+            if (assistantText.length > SSE_MAX_BUFFER_SIZE) {
+              bufferExceeded = true
+              abort()
+              break
+            }
+
             setMessages((prev) =>
               prev.map((msg) =>
                 msg.id === assistantId
@@ -161,7 +173,20 @@ export function useCsChat() {
             )
           }
 
-          if (completed) break
+          if (completed || bufferExceeded) break
+        }
+
+        // 버퍼 초과로 중단된 경우: 부분 응답 유지 + 에러 메시지
+        if (bufferExceeded) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `cs-error-${crypto.randomUUID()}`,
+              role: 'assistant',
+              message: ERROR_BUFFER_TEXT,
+            },
+          ])
+          return
         }
 
         // reader가 done이고 [DONE]을 못 받았더라도 정상 종료로 간주
@@ -170,7 +195,8 @@ export function useCsChat() {
         }
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') {
-          // 의도적 중단 — 무시
+          // bufferExceeded는 루프 직후에서 이미 처리됨
+          // 사용자 abort (X/뒤로가기/ESC) — 무시
           return
         }
 
@@ -202,7 +228,7 @@ export function useCsChat() {
         }
       }
     },
-    [isStreaming, reset, queryClient]
+    [isStreaming, reset, abort, queryClient]
   )
 
   return {

--- a/src/features/chatbot/qna/hooks/useQnaChat.ts
+++ b/src/features/chatbot/qna/hooks/useQnaChat.ts
@@ -10,6 +10,8 @@ import type { ChatMessage } from '@/features/chatbot/widgetTypes'
 import type { QnaSseChunk } from '../types'
 
 const ERROR_TEXT = '응답을 불러오지 못했습니다. 다시 시도해주세요.'
+const ERROR_BUFFER_TEXT = '응답이 너무 길어 중단되었습니다.'
+const SSE_MAX_BUFFER_SIZE = 100_000
 
 function mapHistoryToMessages(
   results: {
@@ -128,6 +130,8 @@ export function useQnaChat({ questionId }: { questionId: number }) {
 
       let completed = false
       let hasReceivedChunk = false
+      let bufferExceeded = false
+      let assistantText = ''
 
       try {
         const signal = reset()
@@ -203,6 +207,14 @@ export function useQnaChat({ questionId }: { questionId: number }) {
             }
             hasReceivedChunk = true
 
+            // assistant 누적 답변 길이 체크 (setMessages 전에 수행)
+            assistantText += parsed.message
+            if (assistantText.length > SSE_MAX_BUFFER_SIZE) {
+              bufferExceeded = true
+              abort()
+              break
+            }
+
             setMessages((prev) =>
               prev.map((msg) =>
                 msg.id === assistantId
@@ -212,7 +224,20 @@ export function useQnaChat({ questionId }: { questionId: number }) {
             )
           }
 
-          if (completed) break
+          if (completed || bufferExceeded) break
+        }
+
+        // 버퍼 초과로 중단된 경우: 부분 응답 유지 + 에러 메시지
+        if (bufferExceeded) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `qna-error-${crypto.randomUUID()}`,
+              role: 'assistant',
+              message: ERROR_BUFFER_TEXT,
+            },
+          ])
+          return
         }
 
         // reader가 done이고 [DONE]을 못 받았더라도 정상 종료로 간주
@@ -221,7 +246,8 @@ export function useQnaChat({ questionId }: { questionId: number }) {
         }
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') {
-          // 의도적 중단 — 무시
+          // bufferExceeded는 루프 직후에서 이미 처리됨
+          // 사용자 abort (X/뒤로가기/ESC) — 무시
           return
         }
 
@@ -264,6 +290,7 @@ export function useQnaChat({ questionId }: { questionId: number }) {
       isError,
       questionId,
       reset,
+      abort,
       queryClient,
       markQnaLimitExceeded,
     ]


### PR DESCRIPTION
## 관련 이슈

- closes #55

## 작업 내용

- CS/QNA 챗봇 SSE 스트리밍에서 assistant 누적 답변이 100KB를 초과하면 abort + 부분 응답 유지 + 에러 메시지 표시
- 타임아웃 자동 abort는 CS PDF 명세("청크 미수신 시 별도 타임아웃 처리 X")와 충돌하여 미적용

## 변경 사항

- `src/features/chatbot/cs/hooks/useCsChat.ts`:
  - `SSE_MAX_BUFFER_SIZE` (100KB), `ERROR_BUFFER_TEXT` 상수 추가
  - `assistantText` 누적 추적 → `setMessages` 호출 전 길이 체크 → 초과 시 abort + break
  - while 루프 직후 `bufferExceeded` 시 부분 응답 유지 + 에러 메시지 추가
  - catch AbortError에서 bufferExceeded 중복 방지
  - useCallback deps에 `abort` 추가 (린트 warning 해결)
- `src/features/chatbot/qna/hooks/useQnaChat.ts`:
  - CS와 동일한 패턴 적용
  - 429 분기는 기존 그대로 유지 (bufferExceeded와 완전 분리)

## 주의사항

- 타임아웃 자동 abort 미적용 사유: CS PDF 명세에 "응답이 너무 오래 걸림 → 별도 타임아웃 처리 X" 정책이 있어 충돌 방지
- `ERROR_BUFFER_TEXT` 메시지는 서버 히스토리/캐시 저장 대상이 아닌 로컬 UI 메시지로만 추가

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다