### PR TITLE
fix: QnA categories/questions 실제 API 연동 수정

### DIFF
--- a/src/features/qna/categories/queries.ts
+++ b/src/features/qna/categories/queries.ts
@@ -5,8 +5,10 @@ import type { CategoriesResponse } from './types'
 const categoriesQueryOptions = queryOptions({
   queryKey: ['qna', 'categories'],
   queryFn: async () => {
-    const { data } = await api.get<CategoriesResponse>('/qna/categories/')
-    return data
+    const { data } = await api.get<{ categories: CategoriesResponse }>(
+      '/qna/categories'
+    )
+    return data.categories
   },
 })
 

--- a/src/features/qna/question-write/queries.ts
+++ b/src/features/qna/question-write/queries.ts
@@ -8,7 +8,7 @@ export function useCreateQuestion() {
     {
       mutationFn: async (payload) => {
         const { data } = await api.post<QuestionCreateResponse>(
-          '/qna/questions/',
+          '/qna/questions',
           payload
         )
         return data

--- a/src/features/qna/question-write/types.ts
+++ b/src/features/qna/question-write/types.ts
@@ -2,6 +2,7 @@ export interface QuestionCreateRequest {
   category_id: number
   title: string
   content: string
+  img_urls?: string[]
 }
 
 export interface QuestionCreateResponse {


### PR DESCRIPTION
## 관련 이슈

- 실제 API 테스트 결과 발견된 버그 수정

## 작업 내용

- 실제 API(`https://api.ozcodingschool.site/api/v1`) 응답과 프론트엔드 코드의 불일치 수정

## 변경 사항

- `GET /qna/categories` trailing slash 제거 (`/qna/categories/` → `/qna/categories`)
- `GET /qna/categories` 응답 구조 언래핑 — 실제 서버는 `{ categories: [] }` 래퍼로 반환하지만 프론트는 `UserCategory[]` 배열로 예상하고 있었음
- `POST /qna/questions` trailing slash 제거 (`/qna/questions/` → `/qna/questions`)
- `QuestionCreateRequest`에 `img_urls` 필드 추가 — 실제 서버 필드명은 `image_urls`가 아닌 `img_urls`

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다