### PR TITLE
fix: 마크다운 에디터 툴바 UX 버그 수정 (#76)

### DIFF
--- a/.claude/scripts/rules/frontend-design-guide.checklist.js
+++ b/.claude/scripts/rules/frontend-design-guide.checklist.js
@@ -21,8 +21,9 @@ const checklist = [
     category: "Readability",
     name: "매직 넘버 명명",
     description: "의미 있는 숫자 리터럴이 명명된 상수로 추출되어 있는가?",
-    // 변경된 파일에 의미 있는 숫자 리터럴 없음. Tailwind 클래스 내 숫자(px-3, pb-10 등)는 CSS 관례이므로 해당 없음
-    status: "N/A",
+    // MarkdownEditor: UNDO_LIMIT=50, FONT_SIZES 배열, CSS 픽셀값(레이아웃 관례 허용)
+    // CommentForm: MAX_LENGTH=500, NEAR_LIMIT_THRESHOLD=50 으로 추출됨 (수정 완료)
+    status: "O",
     violations: [],
   },
   {
@@ -30,7 +31,7 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인증/권한)",
     description: "인증 체크, 권한 검사 등 공통 로직이 래퍼/가드 컴포넌트로 분리되어 있는가?",
-    // 변경된 파일에 인증/권한 로직 없음 (DefaultLayout의 DevAuthPanel은 DEV 전용 테스트 패널)
+    // 스테이징된 파일에 인증/권한 로직 없음
     status: "N/A",
     violations: [],
   },
@@ -39,8 +40,8 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인터랙션)",
     description: "다이얼로그/오버레이 등 복잡한 인터랙션이 전용 컴포넌트로 추출되어 있는가?",
-    // CommentList의 isSortOpen 토글은 단순 드롭다운 수준으로 별도 추출 불필요
-    // MarkdownEditor의 actions 슬롯은 적절한 합성 패턴
+    // MarkdownEditor 툴바 드롭다운은 MDEditor group command 패턴으로 적절히 처리됨
+    // CommentForm/AnswerForm 은 단순 폼 UI
     status: "O",
     violations: [],
   },
@@ -49,8 +50,8 @@ const checklist = [
     category: "Readability",
     name: "조건부 렌더링 분리",
     description: "역할/상태에 따라 크게 다른 UI/로직이 별도 컴포넌트로 분리되어 있는가?",
-    // AnswerForm: isEdit ? '수정' : '등록' — 단순 텍스트 분기, 별도 분리 불필요
-    // CommentList: sortOrder 분기에 따른 UI 변화 단순
+    // MarkdownEditor: isDragOver 오버레이는 단순 분기
+    // CommentForm: counterColor 분기는 동일 요소의 스타일만 변경
     status: "O",
     violations: [],
   },
@@ -59,7 +60,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 삼항 연산자 단순화",
     description: "중첩 삼항 연산자가 if/else 또는 IIFE로 대체되어 있는가?",
-    // 변경된 파일 모두 단순 삼항(1단계)만 사용, 중첩 삼항 없음
+    // CommentForm: isAtLimit ? err : isNearLimit ? warn : muted → if/else 블록으로 수정 완료
     status: "O",
     violations: [],
   },
@@ -68,7 +69,7 @@ const checklist = [
     category: "Readability",
     name: "시선 이동 감소 (Colocation)",
     description: "단일 사용처에서만 쓰이는 단순 로직이 사용 위치 근처에 배치되어 있는가?",
-    // 각 컴포넌트의 상수/로직이 모두 사용 위치 근처에 정의됨
+    // 모든 상수(FONT_FAMILIES, FONT_SIZES, MAX_LENGTH 등)가 사용 위치 근처에 정의됨
     status: "O",
     violations: [],
   },
@@ -77,8 +78,8 @@ const checklist = [
     category: "Readability",
     name: "복잡한 조건에 이름 붙이기",
     description: "2개 이상 조합된 boolean 표현식이 의미 있는 변수명으로 추출되어 있는가?",
-    // CommentForm: hasContent = content.trim().length > 0 — 조건 명명 적절
-    // CommentList: sortOrder === order — 단일 조건으로 명명 불필요
+    // CommentForm: isNearLimit, isAtLimit, hasContent 로 모두 명명됨
+    // MarkdownEditor: isCursorInsideTag 등 헬퍼 함수로 추출됨
     status: "O",
     violations: [],
   },
@@ -89,7 +90,7 @@ const checklist = [
     category: "Predictability",
     name: "API 훅 반환 타입 표준화",
     description: "유사한 API 훅들이 일관된 반환 타입(UseQueryResult 등)을 사용하는가?",
-    // CommentForm: usePostComment → { mutate, isPending } TanStack Query 표준 패턴
+    // useGetPresignedUrl, usePostComment → TanStack Query 표준 패턴 사용
     status: "N/A",
     violations: [],
   },
@@ -98,7 +99,7 @@ const checklist = [
     category: "Predictability",
     name: "검증 함수 반환 타입 표준화",
     description: "검증 함수들이 일관된 Discriminated Union 타입을 반환하는가?",
-    // 검증 함수 없음
+    // 스테이징된 파일에 검증 함수 없음
     status: "N/A",
     violations: [],
   },
@@ -107,7 +108,7 @@ const checklist = [
     category: "Predictability",
     name: "숨겨진 사이드 이펙트 제거",
     description: "함수가 이름에 드러나지 않은 사이드 이펙트(로깅, 분석 등)를 수행하지 않는가?",
-    // handleSubmit: mutate 호출 후 onSuccess에서 setContent('') — 폼 리셋으로 명백한 동작
+    // uploadImageFile, handleDrop, handleChange 모두 이름에 드러난 동작만 수행
     status: "O",
     violations: [],
   },
@@ -127,8 +128,8 @@ const checklist = [
     category: "Cohesion",
     name: "폼 응집도 선택",
     description: "폼 검증이 용도에 맞게 필드 단위 또는 폼 단위로 일관되게 선택되어 있는가?",
-    // CommentForm: hasContent 단일 검사로 단순 폼에 적합
-    // AnswerForm: MarkdownEditor 내부에서 error 처리, 일관성 있음
+    // CommentForm: 단순 길이 검증만 존재, 필드 단위 적합
+    // AnswerForm: 기존 방식 유지 (버튼 텍스트만 변경)
     status: "O",
     violations: [],
   },
@@ -137,7 +138,7 @@ const checklist = [
     category: "Cohesion",
     name: "도메인별 디렉토리 구조",
     description: "기능/도메인 관련 코드가 도메인 폴더에 묶여 있는가?",
-    // 모든 컴포넌트가 올바른 도메인 폴더에 위치 (qna/, common/, layout/)
+    // 모든 파일이 src/components/qna/ 도메인 폴더에 올바르게 위치
     status: "O",
     violations: [],
   },
@@ -146,7 +147,8 @@ const checklist = [
     category: "Cohesion",
     name: "상수와 로직의 근접성",
     description: "상수가 사용 로직과 가까운 위치에 정의되어 있거나 이름으로 용도가 명확한가?",
-    // CommentList: (['latest', 'oldest'] as const) 인라인 선언으로 사용 위치와 밀접
+    // MAX_LENGTH, NEAR_LIMIT_THRESHOLD → 파일 상단, 사용처와 근접
+    // FONT_FAMILIES, FONT_SIZES 등 → MarkdownEditor 파일 상단 명확히 명명
     status: "O",
     violations: [],
   },
