### PR TITLE
fix: 마크다운 미리보기 목록 스타일 복원 및 에디터 모듈 분리 (#77)

### DIFF
--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -13,12 +13,33 @@ interface RoleOption {
   role: UserRole
   label: string
   color: string
+  nickname?: string
 }
 
 const ROLE_OPTIONS: RoleOption[] = [
   { role: 'USER', label: '일반회원', color: 'bg-gray-500' },
-  { role: 'STUDENT', label: '수강생', color: 'bg-blue-500' },
-  { role: 'STUDENT', id: 100, label: '수강생 (작성자)', color: 'bg-blue-700' },
+  { role: 'STUDENT', label: '수강생', color: 'bg-blue-400' },
+  {
+    role: 'STUDENT',
+    id: 100,
+    label: '질문 작성자',
+    color: 'bg-blue-600',
+    nickname: '질문자',
+  },
+  {
+    role: 'STUDENT',
+    id: 211,
+    label: '답변 작성자',
+    color: 'bg-indigo-600',
+    nickname: '테스트유저',
+  },
+  {
+    role: 'STUDENT',
+    id: 301,
+    label: '댓글 작성자',
+    color: 'bg-violet-600',
+    nickname: '댓글러',
+  },
   { role: 'TA', label: '튜터 (TA)', color: 'bg-green-500' },
   { role: 'OM', label: '운영매니저 (OM)', color: 'bg-yellow-500' },
   { role: 'LC', label: '강사 (LC)', color: 'bg-orange-500' },
@@ -31,11 +52,11 @@ function DevAuthPanel() {
 
   if (!import.meta.env.DEV) return null
 
-  const handleLogin = ({ id, role, label }: RoleOption) => {
+  const handleLogin = ({ id, role, label, nickname }: RoleOption) => {
     localStorage.setItem('accessToken', 'dev-mock-token')
     login({
       id,
-      nickname: `Dev ${label}`,
+      nickname: nickname ?? `Dev ${label}`,
       email: `${role.toLowerCase()}@test.com`,
       role,
     })
@@ -56,9 +77,7 @@ function DevAuthPanel() {
               const isActive =
                 isAuthenticated &&
                 user?.role === option.role &&
-                (option.id == null
-                  ? user?.id == null || user?.id !== 100
-                  : user?.id === option.id)
+                user?.id === option.id
               return (
                 <button
                   key={`${option.role}-${option.id ?? 'default'}`}

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.css
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.css
@@ -143,6 +143,39 @@
   color: #6b7280 !important;
 }
 
+/* ── 목록 스타일 복원 ── */
+.post-editor-wrap .wmde-markdown ul {
+  list-style-type: disc !important;
+  padding-left: 2em !important;
+  margin: 0.5em 0 !important;
+}
+.post-editor-wrap .wmde-markdown ol {
+  list-style-type: decimal !important;
+  padding-left: 2em !important;
+  margin: 0.5em 0 !important;
+}
+.post-editor-wrap .wmde-markdown li {
+  margin: 0.25em 0 !important;
+}
+.post-editor-wrap .wmde-markdown ul ul {
+  list-style-type: circle !important;
+}
+.post-editor-wrap .wmde-markdown ul ul ul {
+  list-style-type: square !important;
+}
+
+/* ── 툴바 필 버튼 아이콘 (글꼴·글자크기 드롭다운 아이콘) ── */
+.toolbar-pill-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+/* ── 글자 크기 팝업 최소 너비 ── */
+.toolbar-popup--font-size {
+  min-width: 60px;
+}
+
 /* ── 드롭다운 팝업 ── */
 .toolbar-popup {
   background: #fff;

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
@@ -3,26 +3,42 @@ import MDEditor, {
   commands as mdCommands,
   type ICommand,
 } from '@uiw/react-md-editor'
-import {
-  Undo2,
-  Redo2,
-  Underline,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-  AlignJustify,
-  List,
-  ChevronDown,
-  ArrowUpDown,
-  RemoveFormatting,
-  IndentIncrease,
-  IndentDecrease,
-} from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import remarkBreaks from 'remark-breaks'
 import rehypeRaw from 'rehype-raw'
-import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import rehypeSanitize from 'rehype-sanitize'
 import './MarkdownEditor.css'
-import { useGetPresignedUrl } from '@/features/qna/presigned-url'
+import {
+  editorSanitizeSchema,
+  ACCEPTED_IMAGE_TYPES,
+  FONT_FAMILIES,
+  FONT_SIZES,
+  NO_BLUR_PROPS,
+  PILL,
+  UNDO_LIMIT,
+} from './markdownEditorConstants'
+import {
+  applyInlineFromDropdown,
+  wrapWithStyle,
+  computeNextNumber,
+  renumberFrom,
+} from './markdownEditorUtils'
+import {
+  underlineCommand,
+  bgColorCommand,
+  textColorCommand,
+  alignLeftCommand,
+  alignCenterCommand,
+  alignRightCommand,
+  alignJustifyCommand,
+  listDropdownCmd,
+  lineHeightCmd,
+  outdentCmd,
+  indentCmd,
+  clearFormatCmd,
+} from './markdownEditorCommands'
+import { useMarkdownHistory } from './useMarkdownHistory'
+import { useImageUpload } from './useImageUpload'
 
 export interface MarkdownEditorProps {
   value: string
@@ -31,944 +47,215 @@ export interface MarkdownEditorProps {
   actions?: React.ReactNode
 }
 
-// style 속성 허용, blob: 이미지 src 허용, 스크립트/이벤트 핸들러는 차단
-const editorSanitizeSchema = {
-  ...defaultSchema,
-  attributes: {
-    ...defaultSchema.attributes,
-    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style'],
-  },
-  tagNames: [...(defaultSchema.tagNames ?? []), 'u', 'mark'],
-  protocols: {
-    ...defaultSchema.protocols,
-    src: [...(defaultSchema.protocols?.src ?? ['http', 'https']), 'blob'],
-  },
-}
-
-const ACCEPTED_IMAGE_TYPES = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-]
-
-// 웹폰트 로드 실패 시 시스템 폰트(fallback)로 자동 대체됨
-const FONT_FAMILIES = [
-  { label: '기본서체', value: 'inherit' },
-  {
-    label: '노토 산스',
-    value: "'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif",
-  },
-  {
-    label: '나눔고딕',
-    value: "'Nanum Gothic', 'Dotum', '돋움', sans-serif",
-  },
-  {
-    label: '나눔명조',
-    value: "'Nanum Myeongjo', 'Batang', '바탕', serif",
-  },
-  {
-    label: 'Roboto',
-    value: "'Roboto', Arial, Helvetica, sans-serif",
-  },
-  {
-    label: 'Merriweather',
-    value: "'Merriweather', Georgia, 'Times New Roman', serif",
-  },
-  {
-    label: 'Source Code Pro',
-    value: "'Source Code Pro', 'Courier New', Consolas, monospace",
-  },
-]
-
-const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
-
-const TEXT_PALETTE_COLORS = [
-  '#ffffff', // 흰색 (배경이 어두울 때 사용)
-  '#000000',
-  '#434343',
-  '#666666',
-  '#999999',
-  '#b7b7b7',
-  '#ff0000',
-  '#ff7700',
-  '#ffff00',
-  '#00ff00',
-  '#0000ff',
-  '#9900ff',
-  '#ff00ff',
-  '#00ffff',
-  '#ff6d6d',
-  '#ffd966',
-  '#93c47d',
-  '#76a5af',
-  '#4a86e8',
-  '#8e7cc3',
-  '#c27ba0',
-]
-
-// 배경색 전용 팔레트: 흰색 + 배경 제거(투명) 포함
-const BG_PALETTE_COLORS = ['#ffffff', ...TEXT_PALETTE_COLORS]
-
-// 버튼 클릭 시 textarea 포커스/선택 영역 유지를 위한 공통 props
-const NO_BLUR_PROPS = {
-  onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-}
-
-const PILL: React.CSSProperties = {
-  borderRadius: 6,
-  background: '#f0f2f5',
-  border: '1px solid #e2e8f0',
-  padding: '0 10px',
-  height: 26,
-  width: 'auto',
-  minWidth: 'auto',
-  fontSize: 12,
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 4,
-  cursor: 'pointer',
-  color: '#374151',
-  fontWeight: 400,
-}
-
-type EditorState = {
-  selectedText: string
-  text: string
-  selection: { start: number; end: number }
-}
-
-/** getState() 결과에서 전체 상태를 안전하게 꺼냅니다. */
-function safeGetState(
-  getState?: () => false | EditorState
-): EditorState | null {
-  const s = getState?.()
-  return s && 'text' in s ? s : null
-}
-
-/** 커서가 HTML 태그 내부(<...> 사이)에 있는지 확인합니다. */
-function isCursorInsideTag(text: string, cursor: number): boolean {
-  const lastOpen = text.lastIndexOf('<', cursor - 1)
-  if (lastOpen === -1) return false
-  const lastClose = text.lastIndexOf('>', cursor - 1)
-  return lastOpen > lastClose
-}
-
-/** 커서 위치 기준 현재 단어 범위를 반환합니다 (인라인 서식용).
- *  HTML 태그 문자(<, >)에서 단어 경계로 처리해 태그 내용 선택을 방지합니다. */
-function getWordRange(
-  text: string,
-  cursor: number
-): { start: number; end: number } | null {
-  if (isCursorInsideTag(text, cursor)) return null
-  let start = cursor
-  let end = cursor
-  while (start > 0 && /[^\s<>]/.test(text[start - 1])) start--
-  while (end < text.length && /[^\s<>]/.test(text[end])) end++
-  return start < end ? { start, end } : null
-}
-
-/** 커서를 감싸는 가장 가까운 <span style="...">...</span> 의 범위를 반환합니다.
- *  이미 스타일이 적용된 span에 다시 서식을 적용할 때 중첩 방지용으로 사용합니다.
- *  커서가 </span> 바로 뒤(spanEnd)에 있는 경우도 포함합니다. */
-function getEnclosingSpanRange(
-  text: string,
-  cursor: number
-): { start: number; end: number } | null {
-  // 순방향으로 모든 <span>을 찾아 커서가 포함되는지 확인합니다.
-  // cursor <= spanEnd 조건으로 </span> 바로 뒤에 커서가 있을 때도 매칭됩니다.
-  const spanOpenRe = /<span\b[^>]*>/gi
-  let match: RegExpExecArray | null
-  while ((match = spanOpenRe.exec(text)) !== null) {
-    const spanStart = match.index
-    const openEnd = spanStart + match[0].length
-    const closeIdx = text.indexOf('</span>', openEnd)
-    if (closeIdx === -1) continue
-    const spanEnd = closeIdx + '</span>'.length
-    if (cursor >= spanStart && cursor <= spanEnd) {
-      return { start: spanStart, end: spanEnd }
-    }
-  }
-  return null
-}
-
-/** 커서 위치 기준 현재 줄 범위를 반환합니다 (블록 서식용). */
-function getLineRange(
-  text: string,
-  cursor: number
-): { start: number; end: number } | null {
-  if (isCursorInsideTag(text, cursor)) return null
-  let start = cursor
-  let end = cursor
-  while (start > 0 && text[start - 1] !== '\n') start--
-  while (end < text.length && text[end] !== '\n') end++
-  return start < end ? { start, end } : null
-}
-
-/**
- * execute 핸들러에서 선택 영역이 없으면 현재 단어를 자동 선택 후 wrapFn 적용.
- * 인라인 서식(밑줄, 글자색 등)에 사용합니다.
- */
-function applyInline(
-  state: EditorState,
-  api: {
-    replaceSelection: (t: string) => void
-    setSelectionRange: (r: { start: number; end: number }) => void
-  },
-  wrapFn: (text: string) => string
-) {
-  if (state.selectedText) {
-    api.replaceSelection(wrapFn(state.selectedText))
-    return
-  }
-  const range = getWordRange(state.text, state.selection.start)
-  if (range) {
-    api.setSelectionRange(range)
-    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
-  }
-}
-
-/**
- * execute 핸들러에서 선택 영역이 없으면 현재 줄을 자동 선택 후 wrapFn 적용.
- * 블록 서식(정렬, 들여쓰기 등)에 사용합니다.
- */
-function applyBlock(
-  state: EditorState,
-  api: {
-    replaceSelection: (t: string) => void
-    setSelectionRange: (r: { start: number; end: number }) => void
-  },
-  wrapFn: (text: string) => string
-) {
-  if (state.selectedText) {
-    api.replaceSelection(wrapFn(state.selectedText))
-    return
-  }
-  const range = getLineRange(state.text, state.selection.start)
-  if (range) {
-    api.setSelectionRange(range)
-    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
-  }
-}
-
-/**
- * 드롭다운 children 핸들러용 인라인 서식 적용.
- * 선택 영역 있음 → 선택 텍스트에 적용.
- * 선택 영역 없음 → 커서를 감싸는 기존 <span> 전체를 교체(스타일 코드 중첩 방지).
- *               → span 없으면 현재 단어를 선택해 적용.
- */
-type TextApiWithElement = {
-  replaceSelection: (t: string) => void
-  setSelectionRange: (r: { start: number; end: number }) => void
-  textArea?: HTMLTextAreaElement
-}
-
-/**
- * textarea 값을 직접 교체하고 React onChange를 트리거합니다.
- * setSelectionRange → replaceSelection 순서에서 insertTextAtPosition 내부의
- * focus() 호출이 selection을 리셋하는 문제를 우회합니다.
- *
- * React native property setter hack:
- * 원래 HTMLTextAreaElement.prototype.value setter를 호출하면 React가 변경을
- * "dirty"로 인식한 뒤 input 이벤트에서 onChange를 정상 호출합니다.
- */
-function replaceInText(
-  textApi: TextApiWithElement,
-  fullText: string,
-  start: number,
-  end: number,
-  replacement: string
-): boolean {
-  const ta = textApi.textArea
-  if (!ta) return false
-  const newValue = fullText.slice(0, start) + replacement + fullText.slice(end)
-  const nativeSetter = Object.getOwnPropertyDescriptor(
-    HTMLTextAreaElement.prototype,
-    'value'
-  )?.set
-  if (!nativeSetter) return false
-  nativeSetter.call(ta, newValue)
-  ta.dispatchEvent(new Event('input', { bubbles: true }))
-  ta.selectionStart = ta.selectionEnd = start + replacement.length
-  return true
-}
-
-/**
- * 드롭다운 children 핸들러용 인라인 서식 적용.
- *
- * 우선순위:
- * 1. 커서가 기존 <span> 안에 있으면 → span 전체를 교체 (선택 여부 무관, 중첩 방지)
- * 2. 선택 영역 있음 → 선택 텍스트에 적용
- * 3. 선택 없음 → 현재 단어 선택 후 적용
- * 4. 아무것도 없으면 → 아무것도 하지 않음 (빈 span 삽입 방지)
- *
- * replaceInText를 우선 사용해 setSelectionRange + replaceSelection 패턴에서
- * 발생하는 focus() → selection 리셋 문제를 방지합니다.
- */
-function applyInlineFromDropdown(
-  getState: (() => false | EditorState) | undefined,
-  textApi: TextApiWithElement | undefined,
-  wrapFn: (text: string) => string
-) {
-  const s = safeGetState(getState)
-  if (!s || !textApi) return
-
-  // 1. 커서 시작 위치가 기존 <span> 안이면 span 전체를 교체 (중첩 방지)
-  const spanRange = getEnclosingSpanRange(s.text, s.selection.start)
-  if (spanRange) {
-    const innerText = s.text.slice(spanRange.start, spanRange.end)
-    const replacement = wrapFn(innerText)
-    if (
-      !replaceInText(
-        textApi,
-        s.text,
-        spanRange.start,
-        spanRange.end,
-        replacement
-      )
-    ) {
-      textApi.setSelectionRange(spanRange)
-      textApi.replaceSelection(replacement)
-    }
-    return
-  }
-
-  // 2. 선택 영역이 있으면 선택 텍스트에 적용
-  if (s.selectedText) {
-    const replacement = wrapFn(s.selectedText)
-    if (
-      !replaceInText(
-        textApi,
-        s.text,
-        s.selection.start,
-        s.selection.end,
-        replacement
-      )
-    ) {
-      textApi.replaceSelection(replacement)
-    }
-    return
-  }
-
-  // 3. 선택 없음 → 현재 단어를 선택 후 적용
-  const wordRange = getWordRange(s.text, s.selection.start)
-  if (wordRange) {
-    const innerText = s.text.slice(wordRange.start, wordRange.end)
-    const replacement = wrapFn(innerText)
-    if (
-      !replaceInText(
-        textApi,
-        s.text,
-        wordRange.start,
-        wordRange.end,
-        replacement
-      )
-    ) {
-      textApi.setSelectionRange(wordRange)
-      textApi.replaceSelection(replacement)
-    }
-  }
-  // 4. 아무것도 없으면 종료 (빈 <span></span> 삽입 안 함)
-}
-
-/**
- * 드롭다운 children 핸들러용 블록 서식 적용.
- * 선택 있음 → 선택 텍스트에 적용.
- * 선택 없음 → wrapFn('') 를 커서 위치에 삽입.
- */
-function applyBlockFromDropdown(
-  getState: (() => false | EditorState) | undefined,
-  textApi: TextApiWithElement | undefined,
-  wrapFn: (text: string) => string
-) {
-  const s = safeGetState(getState)
-  if (!s || !textApi) return
-  if (s.selectedText) {
-    textApi.replaceSelection(wrapFn(s.selectedText))
-    return
-  }
-  textApi.replaceSelection(wrapFn(''))
-}
-
-/**
- * 목록 전용 삽입 함수.
- * 선택 있음 → 각 줄 앞에 prefix 추가.
- * 선택 없음 → 현재 줄의 맨 앞으로 커서 이동 후 prefix 삽입.
- *   textarea.selectionStart/End 를 직접 수정해 setSelectionRange(→ focus()) 호출을 피합니다.
- */
-function insertListPrefix(
-  getState: (() => false | EditorState) | undefined,
-  textApi: TextApiWithElement | undefined,
-  prefix: string
-) {
-  const s = safeGetState(getState)
-  if (!s || !textApi) return
-
-  if (s.selectedText) {
-    const lines = s.selectedText
-      .split('\n')
-      .map((l) => `${prefix}${l}`)
-      .join('\n')
-    textApi.replaceSelection(lines)
-    return
-  }
-
-  // 선택 없음: 줄 시작 위치를 계산하고 직접 selectionStart/End 설정
-  const lineStart = s.text.lastIndexOf('\n', s.selection.start - 1) + 1
-  const ta = (textApi as TextApiWithElement).textArea
-  if (ta) {
-    ta.selectionStart = lineStart
-    ta.selectionEnd = lineStart
-  }
-  textApi.replaceSelection(prefix)
-}
-
-/**
- * 선택 텍스트가 이미 <span style="..."> 이면 해당 CSS 속성만 교체/추가하고,
- * 그렇지 않으면 새 <span>으로 감쌉니다.
- * 중첩 span 누적을 방지합니다.
- */
-function wrapWithStyle(
-  selected: string,
-  property: string,
-  value: string
-): string {
-  const match = selected.match(/^<span style="([^"]*)">([\s\S]*)<\/span>$/)
-  if (match) {
-    const existingStyle = match[1]
-    const inner = match[2]
-    const propRe = new RegExp(`(^|;\\s*)${property}\\s*:[^;]*`, 'i')
-    let newStyle: string
-    if (propRe.test(existingStyle)) {
-      newStyle = existingStyle
-        .replace(
-          new RegExp(`${property}\\s*:[^;]*`, 'i'),
-          `${property}: ${value}`
-        )
-        .replace(/^;\s*/, '')
-        .trim()
-    } else if (existingStyle) {
-      newStyle = `${existingStyle}; ${property}: ${value}`
-    } else {
-      newStyle = `${property}: ${value}`
-    }
-    return `<span style="${newStyle}">${inner}</span>`
-  }
-  return `<span style="${property}: ${value}">${selected}</span>`
-}
-
-/**
- * 선택 텍스트가 이미 <mark style="..."> 이면 background-color만 교체하고,
- * 그렇지 않으면 새 <mark>으로 감쌉니다.
- */
-function wrapMarkWithStyle(selected: string, color: string): string {
-  const match = selected.match(/^<mark style="([^"]*)">([\s\S]*)<\/mark>$/)
-  if (match) {
-    const existingStyle = match[1]
-    const inner = match[2]
-    const newStyle = existingStyle
-      .replace(/background-color\s*:[^;]*/i, `background-color: ${color}`)
-      .replace(/^;\s*/, '')
-      .trim()
-    return `<mark style="${newStyle}">${inner}</mark>`
-  }
-  return `<mark style="background-color: ${color}">${selected}</mark>`
-}
-
-/**
- * 선택 텍스트가 이미 <div style="..."> 이면 해당 CSS 속성만 교체/추가하고,
- * 그렇지 않으면 새 <div>로 감쌉니다.
- * 중첩 div 누적을 방지합니다.
- */
-function wrapDivWithStyle(
-  selected: string,
-  property: string,
-  value: string
-): string {
-  const match = selected.match(/^<div style="([^"]*)">([\s\S]*)<\/div>$/)
-  if (match) {
-    const existingStyle = match[1]
-    const inner = match[2]
-    const propRe = new RegExp(`${property}\\s*:[^;]*`, 'i')
-    let newStyle: string
-    if (propRe.test(existingStyle)) {
-      newStyle = existingStyle
-        .replace(propRe, `${property}: ${value}`)
-        .replace(/^;\s*/, '')
-        .trim()
-    } else if (existingStyle) {
-      newStyle = `${existingStyle}; ${property}: ${value}`
-    } else {
-      newStyle = `${property}: ${value}`
-    }
-    return `<div style="${newStyle}">${inner}</div>`
-  }
-  return `<div style="${property}: ${value}">${selected}</div>`
-}
-
-/** 커서를 감싸는 <u>...</u> 범위를 반환합니다. </u> 바로 뒤 커서도 포함합니다. */
-function getEnclosingURange(
-  text: string,
-  cursor: number
-): { start: number; end: number } | null {
-  const re = /<u>/gi
-  let m: RegExpExecArray | null
-  while ((m = re.exec(text)) !== null) {
-    const uStart = m.index
-    const closeIdx = text.indexOf('</u>', uStart + m[0].length)
-    if (closeIdx === -1) continue
-    const uEnd = closeIdx + '</u>'.length
-    if (cursor >= uStart && cursor <= uEnd) {
-      return { start: uStart, end: uEnd }
-    }
-  }
-  return null
-}
-
-/** 밑줄 토글: 커서가 <u> 안에 있거나 선택 텍스트가 <u>로 감싸져 있으면 제거, 아니면 추가 */
-const underlineCommand: ICommand = {
-  name: 'underline',
-  keyCommand: 'underline',
-  buttonProps: {
-    'aria-label': '밑줄',
-    title: '밑줄',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <Underline size={14} />,
-  execute: (state, api) => {
-    // 선택 없이 커서가 <u>...</u> 안에 있으면 → <u> 전체 선택 후 제거
-    if (!state.selectedText) {
-      const uRange = getEnclosingURange(state.text, state.selection.start)
-      if (uRange) {
-        const inner = state.text.slice(
-          uRange.start + '<u>'.length,
-          uRange.end - '</u>'.length
-        )
-        api.setSelectionRange(uRange)
-        api.replaceSelection(inner)
-        return
-      }
-    }
-    applyInline(state, api, (text) => {
-      const uMatch = text.match(/^<u>([\s\S]*)<\/u>$/)
-      return uMatch ? uMatch[1] : `<u>${text}</u>`
-    })
-  },
-}
-
-function makeColorCommand(
-  name: string,
-  label: string,
-  icon: React.ReactElement,
-  colors: string[],
-  wrap: (color: string, text: string) => string
-): ICommand {
-  return {
-    name,
-    keyCommand: 'group',
-    groupName: name,
-    // onMouseDown: preventDefault → 팔레트 클릭 시 에디터 포커스/선택 영역 유지
-    buttonProps: {
-      'aria-label': label,
-      title: label,
-      onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
-        e.preventDefault(),
-    },
-    icon,
-    children: ({ close, getState, textApi }) => (
-      <div className="color-palette" onMouseDown={(e) => e.preventDefault()}>
-        {colors.map((color) => (
-          <div
-            key={color}
-            className="color-swatch"
-            style={{ background: color }}
-            data-white={color === '#ffffff' ? 'true' : undefined}
-            title={color === '#ffffff' ? '흰색' : color}
-            onClick={() => {
-              applyInlineFromDropdown(getState, textApi, (t) => wrap(color, t))
-              close()
-            }}
-          />
-        ))}
-      </div>
-    ),
-    execute: () => {},
-  }
-}
-
-const bgColorCommand: ICommand = {
-  name: 'bg-color',
-  keyCommand: 'group',
-  groupName: 'bg-color',
-  buttonProps: {
-    'aria-label': '배경색',
-    title: '배경색',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      <span
-        style={{
-          width: 16,
-          height: 16,
-          borderRadius: 3,
-          background: '#4285f4',
-          border: '1px solid rgba(0,0,0,0.12)',
-          display: 'inline-block',
-        }}
-      />
-      <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="bg-color-popup" onMouseDown={(e) => e.preventDefault()}>
-      {/* 배경 제거 버튼 */}
-      <button
-        type="button"
-        className="bg-color-remove-btn"
-        onClick={() => {
-          applyInlineFromDropdown(getState, textApi, (t) =>
-            t.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
-          )
-          close()
-        }}
-      >
-        ✕ 배경 제거
-      </button>
-      {/* 색상 팔레트 */}
-      <div className="color-palette">
-        {BG_PALETTE_COLORS.map((color) => (
-          <div
-            key={color}
-            className="color-swatch"
-            style={{
-              background: color,
-              border:
-                color === '#ffffff'
-                  ? '1px solid #cdcdcd'
-                  : '1px solid rgba(0,0,0,0.12)',
-            }}
-            title={color === '#ffffff' ? '흰색' : color}
-            onClick={() => {
-              applyInlineFromDropdown(getState, textApi, (t) =>
-                wrapMarkWithStyle(t, color)
-              )
-              close()
-            }}
-          />
-        ))}
-      </div>
-    </div>
-  ),
-  execute: () => {},
-}
-
-const textColorCommand = makeColorCommand(
-  'text-color',
-  '글자색',
-  <span
-    style={{
-      display: 'inline-flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: 2,
-      lineHeight: 1,
-    }}
-  >
-    <span style={{ fontWeight: 700, fontSize: 13 }}>A</span>
-    <span
-      style={{
-        width: 14,
-        height: 3,
-        background: '#e53e3e',
-        borderRadius: 1,
-        display: 'block',
-      }}
-    />
-  </span>,
-  TEXT_PALETTE_COLORS,
-  (color, text) => wrapWithStyle(text, 'color', color)
-)
-
-const alignLeftCommand: ICommand = {
-  name: 'align-left',
-  keyCommand: 'align-left',
-  buttonProps: {
-    'aria-label': '왼쪽 정렬',
-    title: '왼쪽 정렬',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <AlignLeft size={14} />,
-  execute: (state, api) =>
-    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'left')),
-}
-
-const alignCenterCommand: ICommand = {
-  name: 'align-center',
-  keyCommand: 'align-center',
-  buttonProps: {
-    'aria-label': '가운데 정렬',
-    title: '가운데 정렬',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <AlignCenter size={14} />,
-  execute: (state, api) =>
-    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'center')),
-}
-
-const alignRightCommand: ICommand = {
-  name: 'align-right',
-  keyCommand: 'align-right',
-  buttonProps: {
-    'aria-label': '오른쪽 정렬',
-    title: '오른쪽 정렬',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <AlignRight size={14} />,
-  execute: (state, api) =>
-    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'right')),
-}
-
-const alignJustifyCommand: ICommand = {
-  name: 'align-justify',
-  keyCommand: 'align-justify',
-  buttonProps: {
-    'aria-label': '양쪽 정렬',
-    title: '양쪽 정렬',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <AlignJustify size={14} />,
-  execute: (state, api) =>
-    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'justify')),
-}
-
-const listDropdownCmd: ICommand = {
-  name: 'list-style',
-  keyCommand: 'group',
-  groupName: 'list-style',
-  buttonProps: {
-    'aria-label': '목록',
-    title: '목록',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
-      <List size={13} />
-      <ChevronDown size={10} />
-    </span>
-  ),
-  children: ({ close, getState, textApi }) => (
-    <div className="toolbar-popup" onMouseDown={(e) => e.preventDefault()}>
-      <button
-        type="button"
-        onClick={() => {
-          insertListPrefix(getState, textApi, '- ')
-          close()
-        }}
-      >
-        글머리 목록
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          insertListPrefix(getState, textApi, '1. ')
-          close()
-        }}
-      >
-        번호 목록
-      </button>
-      <button
-        type="button"
-        onClick={() => {
-          insertListPrefix(getState, textApi, '- [ ] ')
-          close()
-        }}
-      >
-        체크 목록
-      </button>
-    </div>
-  ),
-  execute: () => {},
-}
-
-const lineHeightCmd: ICommand = {
-  name: 'line-height',
-  keyCommand: 'group',
-  groupName: 'line-height',
-  buttonProps: {
-    'aria-label': '줄 간격',
-    title: '줄 간격',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <ArrowUpDown size={14} />,
-  children: ({ close, getState, textApi }) => (
-    <div
-      className="toolbar-popup"
-      style={{ minWidth: 80 }}
-      onMouseDown={(e) => e.preventDefault()}
-    >
-      {['1', '1.5', '2', '2.5', '3'].map((h) => (
-        <button
-          key={h}
-          type="button"
-          onClick={() => {
-            applyBlockFromDropdown(getState, textApi, (t) =>
-              wrapDivWithStyle(t, 'line-height', h)
-            )
-            close()
-          }}
-        >
-          {h}배
-        </button>
-      ))}
-    </div>
-  ),
-  execute: () => {},
-}
-
-const outdentCmd: ICommand = {
-  name: 'outdent',
-  keyCommand: 'outdent',
-  buttonProps: {
-    'aria-label': '내어쓰기',
-    title: '내어쓰기',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <IndentDecrease size={14} />,
-  execute: (state, api) =>
-    applyBlock(state, api, (t) =>
-      t
-        .split('\n')
-        .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
-        .join('\n')
-    ),
-}
-
-const indentCmd: ICommand = {
-  name: 'indent',
-  keyCommand: 'indent',
-  buttonProps: {
-    'aria-label': '들여쓰기',
-    title: '들여쓰기',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <IndentIncrease size={14} />,
-  execute: (state, api) =>
-    applyBlock(state, api, (t) =>
-      t
-        .split('\n')
-        .map((l) => `  ${l}`)
-        .join('\n')
-    ),
-}
-
-const clearFormatCmd: ICommand = {
-  name: 'clear-format',
-  keyCommand: 'clear-format',
-  buttonProps: {
-    'aria-label': '서식 제거',
-    title: '서식 제거',
-    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
-  },
-  icon: <RemoveFormatting size={14} />,
-  execute: (state, api) =>
-    applyInline(state, api, (t) =>
-      t
-        .replace(/\*\*(.*?)\*\*/gs, '$1')
-        .replace(/\*(.*?)\*/gs, '$1')
-        .replace(/~~(.*?)~~/gs, '$1')
-        .replace(/<[^>]+>/gs, '')
-    ),
-}
-
-const UNDO_LIMIT = 50
-
 export function MarkdownEditor({
   value,
   onChange,
   error,
   actions,
 }: MarkdownEditorProps) {
-  const { mutateAsync: getPresignedUrl } = useGetPresignedUrl()
-  const [isUploading, setIsUploading] = useState(false)
-  const [imageError, setImageError] = useState<string | null>(null)
-  const [undoStack, setUndoStack] = useState<string[]>([])
-  const [redoStack, setRedoStack] = useState<string[]>([])
   const [selectedFontLabel, setSelectedFontLabel] = useState('기본서체')
   const [selectedFontSize, setSelectedFontSize] = useState(16)
-  const valueRef = useRef(value)
-  const objectUrlsRef = useRef<Set<string>>(new Set())
   const [isDragOver, setIsDragOver] = useState(false)
   const dragCounterRef = useRef(0)
+  const editorWrapRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    valueRef.current = value
-  }, [value])
+  const {
+    valueRef,
+    setUndoStack,
+    setRedoStack,
+    handleChange,
+    undoCommand,
+    redoCommand,
+  } = useMarkdownHistory(value, onChange)
 
+  const { isUploading, imageError, uploadImageFile, imageCommand } =
+    useImageUpload(valueRef, onChange)
+
+  // Tab / Enter 인터셉트: 들여쓰기된 목록 항목의 번호·연속성 처리
+  // wrap(부모)에 capture 등록 → 라이브러리 textarea 리스너보다 반드시 먼저 실행됨
   useEffect(() => {
-    const urls = objectUrlsRef.current
-    return () => {
-      urls.forEach((url) => URL.revokeObjectURL(url))
+    const wrap = editorWrapRef.current
+    if (!wrap) return
+
+    const applyText = (
+      ta: HTMLTextAreaElement,
+      newText: string,
+      cursor: number
+    ) => {
+      const nativeSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value'
+      )?.set
+      if (!nativeSetter) return
+      nativeSetter.call(ta, newText)
+      ta.dispatchEvent(new Event('input', { bubbles: true }))
+      ta.selectionStart = ta.selectionEnd = cursor
     }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.target instanceof HTMLTextAreaElement)) return
+      const ta = e.target
+      const text = ta.value
+      const cursor = ta.selectionStart
+      const lineStart = text.lastIndexOf('\n', cursor - 1) + 1
+      const lineEndRaw = text.indexOf('\n', cursor)
+      const lineEnd = lineEndRaw === -1 ? text.length : lineEndRaw
+      const line = text.slice(lineStart, lineEnd)
+
+      // ── Tab / Shift+Tab: 번호 목록 들여쓰기 + 번호 재정규화 ──
+      if (e.key === 'Tab') {
+        const match = line.match(/^(\s*)(\d+)\. (.*)/)
+        if (!match) return
+
+        e.preventDefault()
+        e.stopPropagation()
+
+        const currentIndent = match[1]
+        const content = match[3]
+        const lines = text.split('\n')
+        const lineIndex = (text.slice(0, lineStart).match(/\n/g) ?? []).length
+
+        let newLineStr: string
+        let newLines: string[]
+
+        if (!e.shiftKey) {
+          // Tab: 3칸 들여쓰기 + 번호 1로 초기화
+          const newIndent = currentIndent + '   '
+          newLineStr = `${newIndent}1. ${content}`
+          newLines = renumberFrom(
+            [
+              ...lines.slice(0, lineIndex),
+              newLineStr,
+              ...lines.slice(lineIndex + 1),
+            ],
+            lineIndex + 1,
+            currentIndent
+          )
+        } else {
+          // Shift+Tab: 3칸 내어쓰기 + 부모 레벨 번호 계산
+          if (currentIndent.length < 3) return
+          const newIndent = currentIndent.slice(3)
+          const num = computeNextNumber(lines, lineIndex, newIndent)
+          newLineStr = `${newIndent}${num}. ${content}`
+          newLines = renumberFrom(
+            [
+              ...lines.slice(0, lineIndex),
+              newLineStr,
+              ...lines.slice(lineIndex + 1),
+            ],
+            lineIndex + 1,
+            newIndent
+          )
+        }
+
+        const newText = newLines.join('\n')
+        const newLineStart =
+          lineIndex === 0
+            ? 0
+            : newLines.slice(0, lineIndex).join('\n').length + 1
+        applyText(ta, newText, newLineStart + newLineStr.length)
+        return
+      }
+
+      // ── Enter: 들여쓰기된 목록 항목 연속 생성 ──
+      // 라이브러리는 indent 있는 항목을 인식 못함 → 여기서 처리
+      // isComposing=true: 한글 IME 조합 중 Enter → 글자 확정만 하고 줄바꿈은 다음 이벤트에서 처리
+      if (
+        e.key === 'Enter' &&
+        !e.shiftKey &&
+        !e.isComposing &&
+        ta.selectionStart === ta.selectionEnd
+      ) {
+        // 들여쓰기된 번호 목록 (비어있지 않은 항목)
+        const orderedMatch = line.match(/^( +)(\d+)\. (.+)/)
+        if (orderedMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent, numStr] = orderedMatch
+          const insertion = `\n${indent}${parseInt(numStr, 10) + 1}. `
+          const newText = text.slice(0, cursor) + insertion + text.slice(cursor)
+          applyText(ta, newText, cursor + insertion.length)
+          return
+        }
+
+        // 들여쓰기된 번호 목록 (빈 항목 → 상위 레벨로 복귀)
+        const orderedEmptyMatch = line.match(/^( +)(\d+)\. $/)
+        if (orderedEmptyMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent] = orderedEmptyMatch
+          const newIndent = indent.length >= 3 ? indent.slice(3) : ''
+          const lines = text.split('\n')
+          const lineIndex = (text.slice(0, lineStart).match(/\n/g) ?? []).length
+          const num = computeNextNumber(lines, lineIndex, newIndent)
+          const nextItem = newIndent ? `${newIndent}${num}. ` : `${num}. `
+          // 빈 하위 항목 줄을 상위 항목으로 교체
+          const newText =
+            text.slice(0, lineStart) + nextItem + text.slice(lineEnd)
+          applyText(ta, newText, lineStart + nextItem.length)
+          return
+        }
+
+        // 들여쓰기된 글머리 목록 (비어있지 않은 항목)
+        const bulletMatch = line.match(/^( +)([-*]) (.+)/)
+        if (bulletMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent, bullet] = bulletMatch
+          const insertion = `\n${indent}${bullet} `
+          const newText = text.slice(0, cursor) + insertion + text.slice(cursor)
+          applyText(ta, newText, cursor + insertion.length)
+          return
+        }
+
+        // 들여쓰기된 글머리 목록 (빈 항목 → 상위 레벨로 복귀)
+        const bulletEmptyMatch = line.match(/^( +)([-*]) $/)
+        if (bulletEmptyMatch) {
+          e.preventDefault()
+          e.stopPropagation()
+          const [, indent, bullet] = bulletEmptyMatch
+          const newIndent = indent.length >= 2 ? indent.slice(2) : ''
+          const nextItem = newIndent ? `${newIndent}${bullet} ` : `${bullet} `
+          const newText =
+            text.slice(0, lineStart) + nextItem + text.slice(lineEnd)
+          applyText(ta, newText, lineStart + nextItem.length)
+          return
+        }
+      }
+    }
+
+    wrap.addEventListener('keydown', onKeyDown, true)
+    return () => wrap.removeEventListener('keydown', onKeyDown, true)
   }, [])
 
