### PR TITLE
fix: 헤더 네비게이션을 외부 도메인 <a> 태그로 변경

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
 import logoImg from '@/assets/logo.png'
 import defaultProfile from '@/assets/default-profile.png'
-import { ROUTES } from '@/constants/routes'
+import { EXTERNAL_URLS } from '@/constants/routes'
 import { ProfileDropdown } from './ProfileDropdown'
 import { useAuthStore } from '@/stores/authStore'
-import { redirectToLogin } from '@/utils/loginRedirect'
 
 export interface HeaderProps {
   bannerText?: string
@@ -20,11 +18,10 @@ function HeaderBanner({ text }: { text: string }) {
   )
 }
 
-function HeaderLogo({ onClick }: { onClick: () => void }) {
+function HeaderLogo() {
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <a
+      href={EXTERNAL_URLS.HOME}
       className="flex shrink-0 items-center"
       aria-label="홈으로 이동"
     >
@@ -35,63 +32,47 @@ function HeaderLogo({ onClick }: { onClick: () => void }) {
         height={20}
         className="h-5 w-auto"
       />
-    </button>
+    </a>
   )
 }
 
-function HeaderNav({
-  onCommunity,
-  onQna,
-}: {
-  onCommunity: () => void
-  onQna: () => void
-}) {
+function HeaderNav() {
   return (
     <nav className="hidden items-center gap-8 md:flex lg:gap-15">
-      <button
-        type="button"
-        onClick={onCommunity}
+      <a
+        href={EXTERNAL_URLS.COMMUNITY}
         className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
       >
         커뮤니티
-      </button>
-      <button
-        type="button"
-        onClick={onQna}
+      </a>
+      <a
+        href={EXTERNAL_URLS.QNA}
         className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
       >
         질의응답
-      </button>
+      </a>
     </nav>
   )
 }
 
-function AuthLinks({
-  onLogin,
-  onSignup,
-}: {
-  onLogin: () => void
-  onSignup: () => void
-}) {
+function AuthLinks() {
   return (
     <div className="flex items-center gap-3 text-sm tracking-tight text-gray-600 sm:text-base">
-      <button
-        type="button"
-        onClick={onLogin}
+      <a
+        href={EXTERNAL_URLS.LOGIN}
         className="transition-colors duration-150 hover:text-gray-900"
       >
         로그인
-      </button>
+      </a>
       <span className="text-gray-400" aria-hidden="true">
         |
       </span>
-      <button
-        type="button"
-        onClick={onSignup}
+      <a
+        href={EXTERNAL_URLS.SIGNUP}
         className="transition-colors duration-150 hover:text-gray-900"
       >
         회원가입
-      </button>
+      </a>
     </div>
   )
 }
@@ -105,7 +86,6 @@ function ProfileMenu({
   setDropdownOpen: React.Dispatch<React.SetStateAction<boolean>>
   onLogout?: () => void
 }) {
-  const navigate = useNavigate()
   const { user } = useAuthStore()
 
   return (
@@ -133,14 +113,6 @@ function ProfileMenu({
         onClose={() => setDropdownOpen(false)}
         nickname={user?.nickname ?? ''}
         email={user?.email ?? ''}
-        onEnroll={() => {
-          navigate(ROUTES.SIGNUP.SELECT)
-          setDropdownOpen(false)
-        }}
-        onMypage={() => {
-          navigate(ROUTES.MYPAGE.HOME)
-          setDropdownOpen(false)
-        }}
         onLogout={() => {
           onLogout?.()
           setDropdownOpen(false)
@@ -155,7 +127,6 @@ export function Header({
   onLogout,
 }: HeaderProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false)
-  const navigate = useNavigate()
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
 
   return (
@@ -165,11 +136,8 @@ export function Header({
       <div className="border-b border-black/20 bg-white">
         <div className="max-w-container mx-auto flex h-16 items-center justify-between px-4">
           <div className="flex items-center gap-8 lg:gap-15">
-            <HeaderLogo onClick={() => navigate(ROUTES.HOME)} />
-            <HeaderNav
-              onCommunity={() => navigate(ROUTES.COMMUNITY.LIST)}
-              onQna={() => navigate(ROUTES.QNA.LIST)}
-            />
+            <HeaderLogo />
+            <HeaderNav />
           </div>
 
           {isAuthenticated ? (
@@ -179,10 +147,7 @@ export function Header({
               onLogout={onLogout}
             />
           ) : (
-            <AuthLinks
-              onLogin={redirectToLogin}
-              onSignup={() => navigate(ROUTES.SIGNUP.SELECT)}
-            />
+            <AuthLinks />
           )}
         </div>
       </div>

--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useRef } from 'react'
 import { Button } from '@/components/common/Button'
+import { EXTERNAL_URLS } from '@/constants/routes'
 
 export interface ProfileDropdownProps {
   isOpen: boolean
   onClose: () => void
   nickname: string
   email: string
-  onEnroll?: () => void
-  onMypage?: () => void
   onLogout?: () => void
 }
 
@@ -16,8 +15,6 @@ export function ProfileDropdown({
   onClose,
   nickname,
   email,
-  onEnroll,
-  onMypage,
   onLogout,
 }: ProfileDropdownProps) {
   const ref = useRef<HTMLDivElement>(null)
@@ -108,28 +105,22 @@ export function ProfileDropdown({
 
         {/* 메뉴 항목 */}
         <div className="flex flex-col gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            fullWidth
+          <a
+            href={EXTERNAL_URLS.SIGNUP}
             role="menuitem"
             tabIndex={-1}
-            onClick={onEnroll}
-            className="text-text-heading hover:text-primary h-12 justify-start"
+            className="text-text-heading hover:text-primary flex h-12 items-center px-3 text-sm font-medium"
           >
             수강생 등록
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            fullWidth
+          </a>
+          <a
+            href={EXTERNAL_URLS.MYPAGE}
             role="menuitem"
             tabIndex={-1}
-            onClick={onMypage}
-            className="text-text-heading hover:text-primary h-12 justify-start tracking-tight"
+            className="text-text-heading hover:text-primary flex h-12 items-center px-3 text-sm font-medium tracking-tight"
           >
             마이페이지
-          </Button>
+          </a>
           <Button
             variant="ghost"
             size="sm"

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,3 +1,14 @@
+// 외부 도메인 URL (헤더 네비게이션용)
+export const EXTERNAL_URLS = {
+  HOME: 'https://my.ozcodingschool.site/',
+  LOGIN: 'https://my.ozcodingschool.site/login',
+  SIGNUP: 'https://my.ozcodingschool.site/signup',
+  MYPAGE: 'https://my.ozcodingschool.site/mypage',
+  COMMUNITY: 'https://community.ozcodingschool.site/community',
+  QNA: 'https://qna.ozcodingschool.site/',
+} as const
+
+// SPA 내부 라우트
 export const ROUTES = {
   HOME: '/',
 

--- a/src/utils/loginRedirect.ts
+++ b/src/utils/loginRedirect.ts
@@ -1,0 +1,7 @@
+import { EXTERNAL_URLS } from '@/constants/routes'
+
+export const LOGIN_URL = import.meta.env.VITE_LOGIN_URL ?? EXTERNAL_URLS.LOGIN
+
+export function redirectToLogin() {
+  window.location.assign(LOGIN_URL)
+}


### PR DESCRIPTION
## 관련 이슈

- closes #116

## 작업 내용

- 헤더의 `button + useNavigate()` 네비게이션을 실제 외부 도메인 URL의 `<a>` 태그로 변경
- `EXTERNAL_URLS` 상수를 `routes.ts`에 추가하여 외부 URL을 한곳에서 관리

## 변경 사항

- `src/constants/routes.ts` — `EXTERNAL_URLS` 상수 추가 (HOME, LOGIN, SIGNUP, MYPAGE, COMMUNITY, QNA)
- `src/components/layout/Header/Header.tsx` — 로고, 커뮤니티, 질의응답, 로그인, 회원가입을 `<a href>` 로 변경. `useNavigate` 제거
- `src/components/layout/Header/ProfileDropdown.tsx` — 수강생 등록, 마이페이지를 `<a href>` 로 변경. `onEnroll`, `onMypage` props 제거
- `src/utils/loginRedirect.ts` — `EXTERNAL_URLS.LOGIN`을 기본값으로 사용하도록 변경

| 항목 | URL |
|------|-----|
| 로고 | `https://my.ozcodingschool.site/` |
| 커뮤니티 | `https://community.ozcodingschool.site/community` |
| 질의응답 | `https://qna.ozcodingschool.site/` |
| 로그인 | `https://my.ozcodingschool.site/login` |
| 회원가입 | `https://my.ozcodingschool.site/signup` |
| 수강생 등록 | `https://my.ozcodingschool.site/signup` |
| 마이페이지 | `https://my.ozcodingschool.site/mypage` |

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다