@@ -157,7 +159,8 @@ const checklist = [
     category: "Coupling",
     name: "성급한 추상화 지양",
     description: "단순히 비슷하다는 이유로 섣불리 공통 훅/함수로 추출되지 않았는가?",
-    // MarkdownEditor의 actions 슬롯은 AnswerForm 요구사항에서 자연스럽게 도출된 합성 패턴
+    // replaceInText, applyInlineFromDropdown 등은 각자 다른 역할로 구분됨
+    // makeColorCommand는 2개 이상 색상 커맨드에서 공통으로 쓰이는 정당한 추상화
     status: "O",
     violations: [],
   },
@@ -166,8 +169,8 @@ const checklist = [
     category: "Coupling",
     name: "상태 관리 범위 축소",
     description: "여러 관심사가 하나의 훅/컨텍스트에 묶이지 않고 분리되어 있는가?",
-    // CommentList: sortOrder/isSortOpen 로컬 UI 상태만 관리
-    // CommentForm: content 로컬 상태 + usePostComment 서버 상태 분리
+    // MarkdownEditor: isUploading, imageError, undoStack/redoStack, selectedFontLabel/Size, isDragOver → 각 관심사별 독립 state
+    // CommentForm: content(입력값) 단일 state
     status: "O",
     violations: [],
   },
@@ -176,7 +179,7 @@ const checklist = [
     category: "Coupling",
     name: "Props Drilling 제거",
     description: "3단계 이상 props 전달이 컴포지션(children)으로 대체되어 있는가?",
-    // AnswerForm → MarkdownEditor(actions) 1단계 전달, 드릴링 아님
+    // actions prop은 1단계 전달, props drilling 없음
     status: "N/A",
     violations: [],
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.2",
+    "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "remark-breaks": "^4.0.0",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,15 @@ importers:
       react-router:
         specifier: ^7.13.2
         version: 7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -1698,6 +1704,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -2102,6 +2111,9 @@ packages:
 
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -4410,6 +4422,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4962,6 +4979,12 @@ snapshots:
       '@types/hast': 3.0.4
       rehype-parse: 9.0.1
       rehype-stringify: 10.0.1
+      unified: 11.0.5
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
 
   remark-gfm@4.0.1:

--- a/src/components/qna/AnswerForm/AnswerForm.tsx
+++ b/src/components/qna/AnswerForm/AnswerForm.tsx
@@ -173,7 +173,7 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
               loading={isLoading}
               disabled={isLoading}
             >
-              {isEdit ? '수정' : '등록'}
+              {isEdit ? '수정하기' : '답변하기'}
             </Button>
           }
         />

--- a/src/components/qna/CommentForm/CommentForm.tsx
+++ b/src/components/qna/CommentForm/CommentForm.tsx
@@ -2,6 +2,9 @@ import { useState } from 'react'
 import { Button } from '@/components/common/Button'
 import { usePostComment } from '@/features/qna/answer-comments'
 
+const MAX_LENGTH = 500
+const NEAR_LIMIT_THRESHOLD = 50
+
 interface CommentFormProps {
   answerId: number
   questionId: number
@@ -13,29 +16,48 @@ export function CommentForm({ answerId, questionId }: CommentFormProps) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!content.trim()) return
+    if (!content.trim() || content.length > MAX_LENGTH) return
     mutate({ content: content.trim() }, { onSuccess: () => setContent('') })
   }
 
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length <= MAX_LENGTH) {
+      setContent(e.target.value)
+    }
+  }
+
   const hasContent = content.trim().length > 0
