### PR TITLE
fix: 답변 수정 버튼을 본인 답변 카드 내부로 이동 및 버튼 스타일 통일 (#91)

### DIFF
--- a/src/components/qna/AnswerCard/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard/AnswerCard.tsx
@@ -1,6 +1,5 @@
 import type { GetAnswerItem } from '@/features/qna/answers'
 import { MarkdownViewer } from '@/components/qna/MarkdownViewer'
-import { Button } from '@/components/common/Button'
 import { UserAvatar } from '@/components/common/UserAvatar'
 import { CommentForm } from '@/components/qna/CommentForm'
 import { CommentList } from '@/components/qna/CommentList'
@@ -16,6 +15,8 @@ interface AnswerCardProps {
   isAuthenticated: boolean
   userId: number | null | undefined
   onAccept: (answerId: number) => void
+  showForm: boolean
+  onEditAction: () => void
 }
 
 export function AnswerCard({
@@ -28,9 +29,15 @@ export function AnswerCard({
   isAuthenticated,
   userId,
   onAccept,
+  showForm,
+  onEditAction,
 }: AnswerCardProps) {
   const canShowAcceptButton =
     isQuestionOwner && !anyAdopted && answer.author.id !== userId
+
+  // 본인 답변이고 폼이 닫혀 있을 때만 수정 버튼 표시
+  const canShowEditButton =
+    userId != null && answer.author.id === userId && !showForm
 
   return (
     <article className="rounded-[20px] border border-[#CECECE] px-[38px] py-11">
@@ -61,15 +68,25 @@ export function AnswerCard({
             </span>
           )}
           {canShowAcceptButton && (
-            <Button
-              size="sm"
+            <button
               type="button"
               onClick={() => onAccept(answer.id)}
               disabled={isAcceptPending}
-              loading={isAcceptPending && confirmAcceptId === answer.id}
+              className="bg-primary h-12 w-[112px] shrink-0 rounded-full text-base font-semibold text-white transition-colors hover:bg-[#3B0186] disabled:cursor-not-allowed disabled:bg-[#ECECEC] disabled:text-[#BDBDBD]"
             >
-              채택하기
-            </Button>
+              {isAcceptPending && confirmAcceptId === answer.id
+                ? '채택 중...'
+                : '채택하기'}
+            </button>
+          )}
+          {canShowEditButton && (
+            <button
+              type="button"
+              onClick={onEditAction}
+              className="h-12 w-[112px] shrink-0 rounded-full border border-[#6201E0] bg-[#EFE6FC] text-base font-semibold text-[#6201E0] transition-colors hover:bg-[#E0CFFA]"
+            >
+              답변 수정하기
+            </button>
           )}
         </div>
       </div>

--- a/src/components/qna/AnswerPromptCard/AnswerPromptCard.tsx
+++ b/src/components/qna/AnswerPromptCard/AnswerPromptCard.tsx
@@ -27,7 +27,7 @@ export function AnswerPromptCard({
 }: AnswerPromptCardProps) {
   let buttonLabel: string
   if (showForm) {
-    buttonLabel = isEdit ? '수정하기' : '답변하기'
+    buttonLabel = isEdit ? '저장하기' : '등록하기'
   } else {
     buttonLabel = isEdit ? '답변 수정하기' : '답변하기'
   }

--- a/src/components/qna/AnswerSection/AnswerSection.tsx
+++ b/src/components/qna/AnswerSection/AnswerSection.tsx
@@ -17,6 +17,8 @@ interface AnswerSectionProps {
   userId: number | null | undefined
   answers: GetAnswerItem[] | undefined
   onAccept: (answerId: number) => void
+  showForm: boolean
+  onEditAction: () => void
 }
 
 export function AnswerSection({
@@ -32,6 +34,8 @@ export function AnswerSection({
   userId,
   answers,
   onAccept,
+  showForm,
+  onEditAction,
 }: AnswerSectionProps) {
   return (
     <section aria-labelledby="answers-heading" className="mt-[100px]">
@@ -77,6 +81,8 @@ export function AnswerSection({
                   isAuthenticated={isAuthenticated}
                   userId={userId}
                   onAccept={onAccept}
+                  showForm={showForm}
+                  onEditAction={onEditAction}
                 />
               ))}
             </div>

--- a/src/components/qna/QuestionDetail/QuestionDetail.tsx
+++ b/src/components/qna/QuestionDetail/QuestionDetail.tsx
@@ -156,7 +156,7 @@ export function QuestionDetail({
             <button
               type="button"
               onClick={onShare}
-              className="hover:border-primary hover:text-primary inline-flex items-center gap-1.5 rounded-full border border-[#CECECE] px-4 py-2 text-sm text-[#4D4D4D] transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full border border-[#CECECE] px-4 py-2 text-sm text-[#4D4D4D] transition-colors hover:bg-[#ECECEC]"
             >
               <LinkIcon />
               공유하기

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -269,13 +269,16 @@ export function QnaDetailPage() {
             )}
           </div>
         ) : (
-          <AnswerPromptCard
-            nickname={user?.nickname ?? ''}
-            profileImageUrl={user?.profileImage}
-            isEdit={isEdit}
-            disabled={anyAdopted}
-            onAction={() => setShowForm(true)}
-          />
+          // 답변 미작성 상태일 때만 AnswerPromptCard 표시
+          !isEdit && (
+            <AnswerPromptCard
+              nickname={user?.nickname ?? ''}
+              profileImageUrl={user?.profileImage}
+              isEdit={false}
+              disabled={anyAdopted}
+              onAction={() => setShowForm(true)}
+            />
+          )
         ))}
 
       {/* 답변 목록 */}
@@ -292,6 +295,8 @@ export function QnaDetailPage() {
         userId={user?.id}
         answers={answers}
         onAccept={setConfirmAcceptId}
+        showForm={showForm}
+        onEditAction={() => setShowForm(true)}
       />
 
       {/* 채택 확인 모달 */}


### PR DESCRIPTION
## Summary

- 답변 수정 버튼(`답변 수정하기`)을 `AnswerPromptCard`(페이지 상단)에서 본인 답변 `AnswerCard` 내부 헤더 우측으로 이동
- 답변 미작성 상태일 때만 `AnswerPromptCard` 단독 렌더링, 답변 작성 후에는 제거
- 폼 열림 시 에디터는 기존 위치(상단)에서 열리며, 카드 내 수정 버튼은 자동 숨김
- 버튼 레이블 정리: 답변하기 → **등록하기**, 수정하기 → **저장하기** (폼 열린 상태)
- 채택하기·답변하기·등록하기·저장하기 버튼 hover 색상 `#3B0186` 통일
- 공유하기 버튼 hover 배경색 `#ECECEC` 적용
- 답변 수정하기 버튼 스타일: 배경 `#EFE6FC`, 테두리 `#6201E0`

## Test plan

- [ ] 답변 미작성 상태: `AnswerPromptCard`("답변하기") 노출 확인
- [ ] 답변하기 클릭 후 버튼 레이블 "등록하기"로 변경 확인
- [ ] 답변 작성 후: `AnswerPromptCard` 단독 카드 미노출, 본인 답변 카드에 "답변 수정하기" 버튼 노출 확인
- [ ] 답변 수정하기 클릭 후 에디터 상단 열림 + 버튼 레이블 "저장하기"로 변경 확인
- [ ] 각 버튼 hover 색상 확인 (채택하기·등록하기·저장하기: `#3B0186`, 공유하기: `#ECECEC`)
- [ ] 타인 답변 카드에는 수정 버튼 미노출 확인

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)