### PR TITLE
dev → main 배포: 에디터 버그 수정 및 라우팅 설정

### DIFF
--- a/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/qna/MarkdownEditor/MarkdownEditor.tsx
@@ -24,6 +24,9 @@ import {
   renumberFrom,
 } from './markdownEditorUtils'
 import {
+  boldCommand,
+  italicCommand,
+  strikethroughCommand,
   underlineCommand,
   bgColorCommand,
   textColorCommand,
@@ -354,22 +357,10 @@ export function MarkdownEditor({
       fontFamilyCommand,
       fontSizeCommand,
       mdCommands.divider,
-      {
-        ...mdCommands.bold,
-        buttonProps: { ...mdCommands.bold.buttonProps, ...NO_BLUR_PROPS },
-      },
-      {
-        ...mdCommands.italic,
-        buttonProps: { ...mdCommands.italic.buttonProps, ...NO_BLUR_PROPS },
-      },
+      boldCommand,
+      italicCommand,
       underlineCommand,
-      {
-        ...mdCommands.strikethrough,
-        buttonProps: {
-          ...mdCommands.strikethrough.buttonProps,
-          ...NO_BLUR_PROPS,
-        },
-      },
+      strikethroughCommand,
       bgColorCommand,
       textColorCommand,
       mdCommands.divider,

--- a/src/components/qna/MarkdownEditor/markdownEditorCommands.ts
+++ b/src/components/qna/MarkdownEditor/markdownEditorCommands.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { type ICommand } from '@uiw/react-md-editor'
+import { commands as mdCommands, type ICommand } from '@uiw/react-md-editor'
 import {
   Underline,
   AlignLeft,
@@ -24,10 +24,77 @@ import {
   applyBlockFromDropdown,
   insertListPrefix,
   wrapWithStyle,
-  wrapMarkWithStyle,
+  stripStyleProp,
   wrapDivWithStyle,
   getEnclosingURange,
+  getEnclosingMarkRange,
+  safeGetState,
+  replaceInText,
+  type EditorState,
 } from './markdownEditorUtils'
+
+/**
+ * HTML 인식 Bold 토글.
+ * react-md-editor 기본 execute는 \S 기준 단어 선택으로 HTML 속성 안까지 선택될 수 있음.
+ * applyInline 사용으로 <> 경계 인식 + isCursorInsideTag 체크.
+ *
+ * 토글 규칙:
+ *   **text**   → text       (bold 제거)
+ *   *text*     → ***text*** (이미 italic → bold+italic 추가)
+ *   text       → **text**   (bold 추가)
+ */
+export const boldCommand: ICommand = {
+  ...mdCommands.bold,
+  execute: (state: EditorState, api) =>
+    applyInline(state, api, (t) => {
+      if (t.startsWith('**') && t.endsWith('**') && t.length >= 4) {
+        return t.slice(2, -2)
+      }
+      return `**${t}**`
+    }),
+}
+
+/**
+ * HTML 인식 Italic 토글.
+ * Bold 마커 **를 italic 마커 *로 잘못 인식하는 버그 수정.
+ *
+ * 토글 규칙:
+ *   ***text*** → **text**   (bold+italic → bold만 남김)
+ *   *text*     → text       (italic 제거, **로 시작하지 않을 때만)
+ *   **text**   → ***text*** (이미 bold → bold+italic 추가)
+ *   text       → *text*     (italic 추가)
+ */
+export const italicCommand: ICommand = {
+  ...mdCommands.italic,
+  execute: (state: EditorState, api) =>
+    applyInline(state, api, (t) => {
+      if (t.startsWith('***') && t.endsWith('***') && t.length >= 6) {
+        return `**${t.slice(3, -3)}**`
+      }
+      if (t.startsWith('**') && t.endsWith('**') && t.length >= 4) {
+        return `***${t.slice(2, -2)}***`
+      }
+      if (t.startsWith('*') && t.endsWith('*') && t.length >= 2) {
+        return t.slice(1, -1)
+      }
+      return `*${t}*`
+    }),
+}
+
+/**
+ * HTML 인식 Strikethrough 토글.
+ * applyInline 사용으로 HTML 속성 안까지 선택되는 문제 방지.
+ */
+export const strikethroughCommand: ICommand = {
+  ...mdCommands.strikethrough,
+  execute: (state: EditorState, api) =>
+    applyInline(state, api, (t) => {
+      if (t.startsWith('~~') && t.endsWith('~~') && t.length >= 4) {
+        return t.slice(2, -2)
+      }
+      return `~~${t}~~`
+    }),
+}
 
 /** 밑줄 토글: 커서가 <u> 안에 있거나 선택 텍스트가 <u>로 감싸져 있으면 제거, 아니면 추가 */
 export const underlineCommand: ICommand = {
@@ -104,6 +171,13 @@ export function makeColorCommand(
   }
 }
 
+/**
+ * 배경색 커맨드.
+ * 기존 <mark> 방식 대신 <span style="background-color: ...">을 사용합니다.
+ * - font-size, color 등 다른 스타일과 같은 <span>에 병합되어
+ *   폰트 크기가 클 때 배경이 텍스트를 벗어나는 CSS 문제를 방지합니다.
+ * - 레거시 <mark> 콘텐츠는 색상 변경/제거 시 <span>으로 변환합니다.
+ */
 export const bgColorCommand: ICommand = {
   name: 'bg-color',
   keyCommand: 'group',
@@ -135,20 +209,51 @@ export const bgColorCommand: ICommand = {
         className: 'bg-color-popup',
         onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
       },
+      // ── 배경 제거 버튼 ──
       React.createElement(
         'button',
         {
           type: 'button',
           className: 'bg-color-remove-btn',
           onClick: () => {
-            applyInlineFromDropdown(getState, textApi, (t) =>
-              t.replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
-            )
+            const s = safeGetState(getState)
+            if (s && textApi) {
+              // 레거시: 커서가 <mark> 안에 있으면 mark 태그 전체 제거
+              const markRange = getEnclosingMarkRange(s.text, s.selection.start)
+              if (markRange && !s.selectedText) {
+                const inner = s.text
+                  .slice(markRange.start, markRange.end)
+                  .replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
+                if (
+                  !replaceInText(
+                    textApi,
+                    s.text,
+                    markRange.start,
+                    markRange.end,
+                    inner
+                  )
+                ) {
+                  textApi.setSelectionRange(markRange)
+                  textApi.replaceSelection(inner)
+                }
+                close()
+                return
+              }
+            }
+            // 신규: span의 background-color 속성 제거 + 레거시 mark 제거
+            applyInlineFromDropdown(getState, textApi, (t) => {
+              const withoutMark = t.replace(
+                /<mark[^>]*>([\s\S]*?)<\/mark>/g,
+                '$1'
+              )
+              return stripStyleProp(withoutMark, 'background-color')
+            })
             close()
           },
         },
         '✕ 배경 제거'
       ),
+      // ── 색상 팔레트 ──
       React.createElement(
         'div',
         { className: 'color-palette' },
@@ -165,8 +270,41 @@ export const bgColorCommand: ICommand = {
             },
             title: color === '#ffffff' ? '흰색' : color,
             onClick: () => {
+              const s = safeGetState(getState)
+              if (s && textApi) {
+                // 레거시: 커서가 <mark> 안에 있으면 mark를 span으로 변환
+                const markRange = getEnclosingMarkRange(
+                  s.text,
+                  s.selection.start
+                )
+                if (markRange && !s.selectedText) {
+                  const inner = s.text
+                    .slice(markRange.start, markRange.end)
+                    .replace(/<mark[^>]*>([\s\S]*?)<\/mark>/g, '$1')
+                  const replacement = wrapWithStyle(
+                    inner,
+                    'background-color',
+                    color
+                  )
+                  if (
+                    !replaceInText(
+                      textApi,
+                      s.text,
+                      markRange.start,
+                      markRange.end,
+                      replacement
+                    )
+                  ) {
+                    textApi.setSelectionRange(markRange)
+                    textApi.replaceSelection(replacement)
+                  }
+                  close()
+                  return
+                }
+              }
+              // 신규: background-color를 span style로 추가 (기존 span에 병합)
               applyInlineFromDropdown(getState, textApi, (t) =>
-                wrapMarkWithStyle(t, color)
+                wrapWithStyle(t, 'background-color', color)
               )
               close()
             },

--- a/src/components/qna/MarkdownEditor/markdownEditorUtils.ts
+++ b/src/components/qna/MarkdownEditor/markdownEditorUtils.ts
@@ -26,8 +26,41 @@ export function isCursorInsideTag(text: string, cursor: number): boolean {
   return lastOpen > lastClose
 }
 
+/**
+ * 커서가 닫는 HTML 태그(</tag>) 직후에 연속으로 위치한 경우,
+ * 태그 스택 내부의 실제 콘텐츠 끝 위치로 이동합니다.
+ * 이미 콘텐츠 위치이거나 태그 내부이면 원래 cursor를 그대로 반환합니다.
+ *
+ * 예: `<mark><span>content</span></mark>|` → content 끝 위치
+ *     `<u>content</u>|`                   → content 끝 위치
+ *
+ * 이를 통해 배경색·밑줄 등 HTML 태그 기반 서식 적용 후에도
+ * 곧바로 다른 서식(글자색, 폰트 크기 등)을 연속 적용할 수 있습니다.
+ */
+export function getEffectiveCursor(text: string, cursor: number): number {
+  let pos = cursor
+  // 실제 에디터에서 중첩 깊이는 3-4단계 이하이므로 8은 충분한 안전 마진
+  const MAX_DEPTH = 8
+  for (let i = 0; i < MAX_DEPTH; i++) {
+    const before = text.slice(0, pos)
+    const m = before.match(/<\/\w+>$/)
+    if (!m) break
+    const candidate = pos - m[0].length
+    if (isCursorInsideTag(text, candidate)) break
+    // 후보 위치 바로 앞이 실제 콘텐츠 문자이면 도달
+    if (candidate > 0 && /[^\s<>]/.test(text[candidate - 1])) {
+      return candidate
+    }
+    pos = candidate
+  }
+  return cursor
+}
+
 /** 커서 위치 기준 현재 단어 범위를 반환합니다 (인라인 서식용).
- *  HTML 태그 문자(<, >)에서 단어 경계로 처리해 태그 내용 선택을 방지합니다. */
+ *  HTML 태그 문자(<, >)에서 단어 경계로 처리해 태그 내용 선택을 방지합니다.
+ *
+ *  커서가 닫는 태그 뒤에 위치한 경우 getEffectiveCursor로 실제 콘텐츠 위치를 구한 뒤 재탐색합니다.
+ *  중첩 태그(`</span></mark>|` 등)도 재귀적으로 통과합니다. */
 export function getWordRange(
   text: string,
   cursor: number
@@ -37,7 +70,17 @@ export function getWordRange(
   let end = cursor
   while (start > 0 && /[^\s<>]/.test(text[start - 1])) start--
   while (end < text.length && /[^\s<>]/.test(text[end])) end++
-  return start < end ? { start, end } : null
+  if (start < end) return { start, end }
+
+  // 단어 미발견: 닫는 태그 뒤에 커서가 있으면 실제 콘텐츠 위치로 이동 후 재탐색
+  const effective = getEffectiveCursor(text, cursor)
+  if (effective === cursor) return null
+  if (isCursorInsideTag(text, effective)) return null
+  let s = effective
+  let e = effective
+  while (s > 0 && /[^\s<>]/.test(text[s - 1])) s--
+  while (e < text.length && /[^\s<>]/.test(text[e])) e++
+  return s < e ? { start: s, end: e } : null
 }
 
 /** 커서를 감싸는 가장 가까운 <span style="...">...</span> 의 범위를 반환합니다.
@@ -199,6 +242,8 @@ export function replaceInText(
  *
  * 우선순위:
  * 1. 커서가 기존 <span> 안에 있으면 → span 전체를 교체 (선택 여부 무관, 중첩 방지)
+ *    커서가 </mark></span> 등 닫는 태그 뒤에 있을 때도 getEffectiveCursor로
+ *    실제 콘텐츠 위치를 구해 span을 탐색합니다.
  * 2. 선택 영역 있음 → 선택 텍스트에 적용
  * 3. 선택 없음 → 현재 단어 선택 후 적용
  * 4. 아무것도 없으면 → 아무것도 하지 않음 (빈 span 삽입 방지)
@@ -215,7 +260,9 @@ export function applyInlineFromDropdown(
   if (!s || !textApi) return
 
   // 1. 커서 시작 위치가 기존 <span> 안이면 span 전체를 교체 (중첩 방지)
-  const spanRange = getEnclosingSpanRange(s.text, s.selection.start)
+  //    닫는 태그 뒤에 커서가 있을 때는 effectiveCursor로 실제 콘텐츠 위치를 구해 재탐색
+  const effectiveCursor = getEffectiveCursor(s.text, s.selection.start)
+  const spanRange = getEnclosingSpanRange(s.text, effectiveCursor)
   if (spanRange) {
     const innerText = s.text.slice(spanRange.start, spanRange.end)
     const replacement = wrapFn(innerText)
@@ -251,8 +298,8 @@ export function applyInlineFromDropdown(
     return
   }
 
-  // 3. 선택 없음 → 현재 단어를 선택 후 적용
-  const wordRange = getWordRange(s.text, s.selection.start)
+  // 3. 선택 없음 → effectiveCursor 기준 단어를 선택 후 적용
+  const wordRange = getWordRange(s.text, effectiveCursor)
   if (wordRange) {
     const innerText = s.text.slice(wordRange.start, wordRange.end)
     const replacement = wrapFn(innerText)
@@ -385,6 +432,29 @@ export function wrapMarkWithStyle(selected: string, color: string): string {
 }
 
 /**
+ * span 요소의 style 속성에서 특정 CSS 프로퍼티를 제거합니다.
+ * 제거 후 style이 비어지면 span 태그 자체를 제거하고 내용만 남깁니다.
+ * 배경색 제거 시 사용합니다.
+ */
+export function stripStyleProp(html: string, property: string): string {
+  const propRe = new RegExp(`${property}\\s*:[^;]*(;\\s*)?`, 'gi')
+  // non-greedy([\s\S]*?)를 사용해 첫 번째 </span>에서 멈춥니다.
+  // 중첩 span의 경우 replacement의 `${inner}</span>` 패턴이 닫는 태그를 재구성하므로
+  // 나머지 </span>이 올바르게 남아 구조가 유지됩니다.
+  return html.replace(
+    /<span style="([^"]*)">([\s\S]*?)<\/span>/gi,
+    (_, style, inner) => {
+      const newStyle = style
+        .replace(propRe, '')
+        .replace(/;{2,}/g, ';')
+        .replace(/^;+|;+$/g, '')
+        .trim()
+      return newStyle ? `<span style="${newStyle}">${inner}</span>` : inner
+    }
+  )
+}
+
+/**
  * 선택 텍스트가 이미 <div style="..."> 이면 해당 CSS 속성만 교체/추가하고,
  * 그렇지 않으면 새 <div>로 감쌉니다.
  * 중첩 div 누적을 방지합니다.
@@ -413,6 +483,28 @@ export function wrapDivWithStyle(
     return `<div style="${newStyle}">${inner}</div>`
   }
   return `<div style="${property}: ${value}">${selected}</div>`
+}
+
+/** 커서를 감싸는 가장 가까운 <mark style="...">...</mark> 의 범위를 반환합니다.
+ *  배경색이 이미 적용된 mark에 다시 색상을 적용하거나 제거할 때 사용합니다.
+ *  커서가 </mark> 바로 뒤에 있는 경우도 포함합니다. */
+export function getEnclosingMarkRange(
+  text: string,
+  cursor: number
+): { start: number; end: number } | null {
+  const markOpenRe = /<mark\b[^>]*>/gi
+  let match: RegExpExecArray | null
+  while ((match = markOpenRe.exec(text)) !== null) {
+    const markStart = match.index
+    const openEnd = markStart + match[0].length
+    const closeIdx = text.indexOf('</mark>', openEnd)
+    if (closeIdx === -1) continue
+    const markEnd = closeIdx + '</mark>'.length
+    if (cursor >= markStart && cursor <= markEnd) {
+      return { start: markStart, end: markEnd }
+    }
+  }
+  return null
 }
 
 /** 커서를 감싸는 <u>...</u> 범위를 반환합니다. </u> 바로 뒤 커서도 포함합니다. */

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router'
+import { Navigate, Routes, Route } from 'react-router'
 import { DefaultLayout } from '@/components'
 import {
   QnaListPage,
@@ -12,6 +12,8 @@ import { ComponentShowcase } from '@/pages/ComponentShowcase'
 export function RouterProvider() {
   return (
     <Routes>
+      <Route path="/" element={<Navigate to="/qna" replace />} />
+
       {/* Header + Footer */}
       <Route element={<DefaultLayout />}>
         <Route path="qna">

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- 마크다운 에디터 서식 커맨드 HTML 인식 및 중첩 스타일 병합 버그 수정 (#86)
- 루트 경로(`/`) → `/qna` 리다이렉트 추가 (#87)
- Vercel SPA 라우팅 설정 (`vercel.json`) 추가 (#87)

## Test plan
- [ ] `/` 접속 시 `/qna`로 리다이렉트 확인
- [ ] `/qna`, `/qna/write` 등 SPA 경로 직접 접속/새로고침 시 정상 렌더링 확인
- [ ] 마크다운 에디터 서식 토글(볼드, 이탤릭 등) 정상 동작 확인
- [ ] Vercel 배포 후 전체 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)