### PR TITLE
style: 답변 카드 헤더 재활용 및 에디터 UX 개선

### DIFF
--- a/src/components/qna/AnswerForm/AnswerForm.tsx
+++ b/src/components/qna/AnswerForm/AnswerForm.tsx
@@ -2,6 +2,7 @@ import {
   useState,
   useEffect,
   useRef,
+  useCallback,
   forwardRef,
   useImperativeHandle,
 } from 'react'
@@ -9,9 +10,7 @@ import { Button } from '@/components/common/Button'
 import { MarkdownEditor } from '@/components/qna/MarkdownEditor'
 
 export interface AnswerFormProps {
-  questionTitle: string
   onSubmit: (content: string, imageUrls: string[]) => void
-  onCancel?: () => void
   isLoading?: boolean
   mode?: 'create' | 'edit'
   initialContent?: string
@@ -21,6 +20,7 @@ export interface AnswerFormProps {
 
 export interface AnswerFormHandle {
   focusEditor: () => void
+  submit: () => void
 }
 
 const DEBOUNCE_DELAY_MS = 500
@@ -32,21 +32,17 @@ function getDraftKey(answerId: number) {
 export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
   function AnswerForm(
     {
-      questionTitle,
       onSubmit,
       isLoading = false,
       mode = 'create',
       initialContent = '',
+      initialImgUrls = [],
       answerId,
     },
     ref
   ) {
     const isEdit = mode === 'edit'
     const draftKey = isEdit && answerId != null ? getDraftKey(answerId) : null
-
-    useImperativeHandle(ref, () => ({
-      focusEditor: () => {},
-    }))
 
     const [showRestorePrompt, setShowRestorePrompt] = useState(() => {
       if (!isEdit || !draftKey) return false
@@ -59,6 +55,7 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
       return saved != null && saved !== initialContent ? saved : null
     })
     const [content, setContent] = useState(initialContent)
+    const [imgUrls] = useState(initialImgUrls)
     const [error, setError] = useState(false)
 
     // debounce 자동 저장
@@ -86,14 +83,14 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
         window.removeEventListener('beforeunload', handleBeforeUnload)
     }, [content])
 
-    const handleSubmit = () => {
+    const handleSubmit = useCallback(() => {
       if (!content.trim()) {
         setError(true)
         return
       }
       setError(false)
-      onSubmit(content, [])
-    }
+      onSubmit(content, imgUrls)
+    }, [content, imgUrls, onSubmit])
 
     const handleContentChange = (value: string) => {
       setContent(value)
@@ -112,8 +109,17 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
       setPendingDraft(null)
     }
 
+    useImperativeHandle(
+      ref,
+      () => ({
+        focusEditor: () => {},
+        submit: handleSubmit,
+      }),
+      [handleSubmit]
+    )
+
     return (
-      <div className="overflow-hidden rounded-[20px] border border-[#cdcdcd] bg-white">
+      <>
         {/* 임시 저장 복원 안내 */}
         {showRestorePrompt && (
           <div className="bg-bg-subtle border-border-base mx-8 mt-4 flex items-center justify-between rounded-md border px-4 py-3">
@@ -140,32 +146,13 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
           </div>
         )}
 
-        {/* 헤더: px-8 py-6, flex row */}
-        <div className="flex items-center justify-between px-8 py-6">
-          <div>
-            <p className="text-text-muted text-xs">답변 대상 질문</p>
-            <p className="text-text-heading mt-0.5 line-clamp-2 text-sm font-medium">
-              {questionTitle}
-            </p>
-          </div>
-          <Button
-            size="sm"
-            onClick={handleSubmit}
-            loading={isLoading}
-            disabled={isLoading}
-          >
-            {isEdit ? '수정하기' : '등록하기'}
-          </Button>
-        </div>
-
-        {/* 에디터: 카드 통합 (bare 모드로 자체 border 제거) */}
         <MarkdownEditor
           value={content}
           onChange={handleContentChange}
           error={error ? '답변 내용을 입력해주세요.' : undefined}
-          bare
+          wrapperClassName="bg-bg-base relative border-t border-[#cdcdcd]"
         />
-      </div>
+      </>
     )
   }
 )