-  const handleChange = (newValue: string) => {
-    setUndoStack((prev) => {
-      const next = [...prev, valueRef.current]
-      return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
-    })
-    setRedoStack([])
-    onChange(newValue)
-  }
-
-  const handleUndo = useCallback(() => {
-    if (undoStack.length === 0) return
-    const prev = undoStack[undoStack.length - 1]
-    setRedoStack((r) => [...r, valueRef.current])
-    setUndoStack((u) => u.slice(0, -1))
-    onChange(prev)
-  }, [undoStack, onChange])
-
-  const handleRedo = useCallback(() => {
-    if (redoStack.length === 0) return
-    const next = redoStack[redoStack.length - 1]
-    setUndoStack((u) => [...u, valueRef.current])
-    setRedoStack((r) => r.slice(0, -1))
-    onChange(next)
-  }, [redoStack, onChange])
-
-  const undoCommand = useMemo<ICommand>(
-    () => ({
-      name: 'undo',
-      keyCommand: 'undo',
-      buttonProps: {
-        'aria-label': '실행 취소',
-        title: '실행 취소',
-        'data-inactive': undoStack.length === 0 ? 'true' : undefined,
-        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
-          e.preventDefault(),
-      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <Undo2 size={14} />,
-      execute: handleUndo,
-    }),
-    [undoStack.length, handleUndo]
-  )
-
-  const redoCommand = useMemo<ICommand>(
-    () => ({
-      name: 'redo',
-      keyCommand: 'redo',
-      buttonProps: {
-        'aria-label': '다시 실행',
-        title: '다시 실행',
-        'data-inactive': redoStack.length === 0 ? 'true' : undefined,
-        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
-          e.preventDefault(),
-      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-      icon: <Redo2 size={14} />,
-      execute: handleRedo,
-    }),
-    [redoStack.length, handleRedo]
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      dragCounterRef.current = 0
+      setIsDragOver(false)
+      const files = Array.from(e.dataTransfer.files)
+      const imageFiles = files.filter((f) =>
+        ACCEPTED_IMAGE_TYPES.includes(f.type)
+      )
+      if (imageFiles.length === 0) {
+        // 이미지가 아닌 파일 → uploadImageFile 내부의 타입 체크에서 에러 메시지 설정
+        if (files.length > 0) await uploadImageFile(files[0], () => {})
+        return
+      }
+      for (const file of imageFiles) {
+        await uploadImageFile(file, (md) => {
+          const current = valueRef.current
+          const sep = current.length > 0 && !current.endsWith('\n') ? '\n' : ''
+          setUndoStack((prev) => {
+            const next = [...prev, current]
+            return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
+          })
+          setRedoStack([])
+          onChange(current + sep + md)
+        })
+      }
+    },
+    [uploadImageFile, onChange, valueRef, setUndoStack, setRedoStack]
   )
 
   const fontFamilyCommand = useMemo<ICommand>(
@@ -984,7 +271,7 @@ export function MarkdownEditor({
           e.preventDefault(),
       },
       icon: (
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+        <span className="toolbar-pill-icon">
           {selectedFontLabel} <ChevronDown size={10} />
         </span>
       ),
@@ -1026,14 +313,13 @@ export function MarkdownEditor({
           e.preventDefault(),
       },
       icon: (
-        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+        <span className="toolbar-pill-icon">
           {selectedFontSize} <ChevronDown size={10} />
         </span>
       ),
       children: ({ close, getState, textApi }) => (
         <div
-          className="toolbar-popup"
-          style={{ minWidth: 60 }}
+          className="toolbar-popup toolbar-popup--font-size"
           onMouseDown={(e) => e.preventDefault()}
         >
           {FONT_SIZES.map((size) => (
@@ -1056,110 +342,6 @@ export function MarkdownEditor({
       execute: () => {},
     }),
     [selectedFontSize]
-  )
-
-  const uploadImageFile = useCallback(
-    async (file: File, insertFn: (md: string) => void) => {
-      if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-        setImageError('JPG, PNG, GIF, WEBP 형식만 업로드할 수 있습니다.')
-        return
-      }
-      setImageError(null)
-      setIsUploading(true)
-      const objectUrl = URL.createObjectURL(file)
-      objectUrlsRef.current.add(objectUrl)
-      insertFn(`![${file.name}](${objectUrl})`)
-      try {
-        const { presigned_url, img_url } = await getPresignedUrl({
-          file_name: file.name,
-        })
-        try {
-          await fetch(presigned_url, {
-            method: 'PUT',
-            body: file,
-            headers: { 'Content-Type': file.type },
-          })
-        } catch (err) {
-          if (!import.meta.env.DEV) throw err
-          // DEV(MSW) 환경에서는 S3 업로드 실패 무시 — objectUrl로 미리보기 유지
-        }
-        if (!import.meta.env.DEV) {
-          onChange(valueRef.current.replaceAll(objectUrl, img_url))
-          URL.revokeObjectURL(objectUrl)
-          objectUrlsRef.current.delete(objectUrl)
-        }
-      } catch {
-        URL.revokeObjectURL(objectUrl)
-        objectUrlsRef.current.delete(objectUrl)
-        setImageError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.')
-      } finally {
-        setIsUploading(false)
-      }
-    },
-    [getPresignedUrl, onChange]
-  )
-
-  const handleDrop = useCallback(
-    async (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault()
-      dragCounterRef.current = 0
-      setIsDragOver(false)
-      const files = Array.from(e.dataTransfer.files)
-      const imageFiles = files.filter((f) =>
-        ACCEPTED_IMAGE_TYPES.includes(f.type)
-      )
-      if (imageFiles.length === 0) {
-        if (files.length > 0)
-          setImageError('JPG, PNG, GIF, WEBP 형식만 업로드할 수 있습니다.')
-        return
-      }
-      for (const file of imageFiles) {
-        await uploadImageFile(file, (md) => {
-          const current = valueRef.current
-          const sep = current.length > 0 && !current.endsWith('\n') ? '\n' : ''
-          setUndoStack((prev) => {
-            const next = [...prev, current]
-            return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
-          })
-          setRedoStack([])
-          onChange(current + sep + md)
-        })
-      }
-    },
-    [uploadImageFile, onChange]
-  )
-
-  const imageCommand: ICommand = useMemo(
-    () => ({
-      name: 'image',
-      keyCommand: 'image',
-      buttonProps: {
-        'aria-label': '이미지 업로드',
-        title: '이미지 업로드',
-        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
-          e.preventDefault(),
-      },
-      icon: (
-        <svg width="14" height="14" viewBox="0 0 20 20">
-          <path
-            fill="currentColor"
-            d="M15 9c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4-7H1c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 13l-6-5-2 2-4-5-4 6V4h16v11z"
-          />
-        </svg>
-      ),
-      execute: (_state, api) => {
-        const input = document.createElement('input')
-        input.type = 'file'
-        input.accept = ACCEPTED_IMAGE_TYPES.join(',')
-        input.onchange = async () => {
-          const file = input.files?.[0]
-          if (!file) return
-          await uploadImageFile(file, (md) => api.replaceSelection(md))
-        }
-        input.click()
-      },
-    }),
-    [uploadImageFile]
   )
 
   const editorCommands: ICommand[] = useMemo(
@@ -1234,7 +416,11 @@ export function MarkdownEditor({
           <p className="text-primary font-medium">이미지를 여기에 놓으세요</p>
         </div>
       )}
-      <div data-color-mode="light" className="post-editor-wrap">
+      <div
+        data-color-mode="light"
+        className="post-editor-wrap"
+        ref={editorWrapRef}
+      >
         <MDEditor
           value={value}
           onChange={(v) => handleChange(v ?? '')}

--- a/src/components/qna/MarkdownEditor/markdownEditorCommands.ts
+++ b/src/components/qna/MarkdownEditor/markdownEditorCommands.ts
@@ -1,0 +1,415 @@
+import React from 'react'
+import { type ICommand } from '@uiw/react-md-editor'
+import {
+  Underline,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+  List,
+  ChevronDown,
+  ArrowUpDown,
+  RemoveFormatting,
+  IndentIncrease,
+  IndentDecrease,
+} from 'lucide-react'
+import {
+  BG_PALETTE_COLORS,
+  TEXT_PALETTE_COLORS,
+} from './markdownEditorConstants'
+import {
+  applyInline,
+  applyBlock,
+  applyInlineFromDropdown,
+  applyBlockFromDropdown,
+  insertListPrefix,
+  wrapWithStyle,
+  wrapMarkWithStyle,
+  wrapDivWithStyle,
+  getEnclosingURange,
+} from './markdownEditorUtils'
+
+/** 밑줄 토글: 커서가 <u> 안에 있거나 선택 텍스트가 <u>로 감싸져 있으면 제거, 아니면 추가 */
+export const underlineCommand: ICommand = {
+  name: 'underline',
+  keyCommand: 'underline',
+  buttonProps: {
+    'aria-label': '밑줄',
+    title: '밑줄',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(Underline, { size: 14 }),
+  execute: (state, api) => {
+    // 선택 없이 커서가 <u>...</u> 안에 있으면 → <u> 전체 선택 후 제거
+    if (!state.selectedText) {
+      const uRange = getEnclosingURange(state.text, state.selection.start)
+      if (uRange) {
+        const inner = state.text.slice(
+          uRange.start + '<u>'.length,
+          uRange.end - '</u>'.length
+        )
+        api.setSelectionRange(uRange)
+        api.replaceSelection(inner)
+        return
+      }
+    }
+    applyInline(state, api, (text) => {
+      const uMatch = text.match(/^<u>([\s\S]*)<\/u>$/)
+      return uMatch ? uMatch[1] : `<u>${text}</u>`
+    })
+  },
+}
+
+export function makeColorCommand(
+  name: string,
+  label: string,
+  icon: React.ReactElement,
+  colors: string[],
+  wrap: (color: string, text: string) => string
+): ICommand {
+  return {
+    name,
+    keyCommand: 'group',
+    groupName: name,
+    // onMouseDown: preventDefault → 팔레트 클릭 시 에디터 포커스/선택 영역 유지
+    buttonProps: {
+      'aria-label': label,
+      title: label,
+      onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+        e.preventDefault(),
+    },
+    icon,
+    children: ({ close, getState, textApi }) =>
+      React.createElement(
+        'div',
+        {
+          className: 'color-palette',
+          onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+        },
+        colors.map((color) =>
+          React.createElement('div', {
+            key: color,
+            className: 'color-swatch',
+            style: { background: color },
+            'data-white': color === '#ffffff' ? 'true' : undefined,
+            title: color === '#ffffff' ? '흰색' : color,
+            onClick: () => {
+              applyInlineFromDropdown(getState, textApi, (t) => wrap(color, t))
+              close()
+            },
+          })
+        )
+      ),
+    execute: () => {},
+  }
+}
+
+export const bgColorCommand: ICommand = {
+  name: 'bg-color',
+  keyCommand: 'group',
+  groupName: 'bg-color',
+  buttonProps: {
+    'aria-label': '배경색',
+    title: '배경색',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(
+    'span',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: 3 } },
+    React.createElement('span', {
+      style: {
+        width: 16,
+        height: 16,
+        borderRadius: 3,
+        background: '#4285f4',
+        border: '1px solid rgba(0,0,0,0.12)',
+        display: 'inline-block',
+      },
+    }),
+    React.createElement(ChevronDown, { size: 10 })
+  ),
+  children: ({ close, getState, textApi }) =>
+    React.createElement(
+      'div',
+      {
+        className: 'bg-color-popup',
+        onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+      },
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          className: 'bg-color-remove-btn',
+          onClick: () => {
+            applyInlineFromDropdown(getState, textApi, (t) =>
+              t.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
+            )
+            close()
+          },
+        },
+        '✕ 배경 제거'
+      ),
+      React.createElement(
+        'div',
+        { className: 'color-palette' },
+        BG_PALETTE_COLORS.map((color) =>
+          React.createElement('div', {
+            key: color,
+            className: 'color-swatch',
+            style: {
+              background: color,
+              border:
+                color === '#ffffff'
+                  ? '1px solid #cdcdcd'
+                  : '1px solid rgba(0,0,0,0.12)',
+            },
+            title: color === '#ffffff' ? '흰색' : color,
+            onClick: () => {
+              applyInlineFromDropdown(getState, textApi, (t) =>
+                wrapMarkWithStyle(t, color)
+              )
+              close()
+            },
+          })
+        )
+      )
+    ),
+  execute: () => {},
+}
+
+export const textColorCommand: ICommand = makeColorCommand(
+  'text-color',
+  '글자색',
+  React.createElement(
+    'span',
+    {
+      style: {
+        display: 'inline-flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 2,
+        lineHeight: 1,
+      },
+    },
+    React.createElement(
+      'span',
+      { style: { fontWeight: 700, fontSize: 13 } },
+      'A'
+    ),
+    React.createElement('span', {
+      style: {
+        width: 14,
+        height: 3,
+        background: '#e53e3e',
+        borderRadius: 1,
+        display: 'block',
+      },
+    })
+  ),
+  TEXT_PALETTE_COLORS,
+  (color, text) => wrapWithStyle(text, 'color', color)
+)
+
+export const alignLeftCommand: ICommand = {
+  name: 'align-left',
+  keyCommand: 'align-left',
+  buttonProps: {
+    'aria-label': '왼쪽 정렬',
+    title: '왼쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignLeft, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'left')),
+}
+
+export const alignCenterCommand: ICommand = {
+  name: 'align-center',
+  keyCommand: 'align-center',
+  buttonProps: {
+    'aria-label': '가운데 정렬',
+    title: '가운데 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignCenter, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'center')),
+}
+
+export const alignRightCommand: ICommand = {
+  name: 'align-right',
+  keyCommand: 'align-right',
+  buttonProps: {
+    'aria-label': '오른쪽 정렬',
+    title: '오른쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignRight, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'right')),
+}
+
+export const alignJustifyCommand: ICommand = {
+  name: 'align-justify',
+  keyCommand: 'align-justify',
+  buttonProps: {
+    'aria-label': '양쪽 정렬',
+    title: '양쪽 정렬',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(AlignJustify, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) => wrapDivWithStyle(t, 'text-align', 'justify')),
+}
+
+export const listDropdownCmd: ICommand = {
+  name: 'list-style',
+  keyCommand: 'group',
+  groupName: 'list-style',
+  buttonProps: {
+    'aria-label': '목록',
+    title: '목록',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(
+    'span',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: 2 } },
+    React.createElement(List, { size: 13 }),
+    React.createElement(ChevronDown, { size: 10 })
+  ),
+  children: ({ close, getState, textApi }) =>
+    React.createElement(
+      'div',
+      {
+        className: 'toolbar-popup',
+        onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+      },
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => {
+            insertListPrefix(getState, textApi, '- ')
+            close()
+          },
+        },
+        '글머리 목록'
+      ),
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => {
+            insertListPrefix(getState, textApi, '1. ')
+            close()
+          },
+        },
+        '번호 목록'
+      ),
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => {
+            insertListPrefix(getState, textApi, '- [ ] ')
+            close()
+          },
+        },
+        '체크 목록'
+      )
+    ),
+  execute: () => {},
+}
+
+export const lineHeightCmd: ICommand = {
+  name: 'line-height',
+  keyCommand: 'group',
+  groupName: 'line-height',
+  buttonProps: {
+    'aria-label': '줄 간격',
+    title: '줄 간격',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(ArrowUpDown, { size: 14 }),
+  children: ({ close, getState, textApi }) =>
+    React.createElement(
+      'div',
+      {
+        className: 'toolbar-popup',
+        style: { minWidth: 80 },
+        onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+      },
+      ['1', '1.5', '2', '2.5', '3'].map((h) =>
+        React.createElement(
+          'button',
+          {
+            key: h,
+            type: 'button',
+            onClick: () => {
+              applyBlockFromDropdown(getState, textApi, (t) =>
+                wrapDivWithStyle(t, 'line-height', h)
+              )
+              close()
+            },
+          },
+          `${h}배`
+        )
+      )
+    ),
+  execute: () => {},
+}
+
+export const outdentCmd: ICommand = {
+  name: 'outdent',
+  keyCommand: 'outdent',
+  buttonProps: {
+    'aria-label': '내어쓰기',
+    title: '내어쓰기',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(IndentDecrease, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) =>
+      t
+        .split('\n')
+        .map((l) => (l.startsWith('  ') ? l.slice(2) : l))
+        .join('\n')
+    ),
+}
+
+export const indentCmd: ICommand = {
+  name: 'indent',
+  keyCommand: 'indent',
+  buttonProps: {
+    'aria-label': '들여쓰기',
+    title: '들여쓰기',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(IndentIncrease, { size: 14 }),
+  execute: (state, api) =>
+    applyBlock(state, api, (t) =>
+      t
+        .split('\n')
+        .map((l) => `  ${l}`)
+        .join('\n')
+    ),
+}
+
+export const clearFormatCmd: ICommand = {
+  name: 'clear-format',
+  keyCommand: 'clear-format',
+  buttonProps: {
+    'aria-label': '서식 제거',
+    title: '서식 제거',
+    onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+  },
+  icon: React.createElement(RemoveFormatting, { size: 14 }),
+  execute: (state, api) =>
+    applyInline(state, api, (t) =>
+      t
+        .replace(/\*\*(.*?)\*\*/gs, '$1')
+        .replace(/\*(.*?)\*/gs, '$1')
+        .replace(/~~(.*?)~~/gs, '$1')
+        .replace(/<[^>]+>/gs, '')
+    ),
+}

--- a/src/components/qna/MarkdownEditor/markdownEditorConstants.ts
+++ b/src/components/qna/MarkdownEditor/markdownEditorConstants.ts
@@ -76,8 +76,8 @@ export const TEXT_PALETTE_COLORS = [
   '#c27ba0',
 ]
 
-// 배경색 전용 팔레트: 흰색 + 배경 제거(투명) 포함
-export const BG_PALETTE_COLORS = ['#ffffff', ...TEXT_PALETTE_COLORS]
+// 배경색 전용 팔레트 (TEXT_PALETTE_COLORS 첫 번째 요소가 이미 '#ffffff'이므로 그대로 사용)
+export const BG_PALETTE_COLORS = TEXT_PALETTE_COLORS
 
 // 버튼 클릭 시 textarea 포커스/선택 영역 유지를 위한 공통 props
 export const NO_BLUR_PROPS = {

--- a/src/components/qna/MarkdownEditor/markdownEditorConstants.ts
+++ b/src/components/qna/MarkdownEditor/markdownEditorConstants.ts
@@ -1,0 +1,104 @@
+import { defaultSchema } from 'rehype-sanitize'
+
+// style 속성 허용, blob: 이미지 src 허용, 스크립트/이벤트 핸들러는 차단
+export const editorSanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'style'],
+  },
+  tagNames: [...(defaultSchema.tagNames ?? []), 'u', 'mark'],
+  protocols: {
+    ...defaultSchema.protocols,
+    src: [...(defaultSchema.protocols?.src ?? ['http', 'https']), 'blob'],
+  },
+}
+
+export const ACCEPTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]
+
+// 웹폰트 로드 실패 시 시스템 폰트(fallback)로 자동 대체됨
+export const FONT_FAMILIES = [
+  { label: '기본서체', value: 'inherit' },
+  {
+    label: '노토 산스',
+    value: "'Noto Sans KR', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif",
+  },
+  {
+    label: '나눔고딕',
+    value: "'Nanum Gothic', 'Dotum', '돋움', sans-serif",
+  },
+  {
+    label: '나눔명조',
+    value: "'Nanum Myeongjo', 'Batang', '바탕', serif",
+  },
+  {
+    label: 'Roboto',
+    value: "'Roboto', Arial, Helvetica, sans-serif",
+  },
+  {
+    label: 'Merriweather',
+    value: "'Merriweather', Georgia, 'Times New Roman', serif",
+  },
+  {
+    label: 'Source Code Pro',
+    value: "'Source Code Pro', 'Courier New', Consolas, monospace",
+  },
+]
+
+export const FONT_SIZES = [10, 12, 14, 16, 18, 20, 24, 28, 32]
+
+export const TEXT_PALETTE_COLORS = [
+  '#ffffff', // 흰색 (배경이 어두울 때 사용)
+  '#000000',
+  '#434343',
+  '#666666',
+  '#999999',
+  '#b7b7b7',
+  '#ff0000',
+  '#ff7700',
+  '#ffff00',
+  '#00ff00',
+  '#0000ff',
+  '#9900ff',
+  '#ff00ff',
+  '#00ffff',
+  '#ff6d6d',
+  '#ffd966',
+  '#93c47d',
+  '#76a5af',
+  '#4a86e8',
+  '#8e7cc3',
+  '#c27ba0',
+]
+
+// 배경색 전용 팔레트: 흰색 + 배경 제거(투명) 포함
+export const BG_PALETTE_COLORS = ['#ffffff', ...TEXT_PALETTE_COLORS]
+
+// 버튼 클릭 시 textarea 포커스/선택 영역 유지를 위한 공통 props
+export const NO_BLUR_PROPS = {
+  onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) => e.preventDefault(),
+}
+
+export const PILL: React.CSSProperties = {
+  borderRadius: 6,
+  background: '#f0f2f5',
+  border: '1px solid #e2e8f0',
+  padding: '0 10px',
+  height: 26,
+  width: 'auto',
+  minWidth: 'auto',
+  fontSize: 12,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  cursor: 'pointer',
+  color: '#374151',
+  fontWeight: 400,
+}
+
+export const UNDO_LIMIT = 50

