### PR TITLE
fix: 답변 개수 제한, 질문자 권한 제어, 채택 UI 원복 (#93)

### DIFF
--- a/.claude/scripts/rules/frontend-design-guide.checklist.js
+++ b/.claude/scripts/rules/frontend-design-guide.checklist.js
@@ -21,9 +21,8 @@ const checklist = [
     category: "Readability",
     name: "매직 넘버 명명",
     description: "의미 있는 숫자 리터럴이 명명된 상수로 추출되어 있는가?",
-    // QnaListPage: PAGE_SIZE=10, SEARCH_DEBOUNCE_MS=300 상수 추출됨
-    // CSS 픽셀값(944px, 211px, 472px 등)은 Figma 디자인 스펙 기반 레이아웃 값으로 허용
-    // Pagination: maxVisible=5 상수 추출됨
+    // AnswerCard: left-6, mt-4 는 Tailwind spacing 토큰. px-3/py-1/text-xs 는 Figma 디자인 스펙.
+    // QnaDetailPage: 신규 숫자 리터럴 없음.
     status: "O",
     violations: [],
   },
@@ -32,8 +31,7 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인증/권한)",
     description: "인증 체크, 권한 검사 등 공통 로직이 래퍼/가드 컴포넌트로 분리되어 있는가?",
-    // Header: useAuthStore 사용하여 인증 상태 확인 — 기존 패턴 유지
-    // 이번 변경에서 인증/권한 로직 신규 추가 없음
+    // !isQuestionOwner 는 기존 canAnswer 패턴과 동일한 인라인 조건 — 신규 인증 래퍼 불필요
     status: "N/A",
     violations: [],
   },
@@ -42,9 +40,8 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인터랙션)",
     description: "다이얼로그/오버레이 등 복잡한 인터랙션이 전용 컴포넌트로 추출되어 있는가?",
