### PR TITLE
feat: DEV 전용 권한별 로그인 패널 추가 (#71)

### DIFF
--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -1,8 +1,112 @@
+import { useState } from 'react'
 import { Outlet } from 'react-router'
 import { Header } from './Header'
 import { Footer } from './Footer'
 import { ChatbotFab, ChatbotWidget } from '@/components/chatbot'
 import { ChatbotPageContextSync } from '@/features/chatbot/ChatbotPageContextSync'
+import { useAuthStore } from '@/stores/authStore'
+import type { UserRole } from '@/stores/authStore'
+
+// DEV 전용 권한별 로그인 패널 — 운영 빌드에서는 렌더링 안 됨
+interface RoleOption {
+  id?: number
+  role: UserRole
+  label: string
+  color: string
+}
+
+const ROLE_OPTIONS: RoleOption[] = [
+  { role: 'USER', label: '일반회원', color: 'bg-gray-500' },
+  { role: 'STUDENT', label: '수강생', color: 'bg-blue-500' },
+  { role: 'STUDENT', id: 100, label: '수강생 (작성자)', color: 'bg-blue-700' },
+  { role: 'TA', label: '튜터 (TA)', color: 'bg-green-500' },
+  { role: 'OM', label: '운영매니저 (OM)', color: 'bg-yellow-500' },
+  { role: 'LC', label: '강사 (LC)', color: 'bg-orange-500' },
+  { role: 'ADMIN', label: '관리자', color: 'bg-red-500' },
+]
+
+function DevAuthPanel() {
+  const { isAuthenticated, user, login, logout } = useAuthStore()
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (!import.meta.env.DEV) return null
+
+  const handleLogin = ({ id, role, label }: RoleOption) => {
+    localStorage.setItem('accessToken', 'dev-mock-token')
+    login({
+      id,
+      nickname: `Dev ${label}`,
+      email: `${role.toLowerCase()}@test.com`,
+      role,
+    })
+  }
+
+  const handleLogout = () => {
+    logout()
+    localStorage.removeItem('accessToken')
+  }
+
+  return (
+    <div className="fixed bottom-4 left-4 z-50">
+      {isOpen && (
+        <div className="mb-2 rounded-lg border border-gray-700 bg-gray-900 p-3 shadow-xl">
+          <p className="mb-2 text-xs font-semibold text-gray-400">DEV 로그인</p>
+          <div className="flex flex-col gap-1">
+            {ROLE_OPTIONS.map((option) => {
+              const isActive =
+                isAuthenticated &&
+                user?.role === option.role &&
+                (option.id == null
+                  ? user?.id == null || user?.id !== 100
+                  : user?.id === option.id)
+              return (
+                <button
+                  key={`${option.role}-${option.id ?? 'default'}`}
+                  type="button"
+                  onClick={() => handleLogin(option)}
+                  className={[
+                    'flex items-center gap-2 rounded px-3 py-1.5 text-left text-xs text-white transition-opacity hover:opacity-90',
+                    option.color,
+                    isActive
+                      ? 'ring-2 ring-white ring-offset-1 ring-offset-gray-900'
+                      : '',
+                  ].join(' ')}
+                >
+                  <span>{option.label}</span>
+                  {isActive && (
+                    <span className="ml-auto text-[10px] opacity-75">현재</span>
+                  )}
+                </button>
+              )
+            })}
+            {isAuthenticated && (
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="mt-1 rounded bg-gray-700 px-3 py-1.5 text-xs text-white transition-opacity hover:opacity-90"
+              >
+                로그아웃
+              </button>
+            )}
+          </div>
+          {isAuthenticated && user && (
+            <p className="mt-2 truncate text-[10px] text-gray-500">
+              {user.nickname} · {user.role ?? '역할없음'}
+              {user.id != null ? ` · id:${user.id}` : ''}
+            </p>
+          )}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        className="rounded-lg bg-gray-800 px-3 py-1.5 text-xs text-white opacity-60 hover:opacity-100"
+      >
+        {isAuthenticated ? `DEV: ${user?.role ?? '로그인됨'}` : 'DEV 로그인'}
+      </button>
+    </div>
+  )
+}
 
 export function DefaultLayout() {
   return (
@@ -13,6 +117,7 @@ export function DefaultLayout() {
       <ChatbotPageContextSync />
       <ChatbotFab />
       <ChatbotWidget />
+      <DevAuthPanel />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `DefaultLayout`에 DEV 전용 권한별 로그인 패널(`DevAuthPanel`) 추가
- 화면 좌하단 고정 버튼 클릭 시 역할별(USER / STUDENT / STUDENT 작성자 / TA / OM / LC / ADMIN) 로그인 버튼 표시
- `import.meta.env.DEV`가 false이면 렌더링되지 않아 프로덕션 빌드에 영향 없음

## Test plan
- [ ] `pnpm dev` 실행 후 좌하단에 `DEV 로그인` 버튼이 보이는지 확인
- [ ] 각 역할 버튼 클릭 시 Zustand authStore에 해당 role/nickname/email이 반영되는지 확인
- [ ] 현재 로그인된 역할에 흰색 ring 강조 표시 확인
- [ ] 로그아웃 버튼 클릭 시 스토어 초기화 + localStorage accessToken 삭제 확인
- [ ] `pnpm build` 후 DEV 패널이 렌더링되지 않는지 확인

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)