--- a/src/components/qna/AnswerForm/AnswerForm.tsx
+++ b/src/components/qna/AnswerForm/AnswerForm.tsx
@@ -34,7 +34,6 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
     {
       questionTitle,
       onSubmit,
-      onCancel,
       isLoading = false,
       mode = 'create',
       initialContent = '',
@@ -114,10 +113,10 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
     }
 
     return (
-      <div className="border-border-base bg-bg-base rounded-lg border p-6">
+      <div className="overflow-hidden rounded-[20px] border border-[#cdcdcd] bg-white">
         {/* 임시 저장 복원 안내 */}
         {showRestorePrompt && (
-          <div className="bg-bg-subtle border-border-base mb-4 flex items-center justify-between rounded-md border px-4 py-3">
+          <div className="bg-bg-subtle border-border-base mx-8 mt-4 flex items-center justify-between rounded-md border px-4 py-3">
             <p className="text-text-body text-sm">
               이전에 작성 중이던 내용이 있습니다. 복원할까요?
             </p>
@@ -141,41 +140,30 @@ export const AnswerForm = forwardRef<AnswerFormHandle, AnswerFormProps>(
           </div>
         )}
 
-        {/* 상단: 질문 제목 + 취소 버튼 */}
-        <div className="mb-4 flex items-start justify-between gap-4">
+        {/* 헤더: px-8 py-6, flex row */}
+        <div className="flex items-center justify-between px-8 py-6">
           <div>
             <p className="text-text-muted text-xs">답변 대상 질문</p>
             <p className="text-text-heading mt-0.5 line-clamp-2 text-sm font-medium">
               {questionTitle}
             </p>
           </div>
-          {onCancel && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={onCancel}
-              disabled={isLoading}
-            >
-              취소
-            </Button>
-          )}
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            loading={isLoading}
+            disabled={isLoading}
+          >
+            {isEdit ? '수정하기' : '등록하기'}
+          </Button>
         </div>
 
-        {/* 중단: 에디터 (하단에 등록 버튼 포함) */}
+        {/* 에디터: 카드 통합 (bare 모드로 자체 border 제거) */}
         <MarkdownEditor
           value={content}
           onChange={handleContentChange}
           error={error ? '답변 내용을 입력해주세요.' : undefined}
-          actions={
-            <Button
-              size="sm"
-              onClick={handleSubmit}
-              loading={isLoading}
-              disabled={isLoading}
-            >
-              {isEdit ? '수정하기' : '답변하기'}
-            </Button>
-          }
+          bare
         />
       </div>
     )