--- a/src/components/qna/MarkdownEditor/markdownEditorUtils.ts
+++ b/src/components/qna/MarkdownEditor/markdownEditorUtils.ts
@@ -1,0 +1,435 @@
+export type EditorState = {
+  selectedText: string
+  text: string
+  selection: { start: number; end: number }
+}
+
+export type TextApiWithElement = {
+  replaceSelection: (t: string) => void
+  setSelectionRange: (r: { start: number; end: number }) => void
+  textArea?: HTMLTextAreaElement
+}
+
+/** getState() 결과에서 전체 상태를 안전하게 꺼냅니다. */
+export function safeGetState(
+  getState?: () => false | EditorState
+): EditorState | null {
+  const s = getState?.()
+  return s && 'text' in s ? s : null
+}
+
+/** 커서가 HTML 태그 내부(<...> 사이)에 있는지 확인합니다. */
+export function isCursorInsideTag(text: string, cursor: number): boolean {
+  const lastOpen = text.lastIndexOf('<', cursor - 1)
+  if (lastOpen === -1) return false
+  const lastClose = text.lastIndexOf('>', cursor - 1)
+  return lastOpen > lastClose
+}
+
+/** 커서 위치 기준 현재 단어 범위를 반환합니다 (인라인 서식용).
+ *  HTML 태그 문자(<, >)에서 단어 경계로 처리해 태그 내용 선택을 방지합니다. */
+export function getWordRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  if (isCursorInsideTag(text, cursor)) return null
+  let start = cursor
+  let end = cursor
+  while (start > 0 && /[^\s<>]/.test(text[start - 1])) start--
+  while (end < text.length && /[^\s<>]/.test(text[end])) end++
+  return start < end ? { start, end } : null
+}
+
+/** 커서를 감싸는 가장 가까운 <span style="...">...</span> 의 범위를 반환합니다.
+ *  이미 스타일이 적용된 span에 다시 서식을 적용할 때 중첩 방지용으로 사용합니다.
+ *  커서가 </span> 바로 뒤(spanEnd)에 있는 경우도 포함합니다. */
+export function getEnclosingSpanRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  // 순방향으로 모든 <span>을 찾아 커서가 포함되는지 확인합니다.
+  // cursor <= spanEnd 조건으로 </span> 바로 뒤에 커서가 있을 때도 매칭됩니다.
+  const spanOpenRe = /<span\b[^>]*>/gi
+  let match: RegExpExecArray | null
+  while ((match = spanOpenRe.exec(text)) !== null) {
+    const spanStart = match.index
+    const openEnd = spanStart + match[0].length
+    const closeIdx = text.indexOf('</span>', openEnd)
+    if (closeIdx === -1) continue
+    const spanEnd = closeIdx + '</span>'.length
+    if (cursor >= spanStart && cursor <= spanEnd) {
+      return { start: spanStart, end: spanEnd }
+    }
+  }
+  return null
+}
+
+/** 커서 위치 기준 현재 줄 범위를 반환합니다 (블록 서식용). */
+export function getLineRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  if (isCursorInsideTag(text, cursor)) return null
+  let start = cursor
+  let end = cursor
+  while (start > 0 && text[start - 1] !== '\n') start--
+  while (end < text.length && text[end] !== '\n') end++
+  return start < end ? { start, end } : null
+}
+
+/**
+ * 번호 목록에서 Tab/Shift+Tab 시 들여쓰기 레벨에 맞는 다음 번호를 계산합니다.
+ * beforeIndex 이전 줄들을 역방향으로 탐색해 targetIndent 레벨의 마지막 번호 + 1을 반환합니다.
+ */
+export function computeNextNumber(
+  lines: string[],
+  beforeIndex: number,
+  targetIndent: string
+): number {
+  for (let i = beforeIndex - 1; i >= 0; i--) {
+    const m = lines[i].match(/^(\s*)(\d+)\. /)
+    if (!m) continue
+    if (m[1] === targetIndent) return parseInt(m[2], 10) + 1
+    if (m[1].length < targetIndent.length) break
+  }
+  return 1
+}
+
+/**
+ * fromIndex부터 targetIndent 레벨의 번호 목록 항목들을 순차적으로 재번호합니다.
+ * 더 깊은 레벨(하위 목록)은 건너뛰고, 더 얕은 레벨에서 중단합니다.
+ */
+export function renumberFrom(
+  lines: string[],
+  fromIndex: number,
+  targetIndent: string
+): string[] {
+  const result = [...lines]
+  let counter = computeNextNumber(result, fromIndex, targetIndent)
+  for (let i = fromIndex; i < result.length; i++) {
+    const m = result[i].match(/^(\s*)(\d+)\. (.*)/)
+    if (!m) continue
+    if (m[1].length < targetIndent.length) break
+    if (m[1] === targetIndent) {
+      result[i] = `${targetIndent}${counter}. ${m[3]}`
+      counter++
+    }
+  }
+  return result
+}
+
+/**
+ * execute 핸들러에서 선택 영역이 없으면 현재 단어를 자동 선택 후 wrapFn 적용.
+ * 인라인 서식(밑줄, 글자색 등)에 사용합니다.
+ */
+export function applyInline(
+  state: EditorState,
+  api: {
+    replaceSelection: (t: string) => void
+    setSelectionRange: (r: { start: number; end: number }) => void
+  },
+  wrapFn: (text: string) => string
+) {
+  if (state.selectedText) {
+    api.replaceSelection(wrapFn(state.selectedText))
+    return
+  }
+  const range = getWordRange(state.text, state.selection.start)
+  if (range) {
+    api.setSelectionRange(range)
+    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
+  }
+}
+
+/**
+ * execute 핸들러에서 선택 영역이 없으면 현재 줄을 자동 선택 후 wrapFn 적용.
+ * 블록 서식(정렬, 들여쓰기 등)에 사용합니다.
+ */
+export function applyBlock(
+  state: EditorState,
+  api: {
+    replaceSelection: (t: string) => void
+    setSelectionRange: (r: { start: number; end: number }) => void
+  },
+  wrapFn: (text: string) => string
+) {
+  if (state.selectedText) {
+    api.replaceSelection(wrapFn(state.selectedText))
+    return
+  }
+  const range = getLineRange(state.text, state.selection.start)
+  if (range) {
+    api.setSelectionRange(range)
+    api.replaceSelection(wrapFn(state.text.slice(range.start, range.end)))
+  }
+}
+
+/**
+ * textarea 값을 직접 교체하고 React onChange를 트리거합니다.
+ * setSelectionRange → replaceSelection 순서에서 insertTextAtPosition 내부의
+ * focus() 호출이 selection을 리셋하는 문제를 우회합니다.
+ *
+ * React native property setter hack:
+ * 원래 HTMLTextAreaElement.prototype.value setter를 호출하면 React가 변경을
+ * "dirty"로 인식한 뒤 input 이벤트에서 onChange를 정상 호출합니다.
+ */
+export function replaceInText(
+  textApi: TextApiWithElement,
+  fullText: string,
+  start: number,
+  end: number,
+  replacement: string
+): boolean {
+  const ta = textApi.textArea
+  if (!ta) return false
+  const newValue = fullText.slice(0, start) + replacement + fullText.slice(end)
+  const nativeSetter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value'
+  )?.set
+  if (!nativeSetter) return false
+  nativeSetter.call(ta, newValue)
+  ta.dispatchEvent(new Event('input', { bubbles: true }))
+  ta.selectionStart = ta.selectionEnd = start + replacement.length
+  return true
+}
+
+/**
+ * 드롭다운 children 핸들러용 인라인 서식 적용.
+ *
+ * 우선순위:
+ * 1. 커서가 기존 <span> 안에 있으면 → span 전체를 교체 (선택 여부 무관, 중첩 방지)
+ * 2. 선택 영역 있음 → 선택 텍스트에 적용
+ * 3. 선택 없음 → 현재 단어 선택 후 적용
+ * 4. 아무것도 없으면 → 아무것도 하지 않음 (빈 span 삽입 방지)
+ *
+ * replaceInText를 우선 사용해 setSelectionRange + replaceSelection 패턴에서
+ * 발생하는 focus() → selection 리셋 문제를 방지합니다.
+ */
+export function applyInlineFromDropdown(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  wrapFn: (text: string) => string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+
+  // 1. 커서 시작 위치가 기존 <span> 안이면 span 전체를 교체 (중첩 방지)
+  const spanRange = getEnclosingSpanRange(s.text, s.selection.start)
+  if (spanRange) {
+    const innerText = s.text.slice(spanRange.start, spanRange.end)
+    const replacement = wrapFn(innerText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        spanRange.start,
+        spanRange.end,
+        replacement
+      )
+    ) {
+      textApi.setSelectionRange(spanRange)
+      textApi.replaceSelection(replacement)
+    }
+    return
+  }
+
+  // 2. 선택 영역이 있으면 선택 텍스트에 적용
+  if (s.selectedText) {
+    const replacement = wrapFn(s.selectedText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        s.selection.start,
+        s.selection.end,
+        replacement
+      )
+    ) {
+      textApi.replaceSelection(replacement)
+    }
+    return
+  }
+
+  // 3. 선택 없음 → 현재 단어를 선택 후 적용
+  const wordRange = getWordRange(s.text, s.selection.start)
+  if (wordRange) {
+    const innerText = s.text.slice(wordRange.start, wordRange.end)
+    const replacement = wrapFn(innerText)
+    if (
+      !replaceInText(
+        textApi,
+        s.text,
+        wordRange.start,
+        wordRange.end,
+        replacement
+      )
+    ) {
+      textApi.setSelectionRange(wordRange)
+      textApi.replaceSelection(replacement)
+    }
+  }
+  // 4. 아무것도 없으면 종료 (빈 <span></span> 삽입 안 함)
+}
+
+/**
+ * 드롭다운 children 핸들러용 블록 서식 적용.
+ * 선택 있음 → 선택 텍스트에 적용.
+ * 선택 없음 → wrapFn('') 를 커서 위치에 삽입.
+ */
+export function applyBlockFromDropdown(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  wrapFn: (text: string) => string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+  if (s.selectedText) {
+    textApi.replaceSelection(wrapFn(s.selectedText))
+    return
+  }
+  textApi.replaceSelection(wrapFn(''))
+}
+
+/**
+ * 목록 전용 삽입 함수.
+ * 선택 있음 → 각 줄 앞에 prefix 추가.
+ * 선택 없음 → 현재 줄의 맨 앞으로 커서 이동 후 prefix 삽입.
+ *   textarea.selectionStart/End 를 직접 수정해 setSelectionRange(→ focus()) 호출을 피합니다.
+ */
+export function insertListPrefix(
+  getState: (() => false | EditorState) | undefined,
+  textApi: TextApiWithElement | undefined,
+  prefix: string
+) {
+  const s = safeGetState(getState)
+  if (!s || !textApi) return
+
+  if (s.selectedText) {
+    const lines = s.selectedText
+      .split('\n')
+      .map((l) => `${prefix}${l}`)
+      .join('\n')
+    textApi.replaceSelection(lines)
+    return
+  }
+
+  // 선택 없음: 줄 시작 위치를 계산하고 직접 selectionStart/End 설정
+  const lineStart = s.text.lastIndexOf('\n', s.selection.start - 1) + 1
+  const nextNewline = s.text.indexOf('\n', lineStart)
+  const lineEnd = nextNewline === -1 ? s.text.length : nextNewline
+  const ta = (textApi as TextApiWithElement).textArea
+  if (ta) {
+    ta.selectionStart = lineStart
+    ta.selectionEnd = lineStart
+  }
+  textApi.replaceSelection(prefix)
+  // prefix 삽입 후 커서를 줄 끝으로 이동
+  if (ta) {
+    const newCursorPos = lineEnd + prefix.length
+    ta.selectionStart = newCursorPos
+    ta.selectionEnd = newCursorPos
+  }
+}
+
+/**
+ * 선택 텍스트가 이미 <span style="..."> 이면 해당 CSS 속성만 교체/추가하고,
+ * 그렇지 않으면 새 <span>으로 감쌉니다.
+ * 중첩 span 누적을 방지합니다.
+ */
+export function wrapWithStyle(
+  selected: string,
+  property: string,
+  value: string
+): string {
+  const match = selected.match(/^<span style="([^"]*)">([\s\S]*)<\/span>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const propRe = new RegExp(`(^|;\\s*)${property}\\s*:[^;]*`, 'i')
+    let newStyle: string
+    if (propRe.test(existingStyle)) {
+      newStyle = existingStyle
+        .replace(
+          new RegExp(`${property}\\s*:[^;]*`, 'i'),
+          `${property}: ${value}`
+        )
+        .replace(/^;\s*/, '')
+        .trim()
+    } else if (existingStyle) {
+      newStyle = `${existingStyle}; ${property}: ${value}`
+    } else {
+      newStyle = `${property}: ${value}`
+    }
+    return `<span style="${newStyle}">${inner}</span>`
+  }
+  return `<span style="${property}: ${value}">${selected}</span>`
+}
+
+/**
+ * 선택 텍스트가 이미 <mark style="..."> 이면 background-color만 교체하고,
+ * 그렇지 않으면 새 <mark>으로 감쌉니다.
+ */
+export function wrapMarkWithStyle(selected: string, color: string): string {
+  const match = selected.match(/^<mark style="([^"]*)">([\s\S]*)<\/mark>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const newStyle = existingStyle
+      .replace(/background-color\s*:[^;]*/i, `background-color: ${color}`)
+      .replace(/^;\s*/, '')
+      .trim()
+    return `<mark style="${newStyle}">${inner}</mark>`
+  }
+  return `<mark style="background-color: ${color}">${selected}</mark>`
+}
+
+/**
+ * 선택 텍스트가 이미 <div style="..."> 이면 해당 CSS 속성만 교체/추가하고,
+ * 그렇지 않으면 새 <div>로 감쌉니다.
+ * 중첩 div 누적을 방지합니다.
+ */
+export function wrapDivWithStyle(
+  selected: string,
+  property: string,
+  value: string
+): string {
+  const match = selected.match(/^<div style="([^"]*)">([\s\S]*)<\/div>$/)
+  if (match) {
+    const existingStyle = match[1]
+    const inner = match[2]
+    const propRe = new RegExp(`${property}\\s*:[^;]*`, 'i')
+    let newStyle: string
+    if (propRe.test(existingStyle)) {
+      newStyle = existingStyle
+        .replace(propRe, `${property}: ${value}`)
+        .replace(/^;\s*/, '')
+        .trim()
+    } else if (existingStyle) {
+      newStyle = `${existingStyle}; ${property}: ${value}`
+    } else {
+      newStyle = `${property}: ${value}`
+    }
+    return `<div style="${newStyle}">${inner}</div>`
+  }
+  return `<div style="${property}: ${value}">${selected}</div>`
+}
+
+/** 커서를 감싸는 <u>...</u> 범위를 반환합니다. </u> 바로 뒤 커서도 포함합니다. */
+export function getEnclosingURange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  const re = /<u>/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    const uStart = m.index
+    const closeIdx = text.indexOf('</u>', uStart + m[0].length)
+    if (closeIdx === -1) continue
+    const uEnd = closeIdx + '</u>'.length
+    if (cursor >= uStart && cursor <= uEnd) {
+      return { start: uStart, end: uEnd }
+    }
+  }
+  return null
+}

