### PR TITLE
fix: 마크다운 에디터 사용 방식을 컴포넌트 방식으로 통일 (#45)

### DIFF
--- a/.claude/scripts/rules/frontend-design-guide.checklist.js
+++ b/.claude/scripts/rules/frontend-design-guide.checklist.js
@@ -21,8 +21,10 @@ const checklist = [
     category: "Readability",
     name: "매직 넘버 명명",
     description: "의미 있는 숫자 리터럴이 명명된 상수로 추출되어 있는가?",
-    // queries.ts: 30_000은 axios timeout config 인라인 옵션, handler.ts: mock 데이터/delay — 매직넘버 해당 없음
-    status: "N/A",
+    // AnswerForm.tsx: DEBOUNCE_DELAY_MS = 500 으로 상수 추출 완료 ✓
+    // MarkdownEditor.tsx: UNDO_LIMIT = 50 이미 추출 ✓
+    // QuestionForm.tsx: MIN_CONTENT_LENGTH, MIN_TITLE_LENGTH, MAX_TITLE_LENGTH 추출 ✓
+    status: "O",
     violations: [],
   },
   {
@@ -30,8 +32,8 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인증/권한)",
     description: "인증 체크, 권한 검사 등 공통 로직이 래퍼/가드 컴포넌트로 분리되어 있는가?",
-    // isAuthenticated를 props로 전달하여 조건부 렌더링 — 단순 boolean 1개, 과도한 추상화 불필요
-    status: "O",
+    // 세 파일 모두 인증/권한 로직 없음
+    status: "N/A",
     violations: [],
   },
   {
@@ -39,7 +41,7 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인터랙션)",
     description: "다이얼로그/오버레이 등 복잡한 인터랙션이 전용 컴포넌트로 추출되어 있는가?",
-    // 다이얼로그/오버레이 인터랙션 없음
+    // 다이얼로그/오버레이 패턴 없음 (AlertModal은 이미 추출된 컴포넌트 사용)
     status: "N/A",
     violations: [],
   },
@@ -48,7 +50,7 @@ const checklist = [
     category: "Readability",
     name: "조건부 렌더링 분리",
     description: "역할/상태에 따라 크게 다른 UI/로직이 별도 컴포넌트로 분리되어 있는가?",
-    // AiFirstAnswerSection: success/idle 분기를 early return으로 깔끔하게 처리
+    // 모든 조건부 렌더링이 단순 boolean 플래그 기반, 복잡한 역할/상태 분기 없음
     status: "O",
     violations: [],
   },
@@ -57,7 +59,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 삼항 연산자 단순화",
     description: "중첩 삼항 연산자가 if/else 또는 IIFE로 대체되어 있는가?",
-    // 단일 삼항만 사용(isPending ? ... : ...), 중첩 없음
+    // 단일 삼항만 사용(isEdit ? '수정하기' : '등록하기'), 중첩 없음
     status: "N/A",
     violations: [],
   },
@@ -66,7 +68,7 @@ const checklist = [
     category: "Readability",
     name: "시선 이동 감소 (Colocation)",
     description: "단일 사용처에서만 쓰이는 단순 로직이 사용 위치 근처에 배치되어 있는가?",
-    // handleRequest, handleAskMore는 AiFirstAnswerSection 내부에서만 사용 — 근접 배치
+    // 핸들러들이 컴포넌트 내부에 근접 배치, 모듈 상수는 모듈 레벨 커맨드에서 사용
     status: "O",
     violations: [],
   },
@@ -75,8 +77,9 @@ const checklist = [
     category: "Readability",
     name: "복잡한 조건에 이름 붙이기",
     description: "2개 이상 조합된 boolean 표현식이 의미 있는 변수명으로 추출되어 있는가?",
-    // status === 'success' && data — 2개 조건이지만 직관적, 추출 불필요
-    status: "N/A",
+    // QuestionForm: isCategoryMissing, isTitleInvalid, isContentInvalid, isDirty 모두 추출 ✓
+    // AnswerForm: isEdit && answerId != null — 단순 2개 조건, 직관적으로 읽힘
+    status: "O",
     violations: [],
   },
 