-    // SortPopover: QnaListPage 내 별도 컴포넌트로 분리됨
-    // CategoryFilter: 전용 컴포넌트로 분리, Modal 공용 컴포넌트 활용
-    status: "O",
+    // 신규 다이얼로그/오버레이 없음
+    status: "N/A",
     violations: [],
   },
   {
@@ -52,8 +49,8 @@ const checklist = [
     category: "Readability",
     name: "조건부 렌더링 분리",
     description: "역할/상태에 따라 크게 다른 UI/로직이 별도 컴포넌트로 분리되어 있는가?",
-    // QuestionCard: 썸네일 유무에 따른 조건부 렌더링 — 같은 컴포넌트 내 단순 분기
-    // QnaListPage: isLoading/isError/data 상태별 분기 — 적절한 단순 분기
+    // AnswerCard: is_adopted 여부에 따른 래퍼 div + article 분기 — 구조적 변경이므로 별도 컴포넌트화 불필요
+    // QnaDetailPage: canAnswer && !isQuestionOwner 조건 추가 — 단순 조건 변경
     status: "O",
     violations: [],
   },
@@ -62,7 +59,9 @@ const checklist = [
     category: "Readability",
     name: "복잡한 삼항 연산자 단순화",
     description: "중첩 삼항 연산자가 if/else 또는 IIFE로 대체되어 있는가?",
-    // 중첩 삼항 연산자 없음. className 조인에 단일 삼항만 사용
+    // AnswerCard: answer.is_adopted ? 'relative mt-4' : undefined — 단일 삼항, 중첩 없음
+    // AnswerCard: answer.is_adopted ? 'border-primary' : 'border-[#CECECE]' — 단일 삼항, 중첩 없음
+    // QnaDetailPage: canShowAnswerPrompt && (...) — 논리 AND, 삼항 아님
     status: "O",
     violations: [],
   },
@@ -71,9 +70,8 @@ const checklist = [
     category: "Readability",
     name: "시선 이동 감소 (Colocation)",
     description: "단일 사용처에서만 쓰이는 단순 로직이 사용 위치 근처에 배치되어 있는가?",
-    // SORT_LABEL, SORT_OPTIONS, PAGE_SIZE 등 QnaListPage 파일 상단에 정의
-    // SortPopover 컴포넌트가 QnaListPage 내에 같이 정의됨 (단일 사용처)
-    // NAV_BTN 상수가 Pagination 파일 내 정의
+    // canShowAnswerPrompt: anyAdopted/isQuestionOwner 정의 직후 배치, 렌더 섹션과 근접
+    // canShowEditButton, canShowAcceptButton: return 직전 정의
     status: "O",
     violations: [],
   },
@@ -82,9 +80,8 @@ const checklist = [
     category: "Readability",
     name: "복잡한 조건에 이름 붙이기",
     description: "2개 이상 조합된 boolean 표현식이 의미 있는 변수명으로 추출되어 있는가?",
-    // QuestionCard: isAnswered = question.answer_count > 0
-    // QnaListPage: hasFilter = categoryId != null
-    // CategoryFilter: canApply = largeCategoryId !== ''
+    // QnaDetailPage: !isEdit && !justPosted → canShowAnswerPrompt 로 추출 완료
+    // AnswerCard: canShowAcceptButton(3조건), canShowEditButton(3조건) 모두 명명됨
     status: "O",
     violations: [],
   },
@@ -95,7 +92,7 @@ const checklist = [
     category: "Predictability",
     name: "API 훅 반환 타입 표준화",
     description: "유사한 API 훅들이 일관된 반환 타입(UseQueryResult 등)을 사용하는가?",
-    // 이번 변경에서 API 훅 신규/변경 없음
+    // API 훅 신규/변경 없음
     status: "N/A",
     violations: [],
   },
@@ -104,7 +101,7 @@ const checklist = [
     category: "Predictability",
     name: "검증 함수 반환 타입 표준화",
     description: "검증 함수들이 일관된 Discriminated Union 타입을 반환하는가?",
-    // 스테이징된 파일에 검증 함수 없음
+    // 검증 함수 없음
     status: "N/A",
     violations: [],
   },
@@ -113,7 +110,7 @@ const checklist = [
     category: "Predictability",
     name: "숨겨진 사이드 이펙트 제거",
     description: "함수가 이름에 드러나지 않은 사이드 이펙트(로깅, 분석 등)를 수행하지 않는가?",
-    // handleTabChange, handlePageChange, updateParam 등 이름에 드러난 동작만 수행
+    // setJustPosted(true): postAnswer onSuccess 콜백 내 state 업데이트 — 이름에 드러난 동작만 수행
     status: "O",
     violations: [],
   },
@@ -133,8 +130,8 @@ const checklist = [
     category: "Cohesion",
     name: "폼 응집도 선택",
     description: "폼 검증이 용도에 맞게 필드 단위 또는 폼 단위로 일관되게 선택되어 있는가?",
-    // CategoryFilter: canApply 단일 조건 (대분류 선택 여부) — 적절
-    status: "O",
+    // 폼 검증 로직 변경 없음
+    status: "N/A",
     violations: [],
   },
   {
@@ -142,9 +139,7 @@ const checklist = [
     category: "Cohesion",
     name: "도메인별 디렉토리 구조",
     description: "기능/도메인 관련 코드가 도메인 폴더에 묶여 있는가?",
-    // QuestionCard, CategoryFilter → src/components/qna/
-    // 카테고리/질문 핸들러 → src/features/qna/
-    // 공용 Modal, Pagination → src/components/common/
+    // 변경 파일 모두 src/components/qna/, src/pages/qna/ 내 — 도메인 구조 준수
     status: "O",
     violations: [],
   },
@@ -153,8 +148,7 @@ const checklist = [
     category: "Cohesion",
     name: "상수와 로직의 근접성",
     description: "상수가 사용 로직과 가까운 위치에 정의되어 있거나 이름으로 용도가 명확한가?",
-    // SORT_LABEL, SORT_OPTIONS → QnaListPage 파일 상단, 사용처와 근접
-    // NAV_BTN → Pagination 파일 내 정의
+    // canShowAnswerPrompt, canShowEditButton, canShowAcceptButton — 각 사용처 근접 정의
     status: "O",
     violations: [],
   },
@@ -165,8 +159,7 @@ const checklist = [
     category: "Coupling",
     name: "성급한 추상화 지양",
     description: "단순히 비슷하다는 이유로 섣불리 공통 훅/함수로 추출되지 않았는가?",
-    // SortPopover: QnaListPage 전용 — 단일 사용처이므로 파일 내 정의 적절
-    // CategoryFilter: onHandle 콜백으로 부모와 소통 — useCategorySelector 훅 재활용
+    // 인라인 스타일 조건 — 불필요한 공통 컴포넌트 추출 없음
     status: "O",
     violations: [],
   },
@@ -175,8 +168,7 @@ const checklist = [
     category: "Coupling",
     name: "상태 관리 범위 축소",
     description: "여러 관심사가 하나의 훅/컨텍스트에 묶이지 않고 분리되어 있는가?",
-    // QnaListPage: URL params(searchParams), 입력값(inputValue), 모달(showCategoryModal), 필터핸들(filterHandle) 각각 독립 state
-    // SortPopover: open, focusIndex 독립 state
+    // justPosted: QnaDetailPage 로컬 상태, 단일 관심사(제출 후 AnswerPromptCard 숨김)만 담당
     status: "O",
     violations: [],
   },
@@ -185,8 +177,8 @@ const checklist = [
     category: "Coupling",
     name: "Props Drilling 제거",
     description: "3단계 이상 props 전달이 컴포지션(children)으로 대체되어 있는가?",
-    // CategoryFilter → QnaListPage: 1단계 props 전달, drilling 없음
-    status: "N/A",
+    // showForm, onEditAction: QnaDetailPage → AnswerSection → AnswerCard (2단계) — 3단계 미만, 허용
+    status: "O",
     violations: [],
   },
 ];

--- a/src/components/qna/AnswerCard/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard/AnswerCard.tsx
@@ -40,78 +40,89 @@ export function AnswerCard({
     userId != null && answer.author.id === userId && !showForm
 
   return (
-    <article className="rounded-[20px] border border-[#CECECE] px-[38px] py-11">
-      {/* 카드 헤더: 프로필 (좌) / 채택 라벨·버튼 (우) */}
-      <div className="mb-10 flex items-center justify-between">
-        <div className="flex items-center gap-5">
-          <UserAvatar
-            size="lg"
-            profileImageUrl={answer.author.profile_image_url}
-            nickname={answer.author.nickname}
-          />
-          <div>
-            <p className="text-base leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D]">
-              {answer.author.nickname}
-            </p>
-            <div className="mt-1 flex items-center gap-2 text-xs leading-normal tracking-[-0.03em] text-[#9D9D9D]">
-              <span>
-                {answer.author.course_name} &lt;{answer.author.cohort_name}&gt;
-              </span>
+    <div className={answer.is_adopted ? 'relative mt-4' : undefined}>
+      {answer.is_adopted && (
+        <div
+          aria-label="질문자가 채택한 답변"
+          className="bg-primary absolute top-0 left-6 -translate-y-1/2 rounded-full px-3 py-1 text-xs font-bold text-white"
+        >
+          질문자 채택
+        </div>
+      )}
+      <article
+        className={[
+          'rounded-[20px] border px-[38px] py-11',
+          answer.is_adopted ? 'border-primary' : 'border-[#CECECE]',
+        ].join(' ')}
+      >
+        {/* 카드 헤더: 프로필 (좌) / 채택 버튼 (우) */}
+        <div className="mb-10 flex items-center justify-between">
+          <div className="flex items-center gap-5">
+            <UserAvatar
+              size="lg"
+              profileImageUrl={answer.author.profile_image_url}
+              nickname={answer.author.nickname}
+            />
+            <div>
+              <p className="text-base leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D]">
+                {answer.author.nickname}
+              </p>
+              <div className="mt-1 flex items-center gap-2 text-xs leading-normal tracking-[-0.03em] text-[#9D9D9D]">
+                <span>
+                  {answer.author.course_name} &lt;{answer.author.cohort_name}
+                  &gt;
+                </span>
+              </div>
             </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {canShowAcceptButton && (
+              <button
+                type="button"
+                onClick={() => onAccept(answer.id)}
+                disabled={isAcceptPending}
+                className="bg-primary h-12 w-[112px] shrink-0 rounded-full text-base font-semibold text-white transition-colors hover:bg-[#3B0186] disabled:cursor-not-allowed disabled:bg-[#ECECEC] disabled:text-[#BDBDBD]"
+              >
+                {isAcceptPending && confirmAcceptId === answer.id
+                  ? '채택 중...'
+                  : '채택하기'}
+              </button>
+            )}
+            {canShowEditButton && (
+              <button
+                type="button"
+                onClick={onEditAction}
+                className="h-12 w-[112px] shrink-0 rounded-full border border-[#6201E0] bg-[#EFE6FC] text-base font-semibold text-[#6201E0] transition-colors hover:bg-[#E0CFFA]"
+              >
+                답변 수정하기
+              </button>
+            )}
           </div>
         </div>
 
-        <div className="flex items-center gap-3">
-          {answer.is_adopted && (
-            <span className="text-primary text-xs font-bold tracking-[-0.03em]">
-              채택된 답변
-            </span>
-          )}
-          {canShowAcceptButton && (
-            <button
-              type="button"
-              onClick={() => onAccept(answer.id)}
-              disabled={isAcceptPending}
-              className="bg-primary h-12 w-[112px] shrink-0 rounded-full text-base font-semibold text-white transition-colors hover:bg-[#3B0186] disabled:cursor-not-allowed disabled:bg-[#ECECEC] disabled:text-[#BDBDBD]"
-            >
-              {isAcceptPending && confirmAcceptId === answer.id
-                ? '채택 중...'
-                : '채택하기'}
-            </button>
-          )}
-          {canShowEditButton && (
-            <button
-              type="button"
-              onClick={onEditAction}
-              className="h-12 w-[112px] shrink-0 rounded-full border border-[#6201E0] bg-[#EFE6FC] text-base font-semibold text-[#6201E0] transition-colors hover:bg-[#E0CFFA]"
-            >
-              답변 수정하기
-            </button>
-          )}
+        {/* 답변 본문 */}
+        <div className="text-base leading-normal tracking-[-0.03em] text-[#121212]">
+          <MarkdownViewer content={answer.content} />
         </div>
-      </div>
 
-      {/* 답변 본문 */}
-      <div className="text-base leading-normal tracking-[-0.03em] text-[#121212]">
-        <MarkdownViewer content={answer.content} />
-      </div>
+        {/* 하단: 시간 + 디바이더 */}
+        <div className="flex justify-end border-b border-[#CECECE] pt-8 pb-5">
+          <time
+            dateTime={answer.updated_at}
+            className="text-base leading-normal tracking-[-0.03em] text-[#9D9D9D]"
+          >
+            {getRelativeTime(answer.updated_at)}
+          </time>
+        </div>
 
-      {/* 하단: 시간 + 디바이더 */}
-      <div className="flex justify-end border-b border-[#CECECE] pt-8 pb-5">
-        <time
-          dateTime={answer.updated_at}
-          className="text-base leading-normal tracking-[-0.03em] text-[#9D9D9D]"
-        >
-          {getRelativeTime(answer.updated_at)}
-        </time>
-      </div>
+        {/* 댓글 입력 (먼저) → 댓글 목록 (나중) — Figma 순서 */}
+        {isAuthenticated && (
+          <CommentForm answerId={answer.id} questionId={numericQuestionId} />
+        )}
 
-      {/* 댓글 입력 (먼저) → 댓글 목록 (나중) — Figma 순서 */}
-      {isAuthenticated && (
-        <CommentForm answerId={answer.id} questionId={numericQuestionId} />
-      )}
-
-      <CommentList comments={answer.comments} />
-    </article>
+        <CommentList comments={answer.comments} />
+      </article>
+    </div>
   )
 }

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -37,6 +37,7 @@ export function QnaDetailPage() {
     ANSWER_ALLOWED_ROLES.includes(user.role)
 
   const [showForm, setShowForm] = useState(false)
+  const [justPosted, setJustPosted] = useState(false)
   const [confirmAcceptId, setConfirmAcceptId] = useState<number | null>(null)
   const answerFormRef = useRef<AnswerFormHandle>(null)
 
@@ -96,6 +97,7 @@ export function QnaDetailPage() {
   const anyAdopted = answers?.some((a) => a.is_adopted) ?? false
   const isQuestionOwner =
     user?.id != null && questionDetail?.author.id === user.id
+  const canShowAnswerPrompt = !isEdit && !justPosted
 
   const handleCreateSubmit = (content: string, imageUrls: string[]) => {
     postAnswer(
@@ -104,6 +106,7 @@ export function QnaDetailPage() {
         onSuccess: () => {
           showToast('답변이 등록되었습니다.', 'success')
           setShowForm(false)
+          setJustPosted(true)
         },
         onError: (error) => {
           const { message, action } = handleApiError(
@@ -236,6 +239,7 @@ export function QnaDetailPage() {
 
       {/* 답변 유도 카드 / 답변 작성·수정 폼 */}
       {canAnswer &&
+        !isQuestionOwner &&
         !isAnswersLoading &&
         !isAnswersError &&
         (showForm ? (
@@ -269,8 +273,8 @@ export function QnaDetailPage() {
             )}
           </div>
         ) : (
-          // 답변 미작성 상태일 때만 AnswerPromptCard 표시
-          !isEdit && (
+          // 답변 미작성 상태이고 방금 제출하지 않은 경우만 AnswerPromptCard 표시
+          canShowAnswerPrompt && (
             <AnswerPromptCard
               nickname={user?.nickname ?? ''}
               profileImageUrl={user?.profileImage}


### PR DESCRIPTION
## 관련 이슈

- closes #93

## 작업 내용

- 답변 개수 제한: 한 질문당 동일 유저는 단 하나의 답변만 작성 가능하도록 제한
- 질문자 권한 제어: 질문 작성자에게 "답변하기" 카드가 노출되지 않도록 처리
- 채택 UI 원복: 채택된 답변 카드의 디자인을 Figma 기준 정상 디자인으로 복원

## 변경 사항

- `QnaDetailPage.tsx`
  - `justPosted` state 추가 — 답변 등록 성공 직후 AnswerPromptCard 재노출 race condition 방지
  - `canShowAnswerPrompt` 변수로 조건 명명 (`!isEdit && !justPosted`)
  - `!isQuestionOwner` 조건 추가 — 질문 작성자에게 답변하기 카드/폼 미노출
- `AnswerCard.tsx`
  - 채택된 답변 카드에 보라색 테두리(`border-primary`) 적용
  - 카드 상단 외부에 "질문자 채택" pill 뱃지 복원 (absolute 포지션)
  - 헤더 내 텍스트 라벨 "채택된 답변" 제거

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다