### PR TITLE
fix: AuthBootstrap 토큰 만료 시 로그인 리다이렉트 방지 (#110)

### DIFF
--- a/src/features/accounts/me/queries.ts
+++ b/src/features/accounts/me/queries.ts
@@ -1,8 +1,19 @@
-import api from '@/api/instance'
+import axios from 'axios'
 import type { MeResponse } from './types'
 
-/** 현재 로그인된 사용자 정보를 가져온다. */
+/**
+ * 현재 로그인된 사용자 정보를 가져온다.
+ * interceptor를 거치지 않는 별도 axios 사용 — /me 실패 시 로그인 리다이렉트 방지.
+ * AuthBootstrap에서 실패를 직접 처리한다 (토큰 삭제 + 비로그인 상태 유지).
+ */
 export async function fetchMe(): Promise<MeResponse> {
-  const { data } = await api.get<MeResponse>('/accounts/me')
+  const token = localStorage.getItem('accessToken')
+  const { data } = await axios.get<MeResponse>(
+    `${import.meta.env.VITE_API_BASE_URL}/accounts/me`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      withCredentials: true,
+    }
+  )
   return data
 }


### PR DESCRIPTION
## 관련 이슈

- closes #110

## 작업 내용

- fetchMe()에서 interceptor 포함 api 인스턴스 → 순수 axios로 변경
- /me 실패 시 AuthBootstrap이 조용히 토큰 삭제 + 비로그인 상태 유지
- 비로그인 허용 페이지(QnA 등)에서 /login으로 강제 리다이렉트되지 않음

## 변경 사항

- src/features/accounts/me/queries.ts (1파일)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)