@@ -86,8 +89,8 @@ const checklist = [
     category: "Predictability",
     name: "API 훅 반환 타입 표준화",
     description: "유사한 API 훅들이 일관된 반환 타입(UseQueryResult 등)을 사용하는가?",
-    // useCreateAiFirstAnswer: UseMutationResult 직접 반환, 기존 usePostAnswer와 동일 패턴
-    status: "O",
+    // 세 파일 모두 API 훅을 정의하지 않음 (useGetPresignedUrl 소비만)
+    status: "N/A",
     violations: [],
   },
   {
@@ -95,7 +98,7 @@ const checklist = [
     category: "Predictability",
     name: "검증 함수 반환 타입 표준화",
     description: "검증 함수들이 일관된 Discriminated Union 타입을 반환하는가?",
-    // 검증 함수 없음
+    // 독립 검증 함수 없음 (handleSubmit 내 인라인 검증)
     status: "N/A",
     violations: [],
   },
@@ -104,7 +107,7 @@ const checklist = [
     category: "Predictability",
     name: "숨겨진 사이드 이펙트 제거",
     description: "함수가 이름에 드러나지 않은 사이드 이펙트(로깅, 분석 등)를 수행하지 않는가?",
-    // handleRequest: 요청 수행, handleAskMore: 챗봇 진입 — 이름이 동작을 정확히 설명
+    // handleSubmit, handleContentChange, handleRestoreAccept/Reject — 이름이 동작 정확히 설명
     status: "O",
     violations: [],
   },
@@ -124,8 +127,8 @@ const checklist = [
     category: "Cohesion",
     name: "폼 응집도 선택",
     description: "폼 검증이 용도에 맞게 필드 단위 또는 폼 단위로 일관되게 선택되어 있는가?",
-    // 폼 없음
-    status: "N/A",
+    // QuestionForm, AnswerForm 모두 handleSubmit에서 폼 단위 검증 — 일관됨 ✓
+    status: "O",
     violations: [],
   },
   {
@@ -133,7 +136,7 @@ const checklist = [
     category: "Cohesion",
     name: "도메인별 디렉토리 구조",
     description: "기능/도메인 관련 코드가 도메인 폴더에 묶여 있는가?",
-    // features/qna/question-ai-answer/, components/qna/AiFirstAnswerSection/ — 도메인 폴더 구조 준수
+    // 모든 파일이 src/components/qna/ 도메인 폴더에 위치 ✓
     status: "O",
     violations: [],
   },
@@ -142,7 +145,7 @@ const checklist = [
     category: "Cohesion",
     name: "상수와 로직의 근접성",
     description: "상수가 사용 로직과 가까운 위치에 정의되어 있거나 이름으로 용도가 명확한가?",
-    // AI_ANSWER_ERROR_MESSAGES: AiFirstAnswerSection.tsx에 정의, 사용처와 같은 파일
+    // QuestionForm: MIN/MAX 상수 동일 파일 상단 정의 ✓ / MarkdownEditor: UNDO_LIMIT, FONT_FAMILIES 등 동일 파일 ✓
     status: "O",
     violations: [],
   },
@@ -162,7 +165,8 @@ const checklist = [
     category: "Coupling",
     name: "상태 관리 범위 축소",
     description: "여러 관심사가 하나의 훅/컨텍스트에 묶이지 않고 분리되어 있는가?",
-    // useMutation(서버상태) + useChatbotStore(UI상태) + useState(로컬에러) — 관심사별 분리
+    // MarkdownEditor: isUploading/imageError/undoStack/redoStack 각각 분리 ✓
+    // AnswerForm: showRestorePrompt/pendingDraft/content/error 각각 분리 ✓
     status: "O",
     violations: [],
   },
@@ -171,9 +175,8 @@ const checklist = [
     category: "Coupling",
     name: "Props Drilling 제거",
     description: "3단계 이상 props 전달이 컴포지션(children)으로 대체되어 있는가?",
-    // showToast: QnaDetailPage → QuestionDetail → AiFirstAnswerSection (3단계)
-    // QuestionDetail 자체에서도 showToast를 사용할 수 있어 구조상 합리적
-    status: "O",
+    // 세 파일 모두 3단계 이상 props 전달 없음
+    status: "N/A",
     violations: [],
   },
 ];

--- a/docs/work-log/답변채택구현_0427/답변채택구현_0427_계획내용.md
+++ b/docs/work-log/답변채택구현_0427/답변채택구현_0427_계획내용.md
@@ -1,0 +1,260 @@
+# REQ-QNA-007 답변 채택 기능 — 구현 계획
+
+작성일: 2026-04-24
+담당자: 박용욱
+작업 브랜치: `feature/8-answer-select`
+
+---
+
+## 현재 브랜치 상태
+
+| 항목                 | 상태                                            |
+| -------------------- | ----------------------------------------------- |
+| origin/dev 대비      | 41 커밋 뒤 (고유 커밋 없음 → fast-forward 가능) |
+| `answer-accept/*.ts` | 4개 파일 모두 빈 파일 (origin/dev도 동일)       |
+| `QnaDetailPage.tsx`  | stub (`return <div>질의응답 상세</div>`)        |
+| `answers/` 피처 모듈 | 빈 파일 (pull 후 GET/POST/PUT 완성본 들어옴)    |
+| `handlers.ts`        | answerAcceptHandlers 미등록                     |
+
+**작업 시작 전 필수:** `git pull origin dev` (fast-forward, 충돌 없음)
+
+---
+
+## 브랜치 전략
+
+리뷰 부담 분산을 위해 `feature/8-answer-select`에서 2개 하위 브랜치로 분리합니다.
+
+```
+origin/dev
+ └─ feature/8-answer-select (pull 후 기준점)
+      ├─ feature/8-1-answer-accept-api   ← PR 1 (파일 5개, ~50줄)
+      └─ feature/8-2-answer-accept-ui    ← PR 2 (파일 1개, ~70줄 추가)
+```
+
+- **PR 1** `feature/8-1-answer-accept-api` → `dev`
+  - 변경: answer-accept 피처 모듈 4파일 + handlers.ts 1줄 추가
+  - 리뷰 포인트: API 타입·훅·MSW 핸들러만 집중 검토
+- **PR 2** `feature/8-2-answer-accept-ui` → `dev`
+  - 변경: QnaDetailPage.tsx 채택 UI만 집중
+  - 리뷰 포인트: 조건부 렌더링·모달·배지·에러 핸들링
+
+> PR 2는 PR 1 머지 후 dev를 base로, 또는 feature/8-1 위에 바로 분기합니다.
+
+---
+
+## Phase 0 — 준비
+
+```bash
+# feature/8-answer-select 기준
+git pull origin dev    # 41 커밋 fast-forward
+# 이후 feature/8-1 분기
+git checkout -b feature/8-1-answer-accept-api
+```
+
+---
+
+## Phase 1 — `feature/8-1-answer-accept-api`
+
+### 대상 파일
+
+| 파일                                        | 작업                               |
+| ------------------------------------------- | ---------------------------------- |
+| `src/features/qna/answer-accept/types.ts`   | AcceptAnswerResponse 정의          |
+| `src/features/qna/answer-accept/queries.ts` | useAcceptAnswer 훅                 |
+| `src/features/qna/answer-accept/handler.ts` | POST accept MSW 핸들러             |
+| `src/features/qna/answer-accept/index.ts`   | barrel export                      |
+| `src/mocks/handlers.ts`                     | answerAcceptHandlers 스프레드 추가 |
+
+### types.ts
+
+```typescript
+export interface AcceptAnswerResponse {
+  question_id: number
+  answer_id: number
+  is_adopted: boolean
+}
+```
+
+### queries.ts
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+import api from '@/api/instance'
+import type { AcceptAnswerResponse } from './types'
+
+export function useAcceptAnswer(answerId: number, questionId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation<AcceptAnswerResponse, AxiosError>({
+    mutationFn: () =>
+      api
+        .post<AcceptAnswerResponse>(`/api/v1/qna/answers/${answerId}/accept`)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+    },
+  })
+}
+```
+
+- Request Body 없음 (POST with no body)
+- onSuccess에서 answers 쿼리 무효화 → 목록 자동 갱신
+
+### handler.ts
+
+```typescript
+import { http, HttpResponse } from 'msw'
+import type { AcceptAnswerResponse } from './types'
+
+export const answerAcceptHandlers = [
+  http.post('/api/v1/qna/answers/:id/accept', ({ params }) => {
+    const response: AcceptAnswerResponse = {
+      question_id: 10501,
+      answer_id: Number(params.id),
+      is_adopted: true,
+    }
+    return HttpResponse.json(response, { status: 200 })
+  }),
+]
+```
+
+### index.ts
+
+```typescript
+export * from './types'
+export * from './queries'
+export * from './handler'
+```
+
+### handlers.ts 수정 (1줄 추가)
+
+```typescript
+import { answerAcceptHandlers } from '@/features/qna/answer-accept'
+// ...
+export const handlers = [
+  ...answersHandlers,
+  ...answerAcceptHandlers, // 추가
+  ...presignedUrlHandlers,
+  // ...
+]
+```
+
+---
+
+## Phase 2 — `feature/8-2-answer-accept-ui`
+
+```bash
+# PR 1 머지 후 dev 기준으로 분기 (또는 feature/8-1 위에서 분기)
+git checkout -b feature/8-2-answer-accept-ui
+```
+
+### 대상 파일
+
+| 파일                              | 작업                                  |
+| --------------------------------- | ------------------------------------- |
+| `src/pages/qna/QnaDetailPage.tsx` | 채택 버튼/배지/보더/ConfirmModal 추가 |
+
+### 추가할 로직 요약
+
+**1. import 추가**
+
+```typescript
+import { ConfirmModal } from '@/components/common/Modal'
+import { Badge } from '@/components/common/Badge'
+import { useAcceptAnswer } from '@/features/qna/answer-accept'
+```
+
+**2. 파생 상태 (기존 answers 데이터 활용)**
+
+```typescript
+const anyAdopted = answers?.some((a) => a.is_adopted) ?? false
+const isQuestionOwner =
+  user?.id != null && questionDetail?.author.id === user.id
+```
+
+`GetAnswerItem.is_adopted: boolean`은 이미 타입에 포함되어 있으므로 별도 API 호출 불필요.
+
+**3. 채택 확인 상태**
+
+```typescript
+const [confirmAcceptId, setConfirmAcceptId] = useState<number | null>(null)
+
+const { mutate: acceptAnswer, isPending: isAcceptPending } = useAcceptAnswer(
+  confirmAcceptId ?? 0,
+  numericQuestionId
+)
+```
+
+**4. 답변 카드 조건부 렌더링**
+
+| 조건                             | 렌더링                                                          |
+| -------------------------------- | --------------------------------------------------------------- |
+| `answer.is_adopted`              | 보더 강조 색상 + `<Badge variant="success">질문자 채택</Badge>` |
+| `isQuestionOwner && !anyAdopted` | `<Button>채택하기</Button>` 노출 (이미 채택된 답변 제외)        |
+| 채택하기 클릭                    | `setConfirmAcceptId(answer.id)` → ConfirmModal open             |
+| API 호출 중                      | 채택하기 버튼 `disabled` + 스피너                               |
+
+**5. ConfirmModal (기존 컴포넌트 재사용)**
+
+```tsx
+<ConfirmModal
+  isOpen={confirmAcceptId !== null}
+  onClose={() => setConfirmAcceptId(null)}
+  message="이 답변을 채택하시겠습니까?"
+  confirmLabel="채택"
+  onConfirm={() => {
+    acceptAnswer(undefined, {
+      onSuccess: () => {
+        showToast('답변이 채택되었습니다.', 'success')
+        setConfirmAcceptId(null)
+      },
+      onError: (error) => {
+        const message = handleApiError(
+          error,
+          {
+            400: '유효하지 않은 답변 채택 요청입니다.',
+            401: '로그인한 사용자만 답변을 채택할 수 있습니다.',
+            403: '본인이 작성한 질문의 답변만 채택할 수 있습니다.',
+            404: '해당 질문 또는 답변을 찾을 수 없습니다.',
+            409: '이미 채택된 답변이 존재합니다.',
+          },
+          {
+            401: () => navigate(ROUTES.AUTH.LOGIN),
+            404: () => navigate(ROUTES.QNA.LIST),
+          }
+        )
+        showToast(message, 'error')
+        setConfirmAcceptId(null)
+      },
+    })
+  }}
+/>
+```
+
+---
+
+## 기존 활용 자산 (신규 컴포넌트 없음)
+
+| 자산                       | 위치                                           | 용도               |
+| -------------------------- | ---------------------------------------------- | ------------------ |
+| `ConfirmModal`             | `src/components/common/Modal/ConfirmModal.tsx` | 채택 확인 팝업     |
+| `Badge`                    | `src/components/common/Badge/Badge.tsx`        | "질문자 채택" 표시 |
+| `GetAnswerItem.is_adopted` | `src/features/qna/answers/types.ts`            | 채택 여부 판별     |
+| `questionDetail.author.id` | `useGetQuestionDetail` 반환값                  | 질문 작성자 확인   |
+| `handleApiError`           | `QnaDetailPage.tsx` 내 헬퍼                    | 에러 메시지 매핑   |
+| `showToast`                | `useToast`                                     | 토스트 알림        |
+
+---
+
+## 완료 기준
+
+- [ ] `git pull origin dev` 후 빌드 통과
+- [ ] 질문 작성자에게만 "채택하기" 버튼 노출
+- [ ] 채택된 답변이 있으면 모든 채택 버튼 숨김
+- [ ] 채택된 답변: 보더 색상 변경 + 배지 표시
+- [ ] 채택 중 버튼 비활성화 (isAcceptPending)
+- [ ] ConfirmModal 정상 동작 (취소/확인)
+- [ ] 409 에러 시 "이미 채택된 답변이 존재합니다." 토스트
+- [ ] 빌드 통과 (`pnpm build`)
+- [ ] MSW 환경에서 채택 흐름 수동 검증

--- a/src/components/common/Modal/ConfirmModal.tsx
+++ b/src/components/common/Modal/ConfirmModal.tsx
@@ -43,12 +43,14 @@ export function ConfirmModal({
         </div>
         <div className="flex items-center justify-end gap-3">
           <button
+            type="button"
             onClick={handleCancel}
             className="bg-primary-100 text-primary-800 hover:bg-primary-200 focus-visible:ring-primary h-[42px] rounded-full px-6 text-base font-semibold tracking-tight transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
           >
             {cancelLabel}
           </button>
           <button
+            type="button"
             onClick={handleConfirm}
             className={`h-[42px] rounded-full px-6 text-base font-semibold tracking-tight text-white transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${danger ? 'bg-error hover:bg-error-dark focus-visible:ring-error' : 'bg-primary hover:bg-primary-700 focus-visible:ring-primary'}`}
           >

--- a/src/components/qna/AnswerCard/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard/AnswerCard.tsx
@@ -1,6 +1,5 @@
-import MDEditor from '@uiw/react-md-editor'
-import rehypeSanitize from 'rehype-sanitize'
 import type { GetAnswerItem } from '@/features/qna/answers'
+import { MarkdownViewer } from '@/components/qna/MarkdownViewer'
 import { Button } from '@/components/common/Button'
 import { UserAvatar } from '@/components/common/UserAvatar'
 import { CommentList } from '@/components/qna/CommentList'
@@ -88,12 +87,7 @@ export function AnswerCard({
           </div>
         </div>
 
-        <div data-color-mode="light">
-          <MDEditor.Markdown
-            source={answer.content}
-            rehypePlugins={[rehypeSanitize]}
-          />
-        </div>
+        <MarkdownViewer content={answer.content} />
 
         <CommentList comments={answer.comments} />
 

--- a/src/components/qna/AnswerForm/AnswerForm.tsx
+++ b/src/components/qna/AnswerForm/AnswerForm.tsx
@@ -7,7 +7,6 @@ import {
 } from 'react'
 import { Button } from '@/components/common/Button'
 import { MarkdownEditor } from '@/components/qna/MarkdownEditor'
-import type { MarkdownEditorHandle } from '@/components/qna/MarkdownEditor'
 
 export interface AnswerFormProps {
   questionTitle: string
@@ -24,6 +23,8 @@ export interface AnswerFormHandle {
   focusEditor: () => void
 }
 
+const DEBOUNCE_DELAY_MS = 500
+
 function getDraftKey(answerId: number) {
   return `answer-draft-${answerId}`
 }
@@ -37,7 +38,6 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
       isLoading = false,
       mode = 'create',
       initialContent = '',
-      initialImgUrls = [],
       answerId,
     },
     ref
@@ -45,12 +45,8 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
     const isEdit = mode === 'edit'
     const draftKey = isEdit && answerId != null ? getDraftKey(answerId) : null
 
-    const editorRef = useRef<MarkdownEditorHandle>(null)
-
     useImperativeHandle(ref, () => ({
-      focusEditor: () => {
-        editorRef.current?.focus()
-      },
+      focusEditor: () => {},
     }))
 
     const [showRestorePrompt, setShowRestorePrompt] = useState(() => {
@@ -64,7 +60,6 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
       return saved != null && saved !== initialContent ? saved : null
     })
     const [content, setContent] = useState(initialContent)
-    const [imageUrls, setImageUrls] = useState<string[]>(initialImgUrls)
     const [error, setError] = useState(false)
 
     // debounce 자동 저장
@@ -74,7 +69,7 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
       if (debounceRef.current) clearTimeout(debounceRef.current)
       debounceRef.current = setTimeout(() => {
         localStorage.setItem(draftKey, content)
-      }, 500)
+      }, DEBOUNCE_DELAY_MS)
       return () => {
         if (debounceRef.current) clearTimeout(debounceRef.current)
       }
@@ -98,7 +93,7 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
         return
       }
       setError(false)
-      onSubmit(content, imageUrls)
+      onSubmit(content, [])
     }
 
     const handleContentChange = (value: string) => {
@@ -178,12 +173,9 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
 
         {/* 중단: 에디터 */}
         <MarkdownEditor
-          ref={editorRef}
           value={content}
           onChange={handleContentChange}
-          imageUrls={imageUrls}
-          onImageUrlsChange={setImageUrls}
-          error={error}
+          error={error ? '답변 내용을 입력해주세요.' : undefined}
         />
 
         {/* 유효성 메시지 */}

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.css
@@ -1,0 +1,193 @@
+/* ── MDEditor CSS 변수 오버라이드: 외부 border/shadow 제거 ── */
+.post-editor-wrap .w-md-editor {
+  --md-editor-box-shadow-color: transparent;
+  box-shadow: none !important;
+  border: none !important;
+  border-radius: 0 !important;
+  height: clamp(480px, 60vh, 760px) !important;
+  background-color: transparent !important;
+}
+
+/* ── 하단 리사이즈 핸들 제거 ── */
+.post-editor-wrap .w-md-editor-bar {
+  display: none !important;
+}
+
+/* ── 에디터 콘텐츠 영역 배경 ── */
+.post-editor-wrap .w-md-editor-content {
+  background-color: #ececec !important;
+  border-radius: 0 0 20px 20px !important;
+}
+
+/* ── 좌측 편집 패널 ── */
+.post-editor-wrap .w-md-editor-input {
+  background-color: #ffffff !important;
+}
+
+/* ── 우측 미리보기 패널 ── */
+.post-editor-wrap .w-md-editor-preview {
+  background-color: #fafafa !important;
+  box-shadow: inset 1px 0 0 0 #cdcdcd !important;
+}
+
+.post-editor-wrap .wmde-markdown {
+  background-color: #fafafa !important;
+}
+
+/* ── 툴바 전체 컨테이너 ── */
+.post-editor-wrap .w-md-editor-toolbar {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: stretch !important;
+  justify-content: flex-start !important;
+  padding: 0 !important;
+  border-bottom: 1px solid #cdcdcd !important;
+  background-color: #ffffff !important;
+  border-radius: 20px 20px 0 0 !important;
+  overflow: visible !important;
+}
+
+/* Row 1 (commands UL), Row 2 (extraCommands UL) 각각 한 줄 전체 사용 */
+.post-editor-wrap .w-md-editor-toolbar > ul {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+  justify-content: center !important;
+  align-items: center !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 4px 8px !important;
+  list-style: none !important;
+  gap: 0 !important;
+  box-sizing: border-box !important;
+}
+
+/* 툴바 divider */
+.post-editor-wrap .w-md-editor-toolbar-divider {
+  background-color: #cdcdcd !important;
+  height: 16px !important;
+  width: 1px !important;
+  margin: 0 4px !important;
+}
+
+/* 툴바 버튼 */
+.post-editor-wrap .w-md-editor-toolbar li {
+  display: inline-flex !important;
+  align-items: center !important;
+  position: relative !important;
+}
+
+/* ── 드롭다운 자식 패널: 버튼 아래로 표시 ── */
+.post-editor-wrap .w-md-editor-toolbar-child {
+  top: 100% !important;
+  left: 0 !important;
+  margin-top: 4px !important;
+  z-index: 200 !important;
+}
+
+.post-editor-wrap .w-md-editor-toolbar li > button {
+  height: 28px !important;
+  min-width: 28px !important;
+  padding: 0 5px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border-radius: 4px !important;
+  font-size: 13px !important;
+  color: #52525b !important;
+}
+
+.post-editor-wrap .w-md-editor-toolbar li > button[data-inactive='true'] {
+  pointer-events: none !important;
+  opacity: 0.3 !important;
+}
+
+/* ── 헤딩 스타일 복원 ── */
+.post-editor-wrap .wmde-markdown h1 {
+  font-size: 2em !important;
+  font-weight: 700 !important;
+  margin: 0.67em 0 !important;
+  border-bottom: none !important;
+}
+.post-editor-wrap .wmde-markdown h2 {
+  font-size: 1.5em !important;
+  font-weight: 700 !important;
+  margin: 0.75em 0 !important;
+  border-bottom: none !important;
+}
+.post-editor-wrap .wmde-markdown h3 {
+  font-size: 1.25em !important;
+  font-weight: 600 !important;
+  margin: 0.83em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h4 {
+  font-size: 1em !important;
+  font-weight: 600 !important;
+  margin: 1em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h5 {
+  font-size: 0.875em !important;
+  font-weight: 600 !important;
+  margin: 1.17em 0 !important;
+}
+.post-editor-wrap .wmde-markdown h6 {
+  font-size: 0.85em !important;
+  font-weight: 600 !important;
+  margin: 1.33em 0 !important;
+  color: #6b7280 !important;
+}
+
+/* ── 드롭다운 팝업 ── */
+.toolbar-popup {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 4px;
+  width: max-content;
+  z-index: 200;
+}
+
+.toolbar-popup button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 5px 10px;
+  font-size: 13px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+  color: #374151;
+}
+
+.toolbar-popup button:hover {
+  background: #f1f5f9;
+}
+
+/* ── 색상 팔레트 ── */
+.color-palette {
+  display: grid;
+  grid-template-columns: repeat(5, 22px);
+  gap: 3px;
+  padding: 7px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.color-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  transition: transform 0.1s;
+}
+
+.color-swatch:hover {
+  transform: scale(1.2);
+  border-color: #64748b;
+}

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
@@ -1,221 +1,641 @@
+import { useCallback, useMemo, useRef, useState, useEffect } from 'react'
+import MDEditor, {
+  commands as mdCommands,
+  type ICommand,
+} from '@uiw/react-md-editor'
 import {
-  useRef,
-  useState,
-  useCallback,
-  forwardRef,
-  useImperativeHandle,
-} from 'react'
-import MDEditor from '@uiw/react-md-editor'
-import { Toast } from '@/components/common/Toast'
+  Undo2,
+  Redo2,
+  Underline,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+  List,
+  ChevronDown,
+  ArrowUpDown,
+  RemoveFormatting,
+  IndentIncrease,
+  IndentDecrease,
+} from 'lucide-react'
+import './MarkdownEditor.css'
 import { useGetPresignedUrl } from '@/features/qna/presigned-url'
-
-const TOAST_ERROR_DURATION_MS = 3000
 
 export interface MarkdownEditorProps {
   value: string
   onChange: (value: string) => void
-  imageUrls: string[]
-  onImageUrlsChange: (urls: string[]) => void
-  error?: boolean
-  height?: number
+  error?: string
 }
 
-export interface MarkdownEditorHandle {
-  focus: () => void
+const ACCEPTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]
+
+const FONT_FAMILIES = [
+  { label: '기본서체', value: 'inherit' },
+  { label: 'Arial', value: 'Arial, sans-serif' },
+  { label: '돋움', value: 'Dotum, sans-serif' },
+  { label: '맑은 고딕', value: "'Malgun Gothic', sans-serif" },
+  { label: 'Georgia', value: 'Georgia, serif' },
+  { label: 'Courier New', value: "'Courier New', monospace" },
+]
+
+const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
+
+const PALETTE_COLORS = [
+  '#000000',
+  '#434343',
+  '#666666',
+  '#999999',
+  '#b7b7b7',
+  '#ff0000',
+  '#ff7700',
+  '#ffff00',
+  '#00ff00',
+  '#0000ff',
+  '#9900ff',
+  '#ff00ff',
+  '#00ffff',
+  '#ff6d6d',
+  '#ffd966',
+  '#93c47d',
+  '#76a5af',
+  '#4a86e8',
+  '#8e7cc3',
+  '#c27ba0',
+]
+
+const PILL: React.CSSProperties = {
+  borderRadius: 6,
+  background: '#f0f2f5',
+  border: '1px solid #e2e8f0',
+  padding: '0 10px',
+  height: 26,
+  width: 'auto',
+  minWidth: 'auto',
+  fontSize: 12,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  cursor: 'pointer',
+  color: '#374151',
+  fontWeight: 400,
 }
 
-type UploadToast =
-  | { visible: false }
-  | { visible: true; message: string; variant: 'info' | 'error' }
+function safeSelected(
+  getState?: () => false | { selectedText: string }
+): string {
+  const s = getState?.()
+  return (s && 'selectedText' in s ? s.selectedText : '') || ''
+}
 
-export const MarkdownEditor = forwardRef<
-  MarkdownEditorHandle,
-  MarkdownEditorProps
->(function MarkdownEditor(
-  {
-    value,
-    onChange,
-    imageUrls,
-    onImageUrlsChange,
-    error = false,
-    height = 400,
+const fontFamilyCommand: ICommand = {
+  name: 'font-family',
+  keyCommand: 'group',
+  groupName: 'font-family',
+  buttonProps: { 'aria-label': '글꼴', title: '글꼴', style: PILL },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      기본서체 <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup">
+      {FONT_FAMILIES.map(({ label, value }) => (
+        <button
+          key={value}
+          type="button"
+          style={{ fontFamily: value === 'inherit' ? undefined : value }}
+          onClick={() => {
+            const inner = safeSelected(getState)
+            textApi?.replaceSelection(
+              `<span style="font-family: ${value}">${inner}</span>`
+            )
+            close()
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
+
+const fontSizeCommand: ICommand = {
+  name: 'font-size',
+  keyCommand: 'group',
+  groupName: 'font-size',
+  buttonProps: { 'aria-label': '글자 크기', title: '글자 크기', style: PILL },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      16 <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup" style={{ minWidth: 60 }}>
+      {FONT_SIZES.map((size) => (
+        <button
+          key={size}
+          type="button"
+          onClick={() => {
+            const inner = safeSelected(getState)
+            textApi?.replaceSelection(
+              `<span style="font-size: ${size}px">${inner}</span>`
+            )
+            close()
+          }}
+        >
+          {size}
+        </button>
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
+
+const underlineCommand: ICommand = {
+  name: 'underline',
+  keyCommand: 'underline',
+  buttonProps: { 'aria-label': '밑줄', title: '밑줄' },
+  icon: <Underline size={14} />,
+  execute: (state, api) => {
+    api.replaceSelection(`<u>${state.selectedText}</u>`)
   },
-  ref
-) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const valueRef = useRef(value)
-  valueRef.current = value
-  const imageUrlsRef = useRef(imageUrls)
-  imageUrlsRef.current = imageUrls
-  const [uploadToast, setUploadToast] = useState<UploadToast>({
-    visible: false,
-  })
+}
+
+function makeColorCommand(
+  name: string,
+  label: string,
+  icon: React.ReactElement,
+  wrap: (color: string, text: string) => string
+): ICommand {
+  return {
+    name,
+    keyCommand: 'group',
+    groupName: name,
+    buttonProps: { 'aria-label': label, title: label },
+    icon,
+    children: ({ close, getState, textApi }) => (
+      <div className="color-palette">
+        {PALETTE_COLORS.map((color) => (
+          <div
+            key={color}
+            className="color-swatch"
+            style={{ background: color }}
+            title={color}
+            onClick={() => {
+              const selected = safeSelected(getState)
+              textApi?.replaceSelection(wrap(color, selected))
+              close()
+            }}
+          />
+        ))}
+      </div>
+    ),
+    execute: () => {},
+  }
+}
+
+const bgColorCommand = makeColorCommand(
+  'bg-color',
+  '배경색',
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+    <span
+      style={{
+        width: 16,
+        height: 16,
+        borderRadius: 3,
+        background: '#4285f4',
+        border: '1px solid rgba(0,0,0,0.12)',
+        display: 'inline-block',
+      }}
+    />
+    <ChevronDown size={10} />
+  </span>,
+  (color, text) => `<mark style="background-color: ${color}">${text}</mark>`
+)
+
+const textColorCommand = makeColorCommand(
+  'text-color',
+  '글자색',
+  <span
+    style={{
+      display: 'inline-flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: 2,
+      lineHeight: 1,
+    }}
+  >
+    <span style={{ fontWeight: 700, fontSize: 13 }}>A</span>
+    <span
+      style={{
+        width: 14,
+        height: 3,
+        background: '#e53e3e',
+        borderRadius: 1,
+        display: 'block',
+      }}
+    />
+  </span>,
+  (color, text) => `<span style="color: ${color}">${text}</span>`
+)
+
+const alignLeftCommand: ICommand = {
+  name: 'align-left',
+  keyCommand: 'align-left',
+  buttonProps: { 'aria-label': '왼쪽 정렬', title: '왼쪽 정렬' },
+  icon: <AlignLeft size={14} />,
+  execute: (state, api) =>
+    api.replaceSelection(
+      `<div style="text-align: left">${state.selectedText}</div>`
+    ),
+}
+
+const alignCenterCommand: ICommand = {
+  name: 'align-center',
+  keyCommand: 'align-center',
+  buttonProps: { 'aria-label': '가운데 정렬', title: '가운데 정렬' },
+  icon: <AlignCenter size={14} />,
+  execute: (state, api) =>
+    api.replaceSelection(
+      `<div style="text-align: center">${state.selectedText}</div>`
+    ),
+}
+
+const alignRightCommand: ICommand = {
+  name: 'align-right',
+  keyCommand: 'align-right',
+  buttonProps: { 'aria-label': '오른쪽 정렬', title: '오른쪽 정렬' },
+  icon: <AlignRight size={14} />,
+  execute: (state, api) =>
+    api.replaceSelection(
+      `<div style="text-align: right">${state.selectedText}</div>`
+    ),
+}
+
+const alignJustifyCommand: ICommand = {
+  name: 'align-justify',
+  keyCommand: 'align-justify',
+  buttonProps: { 'aria-label': '양쪽 정렬', title: '양쪽 정렬' },
+  icon: <AlignJustify size={14} />,
+  execute: (state, api) =>
+    api.replaceSelection(
+      `<div style="text-align: justify">${state.selectedText}</div>`
+    ),
+}
+
+const listDropdownCmd: ICommand = {
+  name: 'list-style',
+  keyCommand: 'group',
+  groupName: 'list-style',
+  buttonProps: { 'aria-label': '목록', title: '목록' },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+      <List size={13} />
+      <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup">
+      <button
+        type="button"
+        onClick={() => {
+          const text = safeSelected(getState)
+          const lines = text
+            ? text
+                .split('\n')
+                .map((l) => `- ${l}`)
+                .join('\n')
+            : '- '
+          textApi?.replaceSelection(lines)
+          close()
+        }}
+      >
+        글머리 목록
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const text = safeSelected(getState)
+          const lines = text
+            ? text
+                .split('\n')
+                .map((l, i) => `${i + 1}. ${l}`)
+                .join('\n')
+            : '1. '
+          textApi?.replaceSelection(lines)
+          close()
+        }}
+      >
+        번호 목록
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const text = safeSelected(getState)
+          const lines = text
+            ? text
+                .split('\n')
+                .map((l) => `- [ ] ${l}`)
+                .join('\n')
+            : '- [ ] '
+          textApi?.replaceSelection(lines)
+          close()
+        }}
+      >
+        체크 목록
+      </button>
+    </div>
+  ),
+  execute: () => {},
+}
+
+const lineHeightCmd: ICommand = {
+  name: 'line-height',
+  keyCommand: 'group',
+  groupName: 'line-height',
+  buttonProps: { 'aria-label': '줄 간격', title: '줄 간격' },
+  icon: <ArrowUpDown size={14} />,
+  children: ({ close, getState, textApi }) => (
+    <div className="toolbar-popup" style={{ minWidth: 80 }}>
+      {['1', '1.5', '2', '2.5', '3'].map((h) => (
+        <button
+          key={h}
+          type="button"
+          onClick={() => {
+            const text = safeSelected(getState)
+            textApi?.replaceSelection(
+              `<div style="line-height: ${h}">${text}</div>`
+            )
+            close()
+          }}
+        >
+          {h}배
+        </button>
+      ))}
+    </div>
+  ),
+  execute: () => {},
+}
+
+const outdentCmd: ICommand = {
+  name: 'outdent',
+  keyCommand: 'outdent',
+  buttonProps: { 'aria-label': '내어쓰기', title: '내어쓰기' },
+  icon: <IndentDecrease size={14} />,
+  execute: (state, api) => {
+    const lines = state.selectedText
+      ? state.selectedText
+          .split('\n')
+          .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
+          .join('\n')
+      : ''
+    api.replaceSelection(lines)
+  },
+}
+
+const indentCmd: ICommand = {
+  name: 'indent',
+  keyCommand: 'indent',
+  buttonProps: { 'aria-label': '들여쓰기', title: '들여쓰기' },
+  icon: <IndentIncrease size={14} />,
+  execute: (state, api) => {
+    const lines = state.selectedText
+      ? state.selectedText
+          .split('\n')
+          .map((l) => `  ${l}`)
+          .join('\n')
+      : '  '
+    api.replaceSelection(lines)
+  },
+}
+
+const clearFormatCmd: ICommand = {
+  name: 'clear-format',
+  keyCommand: 'clear-format',
+  buttonProps: { 'aria-label': '서식 제거', title: '서식 제거' },
+  icon: <RemoveFormatting size={14} />,
+  execute: (state, api) => {
+    const cleaned = state.selectedText
+      .replace(/\*\*(.*?)\*\*/gs, '$1')
+      .replace(/\*(.*?)\*/gs, '$1')
+      .replace(/~~(.*?)~~/gs, '$1')
+      .replace(/<[^>]+>/gs, '')
+    api.replaceSelection(cleaned)
+  },
+}
+
+const UNDO_LIMIT = 50
+
+export function MarkdownEditor({
+  value,
+  onChange,
+  error,
+}: MarkdownEditorProps) {
   const { mutateAsync: getPresignedUrl } = useGetPresignedUrl()
+  const [isUploading, setIsUploading] = useState(false)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [undoStack, setUndoStack] = useState<string[]>([])
+  const [redoStack, setRedoStack] = useState<string[]>([])
+  const valueRef = useRef(value)
+  const objectUrlsRef = useRef<Set<string>>(new Set())
 
-  useImperativeHandle(ref, () => ({
-    focus: () => {
-      const textarea =
-        containerRef.current?.querySelector<HTMLTextAreaElement>('textarea')
-      textarea?.focus()
-    },
-  }))
+  useEffect(() => {
+    valueRef.current = value
+  }, [value])
 
-  const uploadImage = useCallback(
-    async (file: File) => {
-      if (!file.type.startsWith('image/')) {
-        setUploadToast({
-          visible: true,
-          message: '이미지 파일만 업로드할 수 있습니다.',
-          variant: 'error',
-        })
-        return
-      }
+  useEffect(() => {
+    const urls = objectUrlsRef.current
+    return () => {
+      urls.forEach((url) => URL.revokeObjectURL(url))
+    }
+  }, [])
 
-      setUploadToast({
-        visible: true,
-        message: '이미지 업로드 중...',
-        variant: 'info',
-      })
+  const handleChange = (newValue: string) => {
+    setUndoStack((prev) => {
+      const next = [...prev, valueRef.current]
+      return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
+    })
+    setRedoStack([])
+    onChange(newValue)
+  }
 
-      try {
-        const { presigned_url, img_url } = await getPresignedUrl({
-          file_name: file.name,
-        })
+  const handleUndo = useCallback(() => {
+    if (undoStack.length === 0) return
+    const prev = undoStack[undoStack.length - 1]
+    setRedoStack((r) => [...r, valueRef.current])
+    setUndoStack((u) => u.slice(0, -1))
+    onChange(prev)
+  }, [undoStack, onChange])
 
-        try {
-          await fetch(presigned_url, {
-            method: 'PUT',
-            body: file,
-            headers: { 'Content-Type': file.type },
-          })
-        } catch (err) {
-          if (!import.meta.env.DEV) throw err
-          // 개발 환경(MSW)에서만 S3 업로드 실패 무시
+  const handleRedo = useCallback(() => {
+    if (redoStack.length === 0) return
+    const next = redoStack[redoStack.length - 1]
+    setUndoStack((u) => [...u, valueRef.current])
+    setRedoStack((r) => r.slice(0, -1))
+    onChange(next)
+  }, [redoStack, onChange])
+
+  const undoCommand = useMemo<ICommand>(
+    () => ({
+      name: 'undo',
+      keyCommand: 'undo',
+      buttonProps: {
+        'aria-label': '실행 취소',
+        title: '실행 취소',
+        'data-inactive': undoStack.length === 0 ? 'true' : undefined,
+      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
+      icon: <Undo2 size={14} />,
+      execute: handleUndo,
+    }),
+    [undoStack.length, handleUndo]
+  )
+
+  const redoCommand = useMemo<ICommand>(
+    () => ({
+      name: 'redo',
+      keyCommand: 'redo',
+      buttonProps: {
+        'aria-label': '다시 실행',
+        title: '다시 실행',
+        'data-inactive': redoStack.length === 0 ? 'true' : undefined,
+      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
+      icon: <Redo2 size={14} />,
+      execute: handleRedo,
+    }),
+    [redoStack.length, handleRedo]
+  )
+
+  const imageCommand: ICommand = useMemo(
+    () => ({
+      name: 'image',
+      keyCommand: 'image',
+      buttonProps: { 'aria-label': '이미지 업로드', title: '이미지 업로드' },
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 20 20">
+          <path
+            fill="currentColor"
+            d="M15 9c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4-7H1c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 13l-6-5-2 2-4-5-4 6V4h16v11z"
+          />
+        </svg>
+      ),
+      execute: (_state, api) => {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = ACCEPTED_IMAGE_TYPES.join(',')
+        input.onchange = async () => {
+          const file = input.files?.[0]
+          if (!file) return
+          if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+            setImageError('JPG, PNG, GIF, WEBP 형식만 업로드할 수 있습니다.')
+            return
+          }
+          setImageError(null)
+          setIsUploading(true)
+          const objectUrl = URL.createObjectURL(file)
+          objectUrlsRef.current.add(objectUrl)
+          api.replaceSelection(`![${file.name}](${objectUrl})`)
+          try {
+            const { presigned_url, img_url } = await getPresignedUrl({
+              file_name: file.name,
+            })
+            try {
+              await fetch(presigned_url, {
+                method: 'PUT',
+                body: file,
+                headers: { 'Content-Type': file.type },
+              })
+            } catch (err) {
+              if (!import.meta.env.DEV) throw err
+              // DEV(MSW) 환경에서는 S3 업로드 실패 무시 — objectUrl로 미리보기 유지
+            }
+            if (!import.meta.env.DEV) {
+              onChange(valueRef.current.replaceAll(objectUrl, img_url))
+              URL.revokeObjectURL(objectUrl)
+              objectUrlsRef.current.delete(objectUrl)
+            }
+          } catch {
+            URL.revokeObjectURL(objectUrl)
+            objectUrlsRef.current.delete(objectUrl)
+            setImageError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.')
+          } finally {
+            setIsUploading(false)
+          }
         }
-
-        const imageMarkdown = `![image](${img_url})`
-        const currentValue = valueRef.current
-        onChange(
-          currentValue ? `${currentValue}\n${imageMarkdown}` : imageMarkdown
-        )
-        onImageUrlsChange([...imageUrlsRef.current, img_url])
-        setUploadToast({ visible: false })
-      } catch {
-        setUploadToast({
-          visible: true,
-          message: '이미지 업로드에 실패했습니다.',
-          variant: 'error',
-        })
-      }
-    },
-    [getPresignedUrl, onChange, onImageUrlsChange]
+        input.click()
+      },
+    }),
+    [getPresignedUrl, onChange]
   )
 
-  const handleFileChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0]
-      if (file) uploadImage(file)
-      e.target.value = ''
-    },
-    [uploadImage]
+  const editorCommands: ICommand[] = useMemo(
+    () => [
+      undoCommand,
+      redoCommand,
+      mdCommands.divider,
+      fontFamilyCommand,
+      fontSizeCommand,
+      mdCommands.divider,
+      mdCommands.bold,
+      mdCommands.italic,
+      underlineCommand,
+      mdCommands.strikethrough,
+      bgColorCommand,
+      textColorCommand,
+      mdCommands.divider,
+      mdCommands.link,
+      imageCommand,
+    ],
+    [imageCommand, undoCommand, redoCommand]
   )
 
-  const handleDrop = useCallback(
-    (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault()
-      const file = e.dataTransfer.files?.[0]
-      if (file) uploadImage(file)
-    },
-    [uploadImage]
+  const editorExtraCommands: ICommand[] = useMemo(
+    () => [
+      listDropdownCmd,
+      mdCommands.divider,
+      alignLeftCommand,
+      alignCenterCommand,
+      alignRightCommand,
+      alignJustifyCommand,
+      lineHeightCmd,
+      outdentCmd,
+      indentCmd,
+      clearFormatCmd,
+    ],
+    []
   )
 
   return (
-    <div
-      ref={containerRef}
-      data-color-mode="light"
-      onDrop={handleDrop}
-      onDragOver={(e) => e.preventDefault()}
-      className={[
-        'rounded border',
-        error ? 'border-error ring-error/30 ring-2' : 'border-border-base',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-    >
-      {/* 이미지 첨부 버튼 */}
-      <div className="border-border-base bg-bg-muted flex items-center gap-2 border-b px-3 py-2">
-        <button
-          type="button"
-          onClick={() => fileInputRef.current?.click()}
-          className="text-primary hover:bg-primary-100 active:bg-primary-200 inline-flex items-center gap-1.5 rounded px-2 py-1 text-sm transition-colors"
-        >
-          <ImageIcon />
-          이미지 첨부
-        </button>
-        <span className="text-text-muted text-xs">
-          또는 에디터에 드래그 앤 드롭
-        </span>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={handleFileChange}
+    <div className="bg-bg-base rounded-[20px] border border-[#cdcdcd]">
+      <div data-color-mode="light" className="post-editor-wrap">
+        <MDEditor
+          value={value}
+          onChange={(v) => handleChange(v ?? '')}
+          preview="live"
+          commands={editorCommands}
+          extraCommands={editorExtraCommands}
         />
       </div>
-
-      {/* MDEditor */}
-      <MDEditor
-        value={value}
-        onChange={(v) => onChange(v ?? '')}
-        preview="live"
-        height={height}
-        style={{ borderRadius: 0, border: 'none' }}
-      />
-
-      {/* 업로드 토스트 */}
-      {uploadToast.visible && (
-        <Toast
-          message={uploadToast.message}
-          variant={uploadToast.variant === 'info' ? 'info' : 'error'}
-          duration={
-            uploadToast.variant === 'error' ? TOAST_ERROR_DURATION_MS : 0
-          }
-          onClose={() => setUploadToast({ visible: false })}
-        />
+      {isUploading && (
+        <p className="text-text-muted px-4 pb-2 text-xs" aria-live="polite">
+          이미지 업로드 중...
+        </p>
+      )}
+      {imageError && (
+        <p className="text-error px-4 pb-2 text-xs" role="alert">
+          {imageError}
+        </p>
+      )}
+      {error && (
+        <p className="text-error px-4 pb-2 text-xs" role="alert">
+          {error}
+        </p>
       )}
     </div>
-  )
-})
-
-function ImageIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden="true"
-      className="shrink-0"
-    >
-      <rect
-        x="3"
-        y="3"
-        width="18"
-        height="18"
-        rx="2"
-        stroke="currentColor"
-        strokeWidth="2"
-      />
-      <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" />
-      <path
-        d="M21 15l-5-5L5 21"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
   )
 }

--- a/src/components/qna/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/components/qna/MarkdownViewer/MarkdownViewer.tsx
@@ -1,0 +1,14 @@
+import MDEditor from '@uiw/react-md-editor'
+import rehypeSanitize from 'rehype-sanitize'
+
+export interface MarkdownViewerProps {
+  content: string
+}
+
+export function MarkdownViewer({ content }: MarkdownViewerProps) {
+  return (
+    <div data-color-mode="light">
+      <MDEditor.Markdown source={content} rehypePlugins={[rehypeSanitize]} />
+    </div>
+  )
+}

--- a/src/components/qna/MarkdownViewer/index.ts
+++ b/src/components/qna/MarkdownViewer/index.ts
@@ -1,0 +1,1 @@
+export * from './MarkdownViewer'

--- a/src/components/qna/QuestionDetail/QuestionDetail.tsx
+++ b/src/components/qna/QuestionDetail/QuestionDetail.tsx
@@ -1,6 +1,5 @@
-import rehypeSanitize from 'rehype-sanitize'
-import MDEditor from '@uiw/react-md-editor'
 import { Button } from '@/components/common/Button'
+import { MarkdownViewer } from '@/components/qna/MarkdownViewer'
 import { UserAvatar } from '@/components/common/UserAvatar'
 import { LoadingBox } from '@/components/common/LoadingBox'
 import { QaBadge } from '@/components/qna/QaBadge'
@@ -127,12 +126,7 @@ export function QuestionDetail({
           <hr className="border-border-base my-4" />
 
           {/* 본문 — 마크다운 렌더링 */}
-          <div data-color-mode="light">
-            <MDEditor.Markdown
-              source={questionDetail.content}
-              rehypePlugins={[rehypeSanitize]}
-            />
-          </div>
+          <MarkdownViewer content={questionDetail.content} />
 
           {/* 첨부 이미지 */}
           {questionDetail.images.length > 0 && (

--- a/src/components/qna/QuestionForm/QuestionForm.tsx
+++ b/src/components/qna/QuestionForm/QuestionForm.tsx
@@ -51,7 +51,6 @@ export function QuestionForm({
 
   const [title, setTitle] = useState(initialValues?.title ?? '')
   const [content, setContent] = useState(initialValues?.content ?? '')
-  const [imageUrls, setImageUrls] = useState<string[]>([])
   const [alertMessage, setAlertMessage] = useState('')
   const [isAlertOpen, setIsAlertOpen] = useState(false)
 
@@ -156,13 +155,7 @@ export function QuestionForm({
         </div>
 
         {/* 마크다운 에디터 박스 */}
-        <MarkdownEditor
-          value={content}
-          onChange={setContent}
-          imageUrls={imageUrls}
-          onImageUrlsChange={setImageUrls}
-          height={400}
-        />
+        <MarkdownEditor value={content} onChange={setContent} />
 
         {/* 버튼 */}
         <div className="flex justify-end gap-3">

--- a/src/components/qna/QuestionForm/QuestionForm.tsx
+++ b/src/components/qna/QuestionForm/QuestionForm.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
-import MDEditor from '@uiw/react-md-editor'
-import rehypeSanitize from 'rehype-sanitize'
 import { Button } from '@/components/common/Button'
+import { MarkdownEditor } from '@/components/qna/MarkdownEditor'
 import { Dropdown } from '@/components/common/Dropdown'
 import { AlertModal } from '@/components/common/Modal'
 import { useCategorySelector } from '@/hooks/useCategorySelector'
@@ -52,6 +51,7 @@ export function QuestionForm({
 
   const [title, setTitle] = useState(initialValues?.title ?? '')
   const [content, setContent] = useState(initialValues?.content ?? '')
+  const [imageUrls, setImageUrls] = useState<string[]>([])
   const [alertMessage, setAlertMessage] = useState('')
   const [isAlertOpen, setIsAlertOpen] = useState(false)
 
@@ -156,18 +156,13 @@ export function QuestionForm({
         </div>
 
         {/* 마크다운 에디터 박스 */}
-        <div className="border-border-base overflow-hidden rounded-xl border">
-          <div data-color-mode="light">
-            <MDEditor
-              value={content}
-              onChange={(v) => setContent(v ?? '')}
-              height={400}
-              preview="live"
-              visibleDragbar={false}
-              previewOptions={{ rehypePlugins: [[rehypeSanitize]] }}
-            />
-          </div>
-        </div>
+        <MarkdownEditor
+          value={content}
+          onChange={setContent}
+          imageUrls={imageUrls}
+          onImageUrlsChange={setImageUrls}
+          height={400}
+        />
 
         {/* 버튼 */}
         <div className="flex justify-end gap-3">

--- a/src/components/qna/index.ts
+++ b/src/components/qna/index.ts
@@ -1,5 +1,6 @@
 export * from './QaBadge'
 export * from './MarkdownEditor'
+export * from './MarkdownViewer'
 export * from './AnswerCard'
 export * from './AnswerForm'
 export * from './QuestionCard'

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -318,6 +318,7 @@ export function QnaListPage() {
         <div className="space-y-1">
           {SORT_OPTIONS.map((opt) => (
             <button
+              type="button"
               key={opt}
               onClick={() => {
                 updateParam('sort', opt)


### PR DESCRIPTION
## 관련 이슈

- closes #45

## 작업 내용

- 마크다운 에디터 컴포넌트 통합
- 분산된 에디터 뷰어 및 작성 폼 구현체를 공통 MarkdownEditor 컴포넌트로 통합
- MDEditor를 기반으로 한 일관된 테마 및 스타일(폰트, 컬러 등) 적용 및 피그마 디자인 반영
- ImageUpload 등 불필요하게 분리되었던 이미지 첨부 방식 제거 및 툴바 통합

## 체크리스트

[x] 코드가 정상적으로 동작하는지 확인했습니다
[x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
[x] 컨벤션에 맞게 작성했습니다