--- a/src/components/qna/AnswerPromptCard/AnswerPromptCard.tsx
+++ b/src/components/qna/AnswerPromptCard/AnswerPromptCard.tsx
@@ -5,7 +5,13 @@ interface AnswerPromptCardProps {
   profileImageUrl: string | null | undefined
   isEdit: boolean
   disabled: boolean
-  onAction: () => void
+  onAction?: () => void
+  /** 카드 헤더로 쓸 때 true — 외곽 border/rounded/mt 제거 */
+  asCardHeader?: boolean
+  /** 폼이 펼쳐진 상태 — 버튼이 제출 동작으로 전환 */
+  showForm?: boolean
+  isLoading?: boolean
+  onSubmit?: () => void
 }
 
 export function AnswerPromptCard({
@@ -14,9 +20,20 @@ export function AnswerPromptCard({
   isEdit,
   disabled,
   onAction,
+  asCardHeader = false,
+  showForm = false,
+  isLoading = false,
+  onSubmit,
 }: AnswerPromptCardProps) {
-  return (
-    <div className="mt-[100px] flex items-center gap-3 rounded-[20px] border border-[#CECECE] px-[38px] py-10">
+  let buttonLabel: string
+  if (showForm) {
+    buttonLabel = isEdit ? '수정하기' : '답변하기'
+  } else {
+    buttonLabel = isEdit ? '답변 수정하기' : '답변하기'
+  }
+
+  const content = (
+    <>
       <UserAvatar
         size="lg"
         profileImageUrl={profileImageUrl}
@@ -32,12 +49,24 @@ export function AnswerPromptCard({
       </div>
       <button
         type="button"
-        onClick={onAction}
-        disabled={disabled}
+        onClick={showForm ? (onSubmit ?? (() => {})) : (onAction ?? (() => {}))}
+        disabled={showForm ? isLoading : disabled}
         className="bg-primary h-12 w-[112px] shrink-0 rounded-full text-base font-semibold text-white transition-colors hover:bg-[#3B0186] disabled:cursor-not-allowed disabled:bg-[#ECECEC] disabled:text-[#BDBDBD]"
       >
-        {isEdit ? '답변 수정하기' : '답변하기'}
+        {buttonLabel}
       </button>
+    </>
+  )
+
+  if (asCardHeader) {
+    return (
+      <div className="flex items-center gap-3 px-[38px] py-10">{content}</div>
+    )
+  }
+
+  return (
+    <div className="mt-[100px] flex items-center gap-3 rounded-[20px] border border-[#CECECE] px-[38px] py-10">
+      {content}
     </div>
   )
 }

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
@@ -45,7 +45,7 @@ export interface MarkdownEditorProps {
   onChange: (value: string) => void
   error?: string
   actions?: React.ReactNode
-  bare?: boolean
+  wrapperClassName?: string
 }
 
 export function MarkdownEditor({
@@ -53,7 +53,7 @@ export function MarkdownEditor({
   onChange,
   error,
   actions,
-  bare = false,
+  wrapperClassName,
 }: MarkdownEditorProps) {
   const [selectedFontLabel, setSelectedFontLabel] = useState('기본서체')
   const [selectedFontSize, setSelectedFontSize] = useState(16)
@@ -401,8 +401,8 @@ export function MarkdownEditor({
   return (
     <div
       className={
-        bare
-          ? `relative ${isDragOver ? 'border-primary border border-2' : ''}`
+        wrapperClassName != null
+          ? `${wrapperClassName}${isDragOver ? 'border-primary border-2' : ''}`
           : `bg-bg-base relative rounded-[20px] border ${isDragOver ? 'border-primary border-2' : 'border-[#cdcdcd]'}`
       }
       onDrop={handleDrop}
@@ -424,7 +424,7 @@ export function MarkdownEditor({
       )}
       <div
         data-color-mode="light"
-        className={`post-editor-wrap${bare ? 'border-t border-gray-200' : ''}`}
+        className="post-editor-wrap"
         ref={editorWrapRef}
       >
         <MDEditor

--- a/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
@@ -45,6 +45,7 @@ export interface MarkdownEditorProps {
   onChange: (value: string) => void
   error?: string
   actions?: React.ReactNode
+  bare?: boolean
 }
 
 export function MarkdownEditor({
@@ -52,6 +53,7 @@ export function MarkdownEditor({
   onChange,
   error,
   actions,
+  bare = false,
 }: MarkdownEditorProps) {
   const [selectedFontLabel, setSelectedFontLabel] = useState('기본서체')
   const [selectedFontSize, setSelectedFontSize] = useState(16)
@@ -398,7 +400,11 @@ export function MarkdownEditor({
 
   return (
     <div
-      className={`bg-bg-base relative rounded-[20px] border ${isDragOver ? 'border-primary border-2' : 'border-[#cdcdcd]'}`}
+      className={
+        bare
+          ? `relative ${isDragOver ? 'border-primary border border-2' : ''}`
+          : `bg-bg-base relative rounded-[20px] border ${isDragOver ? 'border-primary border-2' : 'border-[#cdcdcd]'}`
+      }
       onDrop={handleDrop}
       onDragOver={(e) => e.preventDefault()}
       onDragEnter={(e) => {
@@ -418,7 +424,7 @@ export function MarkdownEditor({
       )}
       <div
         data-color-mode="light"
-        className="post-editor-wrap"
+        className={`post-editor-wrap${bare ? 'border-t border-gray-200' : ''}`}
         ref={editorWrapRef}
       >
         <MDEditor

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -93,7 +93,6 @@ export function QnaDetailPage() {
     return <Navigate to={ROUTES.QNA.LIST} />
   }
 
-  const questionTitle = questionDetail?.title ?? '질문 내용을 불러오는 중...'
   const anyAdopted = answers?.some((a) => a.is_adopted) ?? false
   const isQuestionOwner =
     user?.id != null && questionDetail?.author.id === user.id
@@ -235,43 +234,49 @@ export function QnaDetailPage() {
         showToast={showToast}
       />
 
-      {/* 답변 유도 카드 */}
-      {canAnswer && !isAnswersLoading && !isAnswersError && !showForm && (
-        <AnswerPromptCard
-          nickname={user?.nickname ?? ''}
-          profileImageUrl={user?.profileImage}
-          isEdit={isEdit}
-          disabled={anyAdopted}
-          onAction={() => setShowForm(true)}
-        />
-      )}
-
-      {/* 답변 작성 / 수정 폼 */}
-      {canAnswer && !isAnswersLoading && !isAnswersError && showForm && (
-        <div className="mt-4">
-          {isEdit ? (
-            <AnswerForm
-              ref={answerFormRef}
-              questionTitle={questionTitle}
-              onSubmit={handleEditSubmit}
-              onCancel={() => setShowForm(false)}
-              isLoading={isPutPending}
-              mode="edit"
-              initialContent={myAnswer.content}
-              initialImgUrls={myAnswer.images.map((img) => img.img_url)}
-              answerId={myAnswer.id}
+      {/* 답변 유도 카드 / 답변 작성·수정 폼 */}
+      {canAnswer &&
+        !isAnswersLoading &&
+        !isAnswersError &&
+        (showForm ? (
+          <div className="mt-[100px] overflow-hidden rounded-[20px] border border-[#CECECE] bg-white">
+            <AnswerPromptCard
+              nickname={user?.nickname ?? ''}
+              profileImageUrl={user?.profileImage}
+              isEdit={isEdit}
+              disabled={anyAdopted}
+              asCardHeader
+              showForm
+              isLoading={isEdit ? isPutPending : isPostPending}
+              onSubmit={() => answerFormRef.current?.submit()}
             />
-          ) : (
-            <AnswerForm
-              ref={answerFormRef}
-              questionTitle={questionTitle}
-              onSubmit={handleCreateSubmit}
-              onCancel={() => setShowForm(false)}
-              isLoading={isPostPending}
-            />
-          )}
-        </div>
-      )}
+            {isEdit ? (
+              <AnswerForm
+                ref={answerFormRef}
+                onSubmit={handleEditSubmit}
+                isLoading={isPutPending}
+                mode="edit"
+                initialContent={myAnswer.content}
+                initialImgUrls={myAnswer.images.map((img) => img.img_url)}
+                answerId={myAnswer.id}
+              />
+            ) : (
+              <AnswerForm
+                ref={answerFormRef}
+                onSubmit={handleCreateSubmit}
+                isLoading={isPostPending}
+              />
+            )}
+          </div>
+        ) : (
+          <AnswerPromptCard
+            nickname={user?.nickname ?? ''}
+            profileImageUrl={user?.profileImage}
+            isEdit={isEdit}
+            disabled={anyAdopted}
+            onAction={() => setShowForm(true)}
+          />
+        ))}
 
       {/* 답변 목록 */}
       <AnswerSection


### PR DESCRIPTION
## 관련 이슈

- closes #81

## 작업 내용

- 답변 유도 카드(`AnswerPromptCard`) 헤더를 유지한 채 마크다운 에디터가 동일 카드 내에 펼쳐지는 구조로 변경
- `AnswerForm`에서 자체 헤더를 제거하고 에디터 전용 컴포넌트로 역할을 명확화
- `MarkdownEditor`에 `wrapperClassName` prop을 추가해 카드 내부 통합 시 외곽 스타일 제거 가능

## 변경 사항

- **AnswerPromptCard**: `asCardHeader`, `showForm`, `isLoading`, `onSubmit` props 추가. `showForm=true`일 때 버튼이 폼 제출 동작으로 전환
- **AnswerForm**: 자체 카드 래퍼·헤더 제거, `AnswerFormHandle`에 `submit()` 추가, `handleSubmit` useCallback 안정화, `initialImgUrls` state 관리로 수정 모드 이미지 유실 방지, dead props(`questionTitle`, `onCancel`) 제거
- **MarkdownEditor**: `bare` prop 제거 → `wrapperClassName` prop으로 대체
- **QnaDetailPage**: `showForm` 상태에 따라 헤더(`AnswerPromptCard`) + 에디터(`AnswerForm`)를 단일 카드로 조합

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다