+  const remaining = MAX_LENGTH - content.length
+  const isNearLimit = remaining <= NEAR_LIMIT_THRESHOLD
+  const isAtLimit = remaining === 0
+
+  let counterColor = 'var(--color-text-muted)'
+  if (isAtLimit) {
+    counterColor = 'var(--color-error)'
+  } else if (isNearLimit) {
+    counterColor = 'var(--color-warning)'
+  }
 
   return (
     <form onSubmit={handleSubmit} className="mt-3">
       <div className="border-border-base focus-within:border-primary relative rounded-md border transition-colors">
         <textarea
           value={content}
-          onChange={(e) => setContent(e.target.value)}
+          onChange={handleChange}
           placeholder="개인정보를 공유 및 요청하거나, 명예 훼손, 무단 광고, 불법 정보 유포시 모니터링 후 삭제될 수 있습니다."
           aria-label="댓글 입력"
           rows={2}
           disabled={isPending}
           className="w-full resize-none rounded-md px-3 pt-2 pb-10 text-sm outline-none disabled:opacity-50"
         />
-        <div className="absolute right-2 bottom-2">
+        <div className="absolute right-2 bottom-2 flex items-center gap-2">
+          <span className="text-xs" style={{ color: counterColor }}>
+            {content.length} / {MAX_LENGTH}
+          </span>
           <Button
             type="submit"
             size="sm"
-            disabled={!hasContent || isPending}
+            disabled={!hasContent || isAtLimit || isPending}
             loading={isPending}
           >
             등록

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.css
@@ -1,3 +1,9 @@
+/* ── 마크다운 에디터 툴바용 웹폰트 ──
+   index.html을 건드리지 않고 CSS @import로 Google Fonts 로드.
+   로드 실패 시 FONT_FAMILIES fallback 스택의 시스템 폰트로 자동 대체됨.
+*/
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&family=Nanum+Gothic&family=Nanum+Myeongjo&family=Roboto:wght@400;700&family=Merriweather:wght@400;700&family=Source+Code+Pro:wght@400;700&display=swap');
+
 /* ── MDEditor CSS 변수 오버라이드: 외부 border/shadow 제거 ── */
 .post-editor-wrap .w-md-editor {
   --md-editor-box-shadow-color: transparent;
@@ -166,6 +172,34 @@
   background: #f1f5f9;
 }
 
+/* ── 배경색 팝업 ── */
+.bg-color-popup {
+  padding: 7px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.bg-color-remove-btn {
+  display: block;
+  width: 100%;
+  margin-bottom: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  color: #374151;
+  white-space: nowrap;
+}
+
+.bg-color-remove-btn:hover {
+  background: #f1f5f9;
+}
+
 /* ── 색상 팔레트 ── */
 .color-palette {
   display: grid;
@@ -190,4 +224,9 @@
 .color-swatch:hover {
   transform: scale(1.2);
   border-color: #64748b;
+}
+
+/* 흰색 스와치는 배경과 구분되도록 더 진한 테두리 적용 */
+.color-swatch[data-white='true'] {
+  border-color: #cdcdcd;
 }

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
@@ -18,6 +18,7 @@ import {
   IndentIncrease,
   IndentDecrease,
 } from 'lucide-react'
+import remarkBreaks from 'remark-breaks'
 import './MarkdownEditor.css'
 import { useGetPresignedUrl } from '@/features/qna/presigned-url'
 
@@ -35,18 +36,39 @@ const ACCEPTED_IMAGE_TYPES = [
   'image/webp',
 ]
 
+// 웹폰트 로드 실패 시 시스템 폰트(fallback)로 자동 대체됨
 const FONT_FAMILIES = [
   { label: '기본서체', value: 'inherit' },
-  { label: 'Arial', value: 'Arial, sans-serif' },
-  { label: '돋움', value: 'Dotum, sans-serif' },
-  { label: '맑은 고딕', value: "'Malgun Gothic', sans-serif" },
-  { label: 'Georgia', value: 'Georgia, serif' },
-  { label: 'Courier New', value: "'Courier New', monospace" },
+  {
+    label: '노토 산스',
+    value: "'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif",
+  },
+  {
+    label: '나눔고딕',
+    value: "'Nanum Gothic', 'Dotum', '돋움', sans-serif",
+  },
+  {
+    label: '나눔명조',
+    value: "'Nanum Myeongjo', 'Batang', '바탕', serif",
+  },
+  {
+    label: 'Roboto',
+    value: "'Roboto', Arial, Helvetica, sans-serif",
+  },
+  {
+    label: 'Merriweather',
+    value: "'Merriweather', Georgia, 'Times New Roman', serif",
+  },
+  {
+    label: 'Source Code Pro',
+    value: "'Source Code Pro', 'Courier New', Consolas, monospace",
+  },
 ]
 
 const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
 
-const PALETTE_COLORS = [
+const TEXT_PALETTE_COLORS = [
+  '#ffffff', // 흰색 (배경이 어두울 때 사용)
   '#000000',
   '#434343',
   '#666666',
@@ -68,6 +90,9 @@ const PALETTE_COLORS = [
   '#8e7cc3',
   '#c27ba0',
 ]
+
+// 배경색 전용 팔레트: 흰색 + 배경 제거(투명) 포함
+const BG_PALETTE_COLORS = ['#ffffff', ...TEXT_PALETTE_COLORS]
 
 const PILL: React.CSSProperties = {
   borderRadius: 6,
@@ -93,78 +118,71 @@ function safeSelected(
   return (s && 'selectedText' in s ? s.selectedText : '') || ''
 }
 
-const fontFamilyCommand: ICommand = {
-  name: 'font-family',
-  keyCommand: 'group',
-  groupName: 'font-family',
-  buttonProps: { 'aria-label': '글꼴', title: '글꼴', style: PILL },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      기본서체 <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup">
-      {FONT_FAMILIES.map(({ label, value }) => (
-        <button
-          key={value}
-          type="button"
-          style={{ fontFamily: value === 'inherit' ? undefined : value }}
-          onClick={() => {
-            const inner = safeSelected(getState)
-            textApi?.replaceSelection(
-              `<span style="font-family: ${value}">${inner}</span>`
-            )
-            close()
-          }}
-        >
-          {label}
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
+/**
+ * 선택 텍스트가 이미 <span style="..."> 이면 해당 CSS 속성만 교체/추가하고,
+ * 그렇지 않으면 새 <span>으로 감쌉니다.
+ * 중첩 span 누적을 방지합니다.
+ */
+function wrapWithStyle(
+  selected: string,
+  property: string,
+  value: string
+): string {
+  const match = selected.match(/^<span style="([^"]*)">([\s\S]*)<\/span>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const propRe = new RegExp(`(^|;\\s*)${property}\\s*:[^;]*`, 'i')
+    let newStyle: string
+    if (propRe.test(existingStyle)) {
+      newStyle = existingStyle
+        .replace(
+          new RegExp(`${property}\\s*:[^;]*`, 'i'),
+          `${property}: ${value}`
+        )
+        .replace(/^;\s*/, '')
+        .trim()
+    } else if (existingStyle) {
+      newStyle = `${existingStyle}; ${property}: ${value}`
+    } else {
+      newStyle = `${property}: ${value}`
+    }
+    return `<span style="${newStyle}">${inner}</span>`
+  }
+  return `<span style="${property}: ${value}">${selected}</span>`
 }
 
-const fontSizeCommand: ICommand = {
-  name: 'font-size',
-  keyCommand: 'group',
-  groupName: 'font-size',
-  buttonProps: { 'aria-label': '글자 크기', title: '글자 크기', style: PILL },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      16 <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup" style={{ minWidth: 60 }}>
-      {FONT_SIZES.map((size) => (
-        <button
-          key={size}
-          type="button"
-          onClick={() => {
-            const inner = safeSelected(getState)
-            textApi?.replaceSelection(
-              `<span style="font-size: ${size}px">${inner}</span>`
-            )
-            close()
-          }}
-        >
-          {size}
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
+/**
+ * 선택 텍스트가 이미 <mark style="..."> 이면 background-color만 교체하고,
+ * 그렇지 않으면 새 <mark>으로 감쌉니다.
+ */
+function wrapMarkWithStyle(selected: string, color: string): string {
+  const match = selected.match(/^<mark style="([^"]*)">([\s\S]*)<\/mark>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const newStyle = existingStyle
+      .replace(/background-color\s*:[^;]*/i, `background-color: ${color}`)
+      .replace(/^;\s*/, '')
+      .trim()
+    return `<mark style="${newStyle}">${inner}</mark>`
+  }
+  return `<mark style="background-color: ${color}">${selected}</mark>`
 }
 
+/** 밑줄 토글: 이미 <u>로 감싸져 있으면 제거, 아니면 추가 */
 const underlineCommand: ICommand = {
   name: 'underline',
   keyCommand: 'underline',
   buttonProps: { 'aria-label': '밑줄', title: '밑줄' },
   icon: <Underline size={14} />,
   execute: (state, api) => {
-    api.replaceSelection(`<u>${state.selectedText}</u>`)
+    const uMatch = state.selectedText.match(/^<u>([\s\S]*)<\/u>$/)
+    if (uMatch) {
+      api.replaceSelection(uMatch[1])
+    } else {
+      api.replaceSelection(`<u>${state.selectedText}</u>`)
+    }
   },
 }
 
@@ -172,22 +190,30 @@ function makeColorCommand(
   name: string,
   label: string,
   icon: React.ReactElement,
+  colors: string[],
   wrap: (color: string, text: string) => string
 ): ICommand {
   return {
     name,
     keyCommand: 'group',
     groupName: name,
-    buttonProps: { 'aria-label': label, title: label },
+    // onMouseDown: preventDefault → 팔레트 클릭 시 에디터 포커스/선택 영역 유지
+    buttonProps: {
+      'aria-label': label,
+      title: label,
+      onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+        e.preventDefault(),
+    },
     icon,
     children: ({ close, getState, textApi }) => (
-      <div className="color-palette">
-        {PALETTE_COLORS.map((color) => (
+      <div className="color-palette" onMouseDown={(e) => e.preventDefault()}>
+        {colors.map((color) => (
           <div
             key={color}
             className="color-swatch"
             style={{ background: color }}
-            title={color}
+            data-white={color === '#ffffff' ? 'true' : undefined}
+            title={color === '#ffffff' ? '흰색' : color}
             onClick={() => {
               const selected = safeSelected(getState)
               textApi?.replaceSelection(wrap(color, selected))
@@ -201,24 +227,78 @@ function makeColorCommand(
   }
 }
 
-const bgColorCommand = makeColorCommand(
-  'bg-color',
-  '배경색',
-  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-    <span
-      style={{
-        width: 16,
-        height: 16,
-        borderRadius: 3,
-        background: '#4285f4',
-        border: '1px solid rgba(0,0,0,0.12)',
-        display: 'inline-block',
-      }}
-    />
-    <ChevronDown size={10} />
-  </span>,
-  (color, text) => `<mark style="background-color: ${color}">${text}</mark>`
-)
+const bgColorCommand: ICommand = {
+  name: 'bg-color',
+  keyCommand: 'group',
+  groupName: 'bg-color',
+  buttonProps: {
+    'aria-label': '배경색',
+    title: '배경색',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      <span
+        style={{
+          width: 16,
+          height: 16,
+          borderRadius: 3,
+          background: '#4285f4',
+          border: '1px solid rgba(0,0,0,0.12)',
+          display: 'inline-block',
+        }}
+      />
+      <ChevronDown size={10} />
+    </span>
+  ),
+  children: ({ close, getState, textApi }) => (
+    <div className="bg-color-popup" onMouseDown={(e) => e.preventDefault()}>
+      {/* 배경 제거 버튼 */}
+      <button
+        type="button"
+        className="bg-color-remove-btn"
+        onClick={() => {
+          const selected = safeSelected(getState)
+          if (!selected) {
+            close()
+            return
+          }
+          const cleaned = selected.replace(
+            /<mark[^>]*>([\s\S]*?)<\/mark>/g,
+            '$1'
+          )
+          textApi?.replaceSelection(cleaned)
+          close()
+        }}
+      >
+        ✕ 배경 제거
+      </button>
+      {/* 색상 팔레트 */}
+      <div className="color-palette">
+        {BG_PALETTE_COLORS.map((color) => (
+          <div
+            key={color}
+            className="color-swatch"
+            style={{
+              background: color,
+              border:
+                color === '#ffffff'
+                  ? '1px solid #cdcdcd'
+                  : '1px solid rgba(0,0,0,0.12)',
+            }}
+            title={color === '#ffffff' ? '흰색' : color}
+            onClick={() => {
+              const selected = safeSelected(getState)
+              textApi?.replaceSelection(wrapMarkWithStyle(selected, color))
+              close()
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  ),
+  execute: () => {},
+}
 
 const textColorCommand = makeColorCommand(
   'text-color',
@@ -243,7 +323,8 @@ const textColorCommand = makeColorCommand(
       }}
     />
   </span>,
-  (color, text) => `<span style="color: ${color}">${text}</span>`
+  TEXT_PALETTE_COLORS,
+  (color, text) => wrapWithStyle(text, 'color', color)
 )
 
 const alignLeftCommand: ICommand = {
@@ -294,7 +375,11 @@ const listDropdownCmd: ICommand = {
   name: 'list-style',
   keyCommand: 'group',
   groupName: 'list-style',
-  buttonProps: { 'aria-label': '목록', title: '목록' },
+  buttonProps: {
+    'aria-label': '목록',
+    title: '목록',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
   icon: (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
       <List size={13} />
@@ -302,7 +387,7 @@ const listDropdownCmd: ICommand = {
     </span>
   ),
   children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup">
+    <div className="toolbar-popup" onMouseDown={(e) => e.preventDefault()}>
       <button
         type="button"
         onClick={() => {
@@ -360,10 +445,18 @@ const lineHeightCmd: ICommand = {
   name: 'line-height',
   keyCommand: 'group',
   groupName: 'line-height',
-  buttonProps: { 'aria-label': '줄 간격', title: '줄 간격' },
+  buttonProps: {
+    'aria-label': '줄 간격',
+    title: '줄 간격',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
   icon: <ArrowUpDown size={14} />,
   children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup" style={{ minWidth: 80 }}>
+    <div
+      className="toolbar-popup"
+      style={{ minWidth: 80 }}
+      onMouseDown={(e) => e.preventDefault()}
+    >
       {['1', '1.5', '2', '2.5', '3'].map((h) => (
         <button
           key={h}
@@ -422,6 +515,8 @@ const clearFormatCmd: ICommand = {
   buttonProps: { 'aria-label': '서식 제거', title: '서식 제거' },
   icon: <RemoveFormatting size={14} />,
   execute: (state, api) => {
+    // 선택된 텍스트가 없으면 아무것도 하지 않음
+    if (!state.selectedText) return
     const cleaned = state.selectedText
       .replace(/\*\*(.*?)\*\*/gs, '$1')
       .replace(/\*(.*?)\*/gs, '$1')
@@ -444,6 +539,8 @@ export function MarkdownEditor({
   const [imageError, setImageError] = useState<string | null>(null)
   const [undoStack, setUndoStack] = useState<string[]>([])
   const [redoStack, setRedoStack] = useState<string[]>([])
+  const [selectedFontLabel, setSelectedFontLabel] = useState('기본서체')
+  const [selectedFontSize, setSelectedFontSize] = useState(16)
   const valueRef = useRef(value)
   const objectUrlsRef = useRef<Set<string>>(new Set())
   const [isDragOver, setIsDragOver] = useState(false)
@@ -513,6 +610,95 @@ export function MarkdownEditor({
       execute: handleRedo,
     }),
     [redoStack.length, handleRedo]
+  )
+
+  const fontFamilyCommand = useMemo<ICommand>(
+    () => ({
+      name: 'font-family',
+      keyCommand: 'group',
+      groupName: 'font-family',
+      buttonProps: {
+        'aria-label': '글꼴',
+        title: '글꼴',
+        style: PILL,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      },
+      icon: (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+          {selectedFontLabel} <ChevronDown size={10} />
+        </span>
+      ),
+      children: ({ close, getState, textApi }) => (
+        <div className="toolbar-popup" onMouseDown={(e) => e.preventDefault()}>
+          {FONT_FAMILIES.map(({ label, value }) => (
+            <button
+              key={value}
+              type="button"
+              style={{ fontFamily: value === 'inherit' ? undefined : value }}
+              onClick={() => {
+                const inner = safeSelected(getState)
+                textApi?.replaceSelection(
+                  wrapWithStyle(inner, 'font-family', value)
+                )
+                close()
+                setTimeout(() => setSelectedFontLabel(label), 0)
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      ),
+      execute: () => {},
+    }),
+    [selectedFontLabel]
+  )
+
+  const fontSizeCommand = useMemo<ICommand>(
+    () => ({
+      name: 'font-size',
+      keyCommand: 'group',
+      groupName: 'font-size',
+      buttonProps: {
+        'aria-label': '글자 크기',
+        title: '글자 크기',
+        style: PILL,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      },
+      icon: (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+          {selectedFontSize} <ChevronDown size={10} />
+        </span>
+      ),
+      children: ({ close, getState, textApi }) => (
+        <div
+          className="toolbar-popup"
+          style={{ minWidth: 60 }}
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          {FONT_SIZES.map((size) => (
+            <button
+              key={size}
+              type="button"
+              onClick={() => {
+                const inner = safeSelected(getState)
+                textApi?.replaceSelection(
+                  wrapWithStyle(inner, 'font-size', `${size}px`)
+                )
+                close()
+                setTimeout(() => setSelectedFontSize(size), 0)
+              }}
+            >
+              {size}
+            </button>
+          ))}
+        </div>
+      ),
+      execute: () => {},
+    }),
+    [selectedFontSize]
   )
 
   const uploadImageFile = useCallback(
@@ -632,7 +818,7 @@ export function MarkdownEditor({
       mdCommands.link,
       imageCommand,
     ],
-    [imageCommand, undoCommand, redoCommand]
+    [imageCommand, undoCommand, redoCommand, fontFamilyCommand, fontSizeCommand]
   )
 
   const editorExtraCommands: ICommand[] = useMemo(
@@ -678,6 +864,12 @@ export function MarkdownEditor({
           preview="live"
           commands={editorCommands}
           extraCommands={editorExtraCommands}
+          previewOptions={{
+            // react-markdown v10은 allowDangerousHtml 없이 inline HTML을 텍스트로 이스케이프함
+            // remarkRehypeOptions: { allowDangerousHtml: true } 로 inline HTML 노드 통과 허용
+            remarkPlugins: [[remarkBreaks]],
+            remarkRehypeOptions: { allowDangerousHtml: true },
+          }}
         />
       </div>
       {isUploading && (

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
@@ -19,6 +19,8 @@ import {
   IndentDecrease,
 } from 'lucide-react'
 import remarkBreaks from 'remark-breaks'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import './MarkdownEditor.css'
 import { useGetPresignedUrl } from '@/features/qna/presigned-url'
 
@@ -27,6 +29,20 @@ export interface MarkdownEditorProps {
   onChange: (value: string) => void
   error?: string
   actions?: React.ReactNode
+}
+
+// style 속성 허용, blob: 이미지 src 허용, 스크립트/이벤트 핸들러는 차단
+const editorSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style'],
+  },
+  tagNames: [...(defaultSchema.tagNames ?? []), 'u', 'mark'],
+  protocols: {
+    ...defaultSchema.protocols,
+    src: [...(defaultSchema.protocols?.src ?? ['http', 'https']), 'blob'],
+  },
 }
 
 const ACCEPTED_IMAGE_TYPES = [
@@ -94,6 +110,11 @@ const TEXT_PALETTE_COLORS = [
 // 배경색 전용 팔레트: 흰색 + 배경 제거(투명) 포함
 const BG_PALETTE_COLORS = ['#ffffff', ...TEXT_PALETTE_COLORS]
 
+// 버튼 클릭 시 textarea 포커스/선택 영역 유지를 위한 공통 props
+const NO_BLUR_PROPS = {
+  onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+}
+
 const PILL: React.CSSProperties = {
   borderRadius: 6,
   background: '#f0f2f5',
@@ -111,11 +132,295 @@ const PILL: React.CSSProperties = {
   fontWeight: 400,
 }
 
-function safeSelected(
-  getState?: () => false | { selectedText: string }
-): string {
+type EditorState = {
+  selectedText: string
+  text: string
+  selection: { start: number; end: number }
+}
+
+/** getState() 결과에서 전체 상태를 안전하게 꺼냅니다. */
+function safeGetState(
+  getState?: () => false | EditorState
+): EditorState | null {
   const s = getState?.()
-  return (s && 'selectedText' in s ? s.selectedText : '') || ''
+  return s && 'text' in s ? s : null
+}
+
+/** 커서가 HTML 태그 내부(<...> 사이)에 있는지 확인합니다. */
+function isCursorInsideTag(text: string, cursor: number): boolean {
+  const lastOpen = text.lastIndexOf('<', cursor - 1)
+  if (lastOpen === -1) return false
+  const lastClose = text.lastIndexOf('>', cursor - 1)
+  return lastOpen > lastClose
+}
+
+/** 커서 위치 기준 현재 단어 범위를 반환합니다 (인라인 서식용).
+ *  HTML 태그 문자(<, >)에서 단어 경계로 처리해 태그 내용 선택을 방지합니다. */
+function getWordRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  if (isCursorInsideTag(text, cursor)) return null
+  let start = cursor
+  let end = cursor
+  while (start > 0 && /[^\s<>]/.test(text[start - 1])) start--
+  while (end < text.length && /[^\s<>]/.test(text[end])) end++
+  return start < end ? { start, end } : null
+}
+
+/** 커서를 감싸는 가장 가까운 <span style="...">...</span> 의 범위를 반환합니다.
+ *  이미 스타일이 적용된 span에 다시 서식을 적용할 때 중첩 방지용으로 사용합니다.
+ *  커서가 </span> 바로 뒤(spanEnd)에 있는 경우도 포함합니다. */
+function getEnclosingSpanRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  // 순방향으로 모든 <span>을 찾아 커서가 포함되는지 확인합니다.
+  // cursor <= spanEnd 조건으로 </span> 바로 뒤에 커서가 있을 때도 매칭됩니다.
+  const spanOpenRe = /<span\b[^>]*>/gi
+  let match: RegExpExecArray | null
+  while ((match = spanOpenRe.exec(text)) !== null) {
+    const spanStart = match.index
+    const openEnd = spanStart + match[0].length
+    const closeIdx = text.indexOf('</span>', openEnd)
+    if (closeIdx === -1) continue
+    const spanEnd = closeIdx + '</span>'.length
+    if (cursor >= spanStart && cursor <= spanEnd) {
+      return { start: spanStart, end: spanEnd }
+    }
+  }
+  return null
+}
+
+/** 커서 위치 기준 현재 줄 범위를 반환합니다 (블록 서식용). */
+function getLineRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  if (isCursorInsideTag(text, cursor)) return null
+  let start = cursor
+  let end = cursor
+  while (start > 0 && text[start - 1] !== '\n') start--
+  while (end < text.length && text[end] !== '\n') end++
+  return start < end ? { start, end } : null
+}
+
+/**
+ * execute 핸들러에서 선택 영역이 없으면 현재 단어를 자동 선택 후 wrapFn 적용.
+ * 인라인 서식(밑줄, 글자색 등)에 사용합니다.
+ */
+function applyInline(
+  state: EditorState,
+  api: {
+    replaceSelection: (t: string) => void
+    setSelectionRange: (r: { start: number; end: number }) => void
+  },
+  wrapFn: (text: string) => string
+) {
+  if (state.selectedText) {
+    api.replaceSelection(wrapFn(state.selectedText))
+    return
+  }
+  const range = getWordRange(state.text, state.selection.start)
+  if (range) {
+    api.setSelectionRange(range)
+    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
+  }
+}
+
+/**
+ * execute 핸들러에서 선택 영역이 없으면 현재 줄을 자동 선택 후 wrapFn 적용.
+ * 블록 서식(정렬, 들여쓰기 등)에 사용합니다.
+ */
+function applyBlock(
+  state: EditorState,
+  api: {
+    replaceSelection: (t: string) => void
+    setSelectionRange: (r: { start: number; end: number }) => void
+  },
+  wrapFn: (text: string) => string
+) {
+  if (state.selectedText) {
+    api.replaceSelection(wrapFn(state.selectedText))
+    return
+  }
+  const range = getLineRange(state.text, state.selection.start)
+  if (range) {
+    api.setSelectionRange(range)
+    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
+  }
+}
+
+/**
+ * 드롭다운 children 핸들러용 인라인 서식 적용.
+ * 선택 영역 있음 → 선택 텍스트에 적용.
+ * 선택 영역 없음 → 커서를 감싸는 기존 <span> 전체를 교체(스타일 코드 중첩 방지).
+ *               → span 없으면 현재 단어를 선택해 적용.
+ */
+type TextApiWithElement = {
+  replaceSelection: (t: string) => void
+  setSelectionRange: (r: { start: number; end: number }) => void
+  textArea?: HTMLTextAreaElement
+}
+
+/**
+ * textarea 값을 직접 교체하고 React onChange를 트리거합니다.
+ * setSelectionRange → replaceSelection 순서에서 insertTextAtPosition 내부의
+ * focus() 호출이 selection을 리셋하는 문제를 우회합니다.
+ *
+ * React native property setter hack:
+ * 원래 HTMLTextAreaElement.prototype.value setter를 호출하면 React가 변경을
+ * "dirty"로 인식한 뒤 input 이벤트에서 onChange를 정상 호출합니다.
+ */
+function replaceInText(
+  textApi: TextApiWithElement,
+  fullText: string,
+  start: number,
+  end: number,
+  replacement: string
+): boolean {
+  const ta = textApi.textArea
+  if (!ta) return false
+  const newValue = fullText.slice(0, start) + replacement + fullText.slice(end)
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value'
+  )?.set
+  if (!nativeSetter) return false
+  nativeSetter.call(ta, newValue)
+  ta.dispatchEvent(new Event('input', { bubbles: true }))
+  ta.selectionStart = ta.selectionEnd = start + replacement.length
+  return true
+}
+
+/**
+ * 드롭다운 children 핸들러용 인라인 서식 적용.
+ *
+ * 우선순위:
+ * 1. 커서가 기존 <span> 안에 있으면 → span 전체를 교체 (선택 여부 무관, 중첩 방지)
+ * 2. 선택 영역 있음 → 선택 텍스트에 적용
+ * 3. 선택 없음 → 현재 단어 선택 후 적용
+ * 4. 아무것도 없으면 → 아무것도 하지 않음 (빈 span 삽입 방지)
+ *
+ * replaceInText를 우선 사용해 setSelectionRange + replaceSelection 패턴에서
+ * 발생하는 focus() → selection 리셋 문제를 방지합니다.
+ */
+function applyInlineFromDropdown(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  wrapFn: (text: string) => string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+
+  // 1. 커서 시작 위치가 기존 <span> 안이면 span 전체를 교체 (중첩 방지)
+  const spanRange = getEnclosingSpanRange(s.text, s.selection.start)
+  if (spanRange) {
+    const innerText = s.text.slice(spanRange.start, spanRange.end)
+    const replacement = wrapFn(innerText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        spanRange.start,
+        spanRange.end,
+        replacement
+      )
+    ) {
+      textApi.setSelectionRange(spanRange)
+      textApi.replaceSelection(replacement)
+    }
+    return
+  }
+
+  // 2. 선택 영역이 있으면 선택 텍스트에 적용
+  if (s.selectedText) {
+    const replacement = wrapFn(s.selectedText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        s.selection.start,
+        s.selection.end,
+        replacement
+      )
+    ) {
+      textApi.replaceSelection(replacement)
+    }
+    return
+  }
+
+  // 3. 선택 없음 → 현재 단어를 선택 후 적용
+  const wordRange = getWordRange(s.text, s.selection.start)
+  if (wordRange) {
+    const innerText = s.text.slice(wordRange.start, wordRange.end)
+    const replacement = wrapFn(innerText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        wordRange.start,
+        wordRange.end,
+        replacement
+      )
+    ) {
+      textApi.setSelectionRange(wordRange)
+      textApi.replaceSelection(replacement)
+    }
+  }
+  // 4. 아무것도 없으면 종료 (빈 <span></span> 삽입 안 함)
+}
+
+/**
+ * 드롭다운 children 핸들러용 블록 서식 적용.
+ * 선택 있음 → 선택 텍스트에 적용.
+ * 선택 없음 → wrapFn('') 를 커서 위치에 삽입.
+ */
+function applyBlockFromDropdown(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  wrapFn: (text: string) => string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+  if (s.selectedText) {
+    textApi.replaceSelection(wrapFn(s.selectedText))
+    return
+  }
+  textApi.replaceSelection(wrapFn(''))
+}
+
+/**
+ * 목록 전용 삽입 함수.
+ * 선택 있음 → 각 줄 앞에 prefix 추가.
+ * 선택 없음 → 현재 줄의 맨 앞으로 커서 이동 후 prefix 삽입.
+ *   textarea.selectionStart/End 를 직접 수정해 setSelectionRange(→ focus()) 호출을 피합니다.
+ */
+function insertListPrefix(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  prefix: string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+
+  if (s.selectedText) {
+    const lines = s.selectedText
+      .split('\n')
+      .map((l) => `${prefix}${l}`)
+      .join('\n')
+    textApi.replaceSelection(lines)
+    return
+  }
+
+  // 선택 없음: 줄 시작 위치를 계산하고 직접 selectionStart/End 설정
+  const lineStart = s.text.lastIndexOf('\n', s.selection.start - 1) + 1
+  const ta = (textApi as TextApiWithElement).textArea
+  if (ta) {
+    ta.selectionStart = lineStart
+    ta.selectionEnd = lineStart
+  }
+  textApi.replaceSelection(prefix)
 }
 
 /**
@@ -170,19 +475,84 @@ function wrapMarkWithStyle(selected: string, color: string): string {
   return `<mark style="background-color: ${color}">${selected}</mark>`
 }
 
-/** 밑줄 토글: 이미 <u>로 감싸져 있으면 제거, 아니면 추가 */
+/**
+ * 선택 텍스트가 이미 <div style="..."> 이면 해당 CSS 속성만 교체/추가하고,
+ * 그렇지 않으면 새 <div>로 감쌉니다.
+ * 중첩 div 누적을 방지합니다.
+ */
+function wrapDivWithStyle(
+  selected: string,
+  property: string,
+  value: string
+): string {
+  const match = selected.match(/^<div style="([^"]*)">([\s\S]*)<\/div>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const propRe = new RegExp(`${property}\\s*:[^;]*`, 'i')
+    let newStyle: string
+    if (propRe.test(existingStyle)) {
+      newStyle = existingStyle
+        .replace(propRe, `${property}: ${value}`)
+        .replace(/^;\s*/, '')
+        .trim()
+    } else if (existingStyle) {
+      newStyle = `${existingStyle}; ${property}: ${value}`
+    } else {
+      newStyle = `${property}: ${value}`
+    }
+    return `<div style="${newStyle}">${inner}</div>`
+  }
+  return `<div style="${property}: ${value}">${selected}</div>`
+}
+
+/** 커서를 감싸는 <u>...</u> 범위를 반환합니다. </u> 바로 뒤 커서도 포함합니다. */
+function getEnclosingURange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  const re = /<u>/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    const uStart = m.index
+    const closeIdx = text.indexOf('</u>', uStart + m[0].length)
+    if (closeIdx === -1) continue
+    const uEnd = closeIdx + '</u>'.length
+    if (cursor >= uStart && cursor <= uEnd) {
+      return { start: uStart, end: uEnd }
+    }
+  }
+  return null
+}
+
+/** 밑줄 토글: 커서가 <u> 안에 있거나 선택 텍스트가 <u>로 감싸져 있으면 제거, 아니면 추가 */
 const underlineCommand: ICommand = {
   name: 'underline',
   keyCommand: 'underline',
-  buttonProps: { 'aria-label': '밑줄', title: '밑줄' },
+  buttonProps: {
+    'aria-label': '밑줄',
+    title: '밑줄',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
   icon: <Underline size={14} />,
   execute: (state, api) => {
-    const uMatch = state.selectedText.match(/^<u>([\s\S]*)<\/u>$/)
-    if (uMatch) {
-      api.replaceSelection(uMatch[1])
-    } else {
-      api.replaceSelection(`<u>${state.selectedText}</u>`)
+    // 선택 없이 커서가 <u>...</u> 안에 있으면 → <u> 전체 선택 후 제거
+    if (!state.selectedText) {
+      const uRange = getEnclosingURange(state.text, state.selection.start)
+      if (uRange) {
+        const inner = state.text.slice(
+          uRange.start + '<u>'.length,
+          uRange.end - '</u>'.length
+        )
+        api.setSelectionRange(uRange)
+        api.replaceSelection(inner)
+        return
+      }
     }
+    applyInline(state, api, (text) => {
+      const uMatch = text.match(/^<u>([\s\S]*)<\/u>$/)
+      return uMatch ? uMatch[1] : `<u>${text}</u>`
+    })
   },
 }
 
@@ -215,8 +585,7 @@ function makeColorCommand(
             data-white={color === '#ffffff' ? 'true' : undefined}
             title={color === '#ffffff' ? '흰색' : color}
             onClick={() => {
-              const selected = safeSelected(getState)
-              textApi?.replaceSelection(wrap(color, selected))
+              applyInlineFromDropdown(getState, textApi, (t) => wrap(color, t))
               close()
             }}
           />
@@ -258,16 +627,9 @@ const bgColorCommand: ICommand = {
         type="button"
         className="bg-color-remove-btn"
         onClick={() => {
-          const selected = safeSelected(getState)
-          if (!selected) {
-            close()
-            return
-          }
-          const cleaned = selected.replace(
-            /<mark[^>]*>([\s\S]*?)<\/mark>/g,
-            '$1'
+          applyInlineFromDropdown(getState, textApi, (t) =>
+            t.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
           )
-          textApi?.replaceSelection(cleaned)
           close()
         }}
       >
@@ -288,8 +650,9 @@ const bgColorCommand: ICommand = {
             }}
             title={color === '#ffffff' ? '흰색' : color}
             onClick={() => {
-              const selected = safeSelected(getState)
-              textApi?.replaceSelection(wrapMarkWithStyle(selected, color))
+              applyInlineFromDropdown(getState, textApi, (t) =>
+                wrapMarkWithStyle(t, color)
+              )
               close()
             }}
           />
@@ -330,45 +693,53 @@ const textColorCommand = makeColorCommand(
 const alignLeftCommand: ICommand = {
   name: 'align-left',
   keyCommand: 'align-left',
-  buttonProps: { 'aria-label': '왼쪽 정렬', title: '왼쪽 정렬' },
+  buttonProps: {
+    'aria-label': '왼쪽 정렬',
+    title: '왼쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
   icon: <AlignLeft size={14} />,
   execute: (state, api) =>
-    api.replaceSelection(
-      `<div style="text-align: left">${state.selectedText}</div>`
-    ),
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'left')),
 }
 
 const alignCenterCommand: ICommand = {
   name: 'align-center',
   keyCommand: 'align-center',
-  buttonProps: { 'aria-label': '가운데 정렬', title: '가운데 정렬' },
+  buttonProps: {
+    'aria-label': '가운데 정렬',
+    title: '가운데 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
   icon: <AlignCenter size={14} />,
   execute: (state, api) =>
-    api.replaceSelection(
-      `<div style="text-align: center">${state.selectedText}</div>`
-    ),
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'center')),
 }
 
 const alignRightCommand: ICommand = {
   name: 'align-right',
   keyCommand: 'align-right',
-  buttonProps: { 'aria-label': '오른쪽 정렬', title: '오른쪽 정렬' },
+  buttonProps: {
+    'aria-label': '오른쪽 정렬',
+    title: '오른쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
   icon: <AlignRight size={14} />,
   execute: (state, api) =>
-    api.replaceSelection(
-      `<div style="text-align: right">${state.selectedText}</div>`
-    ),
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'right')),
 }
 
 const alignJustifyCommand: ICommand = {
   name: 'align-justify',
   keyCommand: 'align-justify',
-  buttonProps: { 'aria-label': '양쪽 정렬', title: '양쪽 정렬' },
+  buttonProps: {
+    'aria-label': '양쪽 정렬',
+    title: '양쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
   icon: <AlignJustify size={14} />,
   execute: (state, api) =>
-    api.replaceSelection(
-      `<div style="text-align: justify">${state.selectedText}</div>`
-    ),
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'justify')),
 }
 
 const listDropdownCmd: ICommand = {
@@ -391,14 +762,7 @@ const listDropdownCmd: ICommand = {
       <button
         type="button"
         onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l) => `- ${l}`)
-                .join('\n')
-            : '- '
-          textApi?.replaceSelection(lines)
+          insertListPrefix(getState, textApi, '- ')
           close()
         }}
       >
@@ -407,14 +771,7 @@ const listDropdownCmd: ICommand = {
       <button
         type="button"
         onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l, i) => `${i + 1}. ${l}`)
-                .join('\n')
-            : '1. '
-          textApi?.replaceSelection(lines)
+          insertListPrefix(getState, textApi, '1. ')
           close()
         }}
       >
@@ -423,14 +780,7 @@ const listDropdownCmd: ICommand = {
       <button
         type="button"
         onClick={() => {
-          const text = safeSelected(getState)
-          const lines = text
-            ? text
-                .split('\n')
-                .map((l) => `- [ ] ${l}`)
-                .join('\n')
-            : '- [ ] '
-          textApi?.replaceSelection(lines)
+          insertListPrefix(getState, textApi, '- [ ] ')
           close()
         }}
       >
@@ -462,9 +812,8 @@ const lineHeightCmd: ICommand = {
           key={h}
           type="button"
           onClick={() => {
-            const text = safeSelected(getState)
-            textApi?.replaceSelection(
-              `<div style="line-height: ${h}">${text}</div>`
+            applyBlockFromDropdown(getState, textApi, (t) =>
+              wrapDivWithStyle(t, 'line-height', h)
             )
             close()
           }}
@@ -480,50 +829,56 @@ const lineHeightCmd: ICommand = {
 const outdentCmd: ICommand = {
   name: 'outdent',
   keyCommand: 'outdent',
-  buttonProps: { 'aria-label': '내어쓰기', title: '내어쓰기' },
-  icon: <IndentDecrease size={14} />,
-  execute: (state, api) => {
-    const lines = state.selectedText
-      ? state.selectedText
-          .split('\n')
-          .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
-          .join('\n')
-      : ''
-    api.replaceSelection(lines)
+  buttonProps: {
+    'aria-label': '내어쓰기',
+    title: '내어쓰기',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
   },
+  icon: <IndentDecrease size={14} />,
+  execute: (state, api) =>
+    applyBlock(state, api, (t) =>
+      t
+        .split('\n')
+        .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
+        .join('\n')
+    ),
 }
 
 const indentCmd: ICommand = {
   name: 'indent',
   keyCommand: 'indent',
-  buttonProps: { 'aria-label': '들여쓰기', title: '들여쓰기' },
-  icon: <IndentIncrease size={14} />,
-  execute: (state, api) => {
-    const lines = state.selectedText
-      ? state.selectedText
-          .split('\n')
-          .map((l) => `  ${l}`)
-          .join('\n')
-      : '  '
-    api.replaceSelection(lines)
+  buttonProps: {
+    'aria-label': '들여쓰기',
+    title: '들여쓰기',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
   },
+  icon: <IndentIncrease size={14} />,
+  execute: (state, api) =>
+    applyBlock(state, api, (t) =>
+      t
+        .split('\n')
+        .map((l) => `  ${l}`)
+        .join('\n')
+    ),
 }
 
 const clearFormatCmd: ICommand = {
   name: 'clear-format',
   keyCommand: 'clear-format',
-  buttonProps: { 'aria-label': '서식 제거', title: '서식 제거' },
-  icon: <RemoveFormatting size={14} />,
-  execute: (state, api) => {
-    // 선택된 텍스트가 없으면 아무것도 하지 않음
-    if (!state.selectedText) return
-    const cleaned = state.selectedText
-      .replace(/\*\*(.*?)\*\*/gs, '$1')
-      .replace(/\*(.*?)\*/gs, '$1')
-      .replace(/~~(.*?)~~/gs, '$1')
-      .replace(/<[^>]+>/gs, '')
-    api.replaceSelection(cleaned)
+  buttonProps: {
+    'aria-label': '서식 제거',
+    title: '서식 제거',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
   },
+  icon: <RemoveFormatting size={14} />,
+  execute: (state, api) =>
+    applyInline(state, api, (t) =>
+      t
+        .replace(/\*\*(.*?)\*\*/gs, '$1')
+        .replace(/\*(.*?)\*/gs, '$1')
+        .replace(/~~(.*?)~~/gs, '$1')
+        .replace(/<[^>]+>/gs, '')
+    ),
 }
 
 const UNDO_LIMIT = 50
@@ -590,6 +945,8 @@ export function MarkdownEditor({
         'aria-label': '실행 취소',
         title: '실행 취소',
         'data-inactive': undoStack.length === 0 ? 'true' : undefined,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
       } as React.ButtonHTMLAttributes<HTMLButtonElement>,
       icon: <Undo2 size={14} />,
       execute: handleUndo,
@@ -605,6 +962,8 @@ export function MarkdownEditor({
         'aria-label': '다시 실행',
         title: '다시 실행',
         'data-inactive': redoStack.length === 0 ? 'true' : undefined,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
       } as React.ButtonHTMLAttributes<HTMLButtonElement>,
       icon: <Redo2 size={14} />,
       execute: handleRedo,
@@ -637,9 +996,8 @@ export function MarkdownEditor({
               type="button"
               style={{ fontFamily: value === 'inherit' ? undefined : value }}
               onClick={() => {
-                const inner = safeSelected(getState)
-                textApi?.replaceSelection(
-                  wrapWithStyle(inner, 'font-family', value)
+                applyInlineFromDropdown(getState, textApi, (t) =>
+                  wrapWithStyle(t, 'font-family', value)
                 )
                 close()
                 setTimeout(() => setSelectedFontLabel(label), 0)
@@ -683,9 +1041,8 @@ export function MarkdownEditor({
               key={size}
               type="button"
               onClick={() => {
-                const inner = safeSelected(getState)
-                textApi?.replaceSelection(
-                  wrapWithStyle(inner, 'font-size', `${size}px`)
+                applyInlineFromDropdown(getState, textApi, (t) =>
+                  wrapWithStyle(t, 'font-size', `${size}px`)
                 )
                 close()
                 setTimeout(() => setSelectedFontSize(size), 0)
@@ -776,7 +1133,12 @@ export function MarkdownEditor({
     () => ({
       name: 'image',
       keyCommand: 'image',
-      buttonProps: { 'aria-label': '이미지 업로드', title: '이미지 업로드' },
+      buttonProps: {
+        'aria-label': '이미지 업로드',
+        title: '이미지 업로드',
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      },
       icon: (
         <svg width="14" height="14" viewBox="0 0 20 20">
           <path
@@ -808,14 +1170,29 @@ export function MarkdownEditor({
       fontFamilyCommand,
       fontSizeCommand,
       mdCommands.divider,
-      mdCommands.bold,
-      mdCommands.italic,
+      {
+        ...mdCommands.bold,
+        buttonProps: { ...mdCommands.bold.buttonProps, ...NO_BLUR_PROPS },
+      },
+      {
+        ...mdCommands.italic,
+        buttonProps: { ...mdCommands.italic.buttonProps, ...NO_BLUR_PROPS },
+      },
       underlineCommand,
-      mdCommands.strikethrough,
+      {
+        ...mdCommands.strikethrough,
+        buttonProps: {
+          ...mdCommands.strikethrough.buttonProps,
+          ...NO_BLUR_PROPS,
+        },
+      },
       bgColorCommand,
       textColorCommand,
       mdCommands.divider,
-      mdCommands.link,
+      {
+        ...mdCommands.link,
+        buttonProps: { ...mdCommands.link.buttonProps, ...NO_BLUR_PROPS },
+      },
       imageCommand,
     ],
     [imageCommand, undoCommand, redoCommand, fontFamilyCommand, fontSizeCommand]
@@ -865,10 +1242,12 @@ export function MarkdownEditor({
           commands={editorCommands}
           extraCommands={editorExtraCommands}
           previewOptions={{
-            // react-markdown v10은 allowDangerousHtml 없이 inline HTML을 텍스트로 이스케이프함
-            // remarkRehypeOptions: { allowDangerousHtml: true } 로 inline HTML 노드 통과 허용
             remarkPlugins: [[remarkBreaks]],
             remarkRehypeOptions: { allowDangerousHtml: true },
+            rehypePlugins: [
+              [rehypeRaw],
+              [rehypeSanitize, editorSanitizeSchema],
+            ],
           }}
         />
       </div>

--- a/src/components/qna/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/components/qna/MarkdownViewer/MarkdownViewer.tsx
@@ -1,5 +1,21 @@
 import MDEditor from '@uiw/react-md-editor'
-import rehypeSanitize from 'rehype-sanitize'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import remarkBreaks from 'remark-breaks'
+
+// style 속성 허용, blob: 이미지 src 허용, 스크립트/이벤트 핸들러는 차단
+const sanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style'],
+  },
+  tagNames: [...(defaultSchema.tagNames ?? []), 'u', 'mark'],
+  protocols: {
+    ...defaultSchema.protocols,
+    src: [...(defaultSchema.protocols?.src ?? ['http', 'https']), 'blob'],
+  },
+}
 
 export interface MarkdownViewerProps {
   content: string
@@ -8,7 +24,11 @@ export interface MarkdownViewerProps {
 export function MarkdownViewer({ content }: MarkdownViewerProps) {
   return (
     <div data-color-mode="light">
-      <MDEditor.Markdown source={content} rehypePlugins={[rehypeSanitize]} />
+      <MDEditor.Markdown
+        source={content}
+        remarkPlugins={[[remarkBreaks]]}
+        rehypePlugins={[[rehypeRaw], [rehypeSanitize, sanitizeSchema]]}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## 관련 이슈

- closes #76

## 작업 내용

- 마크다운 에디터 툴바 버튼 클릭 시 textarea 선택 영역이 풀리는 문제 수정
- 폰트 스타일/크기 변경이 미리보기에 반영되지 않는 문제 수정
- 폰트 크기 재변경 시 첫 번째 값으로 고정되는 문제 수정
- 정렬·줄 간격 등 블록 서식이 중첩 HTML로 쌓이는 문제 수정
- 목록(글머리/번호/체크) 버튼이 미리보기에 보이지 않는 문제 수정
- 밑줄 버튼 토글 기능 추가 (bold/italic과 동일하게 재클릭 시 제거)
- 댓글 입력 글자 수 제한(500자) 및 잔여 글자 카운터 추가

## 변경 사항

- `MarkdownEditor.tsx`
  - `rehype-raw` + `rehype-sanitize` 플러그인을 `previewOptions`에 추가 → span/div HTML 태그가 미리보기에 렌더링됨
  - React native value setter hack(`replaceInText`)으로 폰트 서식 변경 시 React `onChange`가 정상 트리거되도록 수정
  - `getEnclosingSpanRange`를 순방향 스캔으로 교체 → 커서가 `</span>` 바로 뒤에 있어도 기존 span을 감지해 폰트 크기 재변경 가능
  - `getEnclosingURange` 추가 및 밑줄 버튼 토글 로직 구현
  - `NO_BLUR_PROPS`(`onMouseDown: preventDefault`) 적용으로 툴바 클릭 시 선택 영역 유지
  - `insertListPrefix`로 목록 항목을 커서 위치가 아닌 줄 맨 앞에 삽입
- `MarkdownViewer.tsx`
  - `rehype-raw` + `rehype-sanitize` 적용 (MarkdownEditor preview와 동일한 렌더링 보장)
- `CommentForm.tsx`
  - `MAX_LENGTH = 500`, `NEAR_LIMIT_THRESHOLD = 50` 상수 추가
  - 잔여 글자 카운터 UI 추가 (50자 이하 경고색, 0자 에러색)
- `AnswerForm.tsx`
  - 버튼 레이블 '수정' → '수정하기', '등록' → '답변하기' 변경

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다