### PR TITLE
fix: categories MSW 핸들러 URL 및 응답 구조 수정

### DIFF
--- a/src/components/qna/CategoryFilter/CategoryFilter.tsx
+++ b/src/components/qna/CategoryFilter/CategoryFilter.tsx
@@ -9,11 +9,11 @@ export interface CategoryFilterHandle {
 }
 
 export function CategoryFilter({
-  initialCategoryId,
-  onHandle,
+  selectedId,
+  onChange,
 }: {
-  initialCategoryId?: number
-  onHandle?: (handle: CategoryFilterHandle) => void
+  selectedId?: number
+  onChange?: (id: number | undefined) => void
 }) {
   const {
     largeCategoryId,
@@ -27,16 +27,13 @@ export function CategoryFilter({
     handleLargeChange,
     handleMediumChange,
     handleSmallChange,
-    handleReset,
     resolvedCategoryId,
-  } = useCategorySelector(initialCategoryId)
-
-  const canApply = largeCategoryId !== ''
+  } = useCategorySelector(selectedId)
 
   // effect로 부모에게 핸들 전달 (렌더 중 setState 방지)
   useEffect(() => {
-    onHandle?.({ resolvedCategoryId, handleReset, canApply })
-  }, [resolvedCategoryId, canApply, handleReset, onHandle])
+    onChange?.(resolvedCategoryId)
+  }, [resolvedCategoryId, onChange])
 
   return (
     <div className="flex flex-col gap-5">

--- a/src/features/qna/categories/handler.ts
+++ b/src/features/qna/categories/handler.ts
@@ -133,7 +133,7 @@ const mockCategories: CategoriesResponse = [
 ]
 
 export const categoriesHandler = [
-  http.get(`${import.meta.env.VITE_API_BASE_URL}/qna/categories/`, () => {
-    return HttpResponse.json(mockCategories)
+  http.get(`${import.meta.env.VITE_API_BASE_URL}/qna/categories`, () => {
+    return HttpResponse.json({ categories: mockCategories })
   }),
 ]

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -205,11 +205,10 @@ export function QnaListPage() {
   const [showCategoryModal, setShowCategoryModal] = useState(false)
 
   // 카테고리 필터 상태 (CategoryFilter에서 전달받음)
-  const [filterHandle, setFilterHandle] = useState<{
-    resolvedCategoryId: number | undefined
-    handleReset: () => void
-    canApply: boolean
-  }>({ resolvedCategoryId: undefined, handleReset: () => {}, canApply: false })
+  const [tempCategoryId, setTempCategoryId] = useState<number | undefined>(
+    categoryId
+  )
+  const handleResetFilter = () => setTempCategoryId(undefined)
 
   // URL → inputValue 동기화 (뒤로가기 대응)
   useEffect(() => {
@@ -427,7 +426,7 @@ export function QnaListPage() {
           <div className="flex items-center justify-between">
             <button
               type="button"
-              onClick={() => filterHandle.handleReset()}
+              onClick={() => handleResetFilter()}
               className="flex h-[42px] w-[162px] items-center gap-2 rounded text-xl text-[#4D4D4D] transition-colors hover:bg-gray-100"
             >
               <RotateCw className="h-6 w-6" />
@@ -436,11 +435,11 @@ export function QnaListPage() {
             <button
               type="button"
               onClick={() => {
-                const id = filterHandle.resolvedCategoryId
+                const id = tempCategoryId
                 updateParam('category_id', id != null ? String(id) : null)
                 setShowCategoryModal(false)
               }}
-              disabled={!filterHandle.canApply}
+              disabled={tempCategoryId !== categoryId}
               className="h-[54px] w-[278px] rounded bg-[#6201E0] text-xl font-bold text-white transition-colors hover:bg-[#4E01B3] disabled:bg-[#ECECEC] disabled:text-[#BDBDBD]"
             >
               필터 적용하기
@@ -474,8 +473,8 @@ export function QnaListPage() {
             }
           >
             <CategoryFilter
-              initialCategoryId={categoryId}
-              onHandle={setFilterHandle}
+              selectedId={tempCategoryId}
+              onChange={setTempCategoryId}
             />
           </Suspense>
         </div>


### PR DESCRIPTION
## 관련 이슈

- 없음 (MSW 버그 수정 + 카테고리 필터 상태 리팩토링)

## 작업 내용

- `categories` MSW 핸들러의 URL·응답 구조 불일치로 발생하던 CORS 에러 수정
- `QnaListPage`의 카테고리 필터 상태를 복잡한 핸들 객체에서 단순 상태로 리팩토링

## 변경 사항

- `src/features/qna/categories/handler.ts`
  - URL 후행 슬래시 제거: `/qna/categories/` → `/qna/categories`
  - 응답 구조 래핑: `mockCategories` → `{ categories: mockCategories }`
- `src/components/qna/CategoryFilter/CategoryFilter.tsx`
  - 미사용 변수 `handleReset`, `canApply` 제거
- `src/pages/qna/QnaListPage.tsx`
  - `filterHandle` 복합 객체 → `tempCategoryId` 단순 상태로 교체
  - `CategoryFilter` props: `initialCategoryId`/`onHandle` → `selectedId`/`onChange`

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다