--- a/src/components/qna/MarkdownEditor/useImageUpload.ts
+++ b/src/components/qna/MarkdownEditor/useImageUpload.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React from 'react'
+import { type ICommand } from '@uiw/react-md-editor'
+import { useGetPresignedUrl } from '@/features/qna/presigned-url'
+import { ACCEPTED_IMAGE_TYPES } from './markdownEditorConstants'
+
+export function useImageUpload(
+  valueRef: React.RefObject<string>,
+  onChange: (v: string) => void
+) {
+  const { mutateAsync: getPresignedUrl } = useGetPresignedUrl()
+  const [isUploading, setIsUploading] = useState(false)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const objectUrlsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const urls = objectUrlsRef.current
+    return () => {
+      urls.forEach((url) => URL.revokeObjectURL(url))
+    }
+  }, [])
+
+  const uploadImageFile = useCallback(
+    async (file: File, insertFn: (md: string) => void) => {
+      if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+        setImageError('JPG, PNG, GIF, WEBP 형식만 업로드할 수 있습니다.')
+        return
+      }
+      setImageError(null)
+      setIsUploading(true)
+      const objectUrl = URL.createObjectURL(file)
+      objectUrlsRef.current.add(objectUrl)
+      insertFn(`![${file.name}](${objectUrl})`)
+      try {
+        const { presigned_url, img_url } = await getPresignedUrl({
+          file_name: file.name,
+        })
+        try {
+          await fetch(presigned_url, {
+            method: 'PUT',
+            body: file,
+            headers: { 'Content-Type': file.type },
+          })
+        } catch (err) {
+          if (!import.meta.env.DEV) throw err
+          // DEV(MSW) 환경에서는 S3 업로드 실패 무시 — objectUrl로 미리보기 유지
+        }
+        if (!import.meta.env.DEV) {
+          onChange(valueRef.current.replaceAll(objectUrl, img_url))
+          URL.revokeObjectURL(objectUrl)
+          objectUrlsRef.current.delete(objectUrl)
+        }
+      } catch {
+        URL.revokeObjectURL(objectUrl)
+        objectUrlsRef.current.delete(objectUrl)
+        setImageError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.')
+      } finally {
+        setIsUploading(false)
+      }
+    },
+    [getPresignedUrl, onChange, valueRef]
+  )
+
+  const imageCommand: ICommand = useMemo(
+    () => ({
+      name: 'image',
+      keyCommand: 'image',
+      buttonProps: {
+        'aria-label': '이미지 업로드',
+        title: '이미지 업로드',
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      },
+      icon: React.createElement(
+        'svg',
+        { width: 14, height: 14, viewBox: '0 0 20 20' },
+        React.createElement('path', {
+          fill: 'currentColor',
+          d: 'M15 9c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4-7H1c-.55 0-1 .45-1 1v14c0 .55.45 1 1 1h18c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 13l-6-5-2 2-4-5-4 6V4h16v11z',
+        })
+      ),
+      execute: (_state, api) => {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = ACCEPTED_IMAGE_TYPES.join(',')
+        input.onchange = async () => {
+          const file = input.files?.[0]
+          if (!file) return
+          await uploadImageFile(file, (md) => api.replaceSelection(md))
+        }
+        input.click()
+      },
+    }),
+    [uploadImageFile]
+  )
+
+  return {
+    isUploading,
+    imageError,
+    objectUrlsRef,
+    uploadImageFile,
+    imageCommand,
+  }
+}

