### PR TITLE
fix: .env.development gitignore 제외 (#98)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 .env
 .env.local
 .env.*
+!.env.development
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- `.gitignore`의 `.env.*` 패턴에 의해 `.env.development`가 제외되어, 클론 시 `VITE_API_BASE_URL`이 `undefined`가 되고 MSW 핸들러 URL 매칭 실패 → 화면이 렌더링 후 즉시 사라지는 버그 수정
- `.env.development`를 gitignore 예외 처리하여 레포에 포함

## Changes
- `.gitignore`: `!.env.development` 예외 규칙 추가
- `.env.development`: 레포에 트래킹 추가 (`VITE_API_BASE_URL=/api/v1`)

## Test plan
- [ ] 새 디렉토리에 클론 후 `pnpm install && pnpm dev` 실행 시 정상 동작 확인
- [ ] `.env.development` 파일이 클론에 포함되는지 확인
- [ ] MSW 초기화 성공 로그 (`[MSW] Mocking enabled`) 확인

closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)