### PR TITLE
fix: 루트 경로 리다이렉트 및 Vercel SPA 라우팅 설정

### DIFF
--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router'
+import { Navigate, Routes, Route } from 'react-router'
 import { DefaultLayout } from '@/components'
 import {
   QnaListPage,
@@ -12,6 +12,8 @@ import { ComponentShowcase } from '@/pages/ComponentShowcase'
 export function RouterProvider() {
   return (
     <Routes>
+      <Route path="/" element={<Navigate to="/qna" replace />} />
+
       {/* Header + Footer */}
       <Route element={<DefaultLayout />}>
         <Route path="qna">

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- `/` 접속 시 `/qna`로 리다이렉트 추가 (`Navigate` 컴포넌트)
- `vercel.json` 생성하여 SPA 경로 직접 접속 시 404 방지 (모든 경로 → `index.html` rewrite)

closes #87

## Test plan
- [ ] `/` 접속 시 `/qna`로 리다이렉트 확인
- [ ] `/qna`, `/qna/write` 등 SPA 경로 직접 접속(새로고침) 시 정상 렌더링 확인
- [ ] Vercel 배포 후 동일 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)