--- a/src/components/qna/MarkdownEditor/useMarkdownHistory.ts
+++ b/src/components/qna/MarkdownEditor/useMarkdownHistory.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React from 'react'
+import { Undo2, Redo2 } from 'lucide-react'
+import { type ICommand } from '@uiw/react-md-editor'
+import { UNDO_LIMIT } from './markdownEditorConstants'
+
+export function useMarkdownHistory(
+  value: string,
+  onChange: (v: string) => void
+) {
+  const valueRef = useRef(value)
+  const [undoStack, setUndoStack] = useState<string[]>([])
+  const [redoStack, setRedoStack] = useState<string[]>([])
+
+  useEffect(() => {
+    valueRef.current = value
+  }, [value])
+
+  const handleChange = (newValue: string) => {
+    setUndoStack((prev) => {
+      const next = [...prev, valueRef.current]
+      return next.length > UNDO_LIMIT ? next.slice(-UNDO_LIMIT) : next
+    })
+    setRedoStack([])
+    onChange(newValue)
+  }
+
+  const handleUndo = useCallback(() => {
+    if (undoStack.length === 0) return
+    const prev = undoStack[undoStack.length - 1]
+    setRedoStack((r) => [...r, valueRef.current])
+    setUndoStack((u) => u.slice(0, -1))
+    onChange(prev)
+  }, [undoStack, onChange])
+
+  const handleRedo = useCallback(() => {
+    if (redoStack.length === 0) return
+    const next = redoStack[redoStack.length - 1]
+    setUndoStack((u) => [...u, valueRef.current])
+    setRedoStack((r) => r.slice(0, -1))
+    onChange(next)
+  }, [redoStack, onChange])
+
+  const undoCommand = useMemo<ICommand>(
+    () => ({
+      name: 'undo',
+      keyCommand: 'undo',
+      buttonProps: {
+        'aria-label': '실행 취소',
+        title: '실행 취소',
+        'data-inactive': undoStack.length === 0 ? 'true' : undefined,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
+      icon: React.createElement(Undo2, { size: 14 }),
+      execute: handleUndo,
+    }),
+    [undoStack.length, handleUndo]
+  )
+
+  const redoCommand = useMemo<ICommand>(
+    () => ({
+      name: 'redo',
+      keyCommand: 'redo',
+      buttonProps: {
+        'aria-label': '다시 실행',
+        title: '다시 실행',
+        'data-inactive': redoStack.length === 0 ? 'true' : undefined,
+        onMouseDown: (e: React.MouseEvent<HTMLButtonElement>) =>
+          e.preventDefault(),
+      } as React.ButtonHTMLAttributes<HTMLButtonElement>,
+      icon: React.createElement(Redo2, { size: 14 }),
+      execute: handleRedo,
+    }),
+    [redoStack.length, handleRedo]
+  )
+
+  return {
+    valueRef,
+    undoStack,
+    redoStack,
+    setUndoStack,
+    setRedoStack,
+    handleChange,
+    undoCommand,
+    redoCommand,
+  }
+}


### PR DESCRIPTION
## 관련 이슈

- closes #77

## 작업 내용

- 마크다운 미리보기에서 `ul`/`ol` 목록 기호(disc/decimal)가 사라지는 버그 수정
- MarkdownEditor 단일 파일(1459줄)을 6개 모듈로 분리하는 리팩토링
- 배경색 팔레트에서 흰색 스와치가 중복 렌더링되던 버그 수정

## 변경 사항

- `MarkdownEditor.css`: `.wmde-markdown ul/ol/li` 스타일 명시적 복원 — `list-style-type: disc/decimal`, `padding-left`, `margin` 등 재선언
- `MarkdownEditor.tsx`: 1459줄 단일 파일에서 핵심 로직만 남기고 나머지를 모듈로 분리
- `markdownEditorConstants.ts` (신규): 색상·폰트·PILL 등 상수 정의
- `markdownEditorUtils.ts` (신규): 커서·텍스트 조작 순수 유틸 함수
- `markdownEditorCommands.ts` (신규): 정렬·목록·줄간격 등 정적 커맨드
- `useMarkdownHistory.ts` (신규): undo/redo 커스텀 훅
- `useImageUpload.ts` (신규): 이미지 업로드 커스텀 훅
- `markdownEditorConstants.ts`: `BG_PALETTE_COLORS`에서 `#ffffff` 중복 항목 제거

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다