### PR TITLE
fix: 필터 모달 UI 개선 및 버그 수정 (#120)

### DIFF
--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -72,7 +72,7 @@ export function Modal({
     >
       <div
         className={[
-          'bg-bg-base relative flex max-h-[90vh] w-full flex-col rounded-2xl shadow-xl',
+          'bg-bg-base relative mx-auto flex max-h-[90vh] w-full flex-col overflow-hidden rounded-2xl shadow-xl',
           maxWidth,
         ].join(' ')}
       >

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -113,7 +113,7 @@ function SortPopover({
         ref={triggerRef}
         type="button"
         aria-haspopup="menu"
-        aria-expanded={open}
+        aria-expanded={open ? 'true' : 'false'}
         onClick={() => {
           setOpen((p) => {
             if (!p) {
@@ -123,7 +123,7 @@ function SortPopover({
             return !p
           })
         }}
-        className="flex items-center gap-1 text-base text-[#303030]"
+        className="flex items-center gap-1 text-base text-gray-700"
       >
         {SORT_LABEL[sort]}
         <ArrowUpDown className="h-5 w-5" />
@@ -208,7 +208,11 @@ export function QnaListPage() {
   const [tempCategoryId, setTempCategoryId] = useState<number | undefined>(
     categoryId
   )
-  const handleResetFilter = () => setTempCategoryId(undefined)
+  const [filterResetKey, setFilterResetKey] = useState(0)
+  const handleResetFilter = () => {
+    setTempCategoryId(undefined)
+    setFilterResetKey((k) => k + 1)
+  }
 
   // URL → inputValue 동기화 (뒤로가기 대응)
   useEffect(() => {
@@ -330,7 +334,7 @@ export function QnaListPage() {
         <button
           type="button"
           onClick={() => navigate(ROUTES.QNA.WRITE)}
-          className="flex h-12 items-center gap-2 rounded-[4px] bg-[#6201E0] px-9 text-base font-bold text-white transition-colors hover:bg-[#4E01B3]"
+          className="flex h-12 items-center gap-2 rounded-sm bg-[#6201E0] px-9 text-base font-bold text-white transition-colors hover:bg-[#4E01B3]"
         >
           <Pencil className="h-5 w-5" />
           질문하기
@@ -439,8 +443,7 @@ export function QnaListPage() {
                 updateParam('category_id', id != null ? String(id) : null)
                 setShowCategoryModal(false)
               }}
-              disabled={tempCategoryId !== categoryId}
-              className="h-[54px] w-[278px] rounded bg-[#6201E0] text-xl font-bold text-white transition-colors hover:bg-[#4E01B3] disabled:bg-[#ECECEC] disabled:text-[#BDBDBD]"
+              className="h-[54px] w-[278px] rounded bg-[#6201E0] text-xl font-bold text-white transition-colors hover:bg-[#4E01B3]"
             >
               필터 적용하기
             </button>
@@ -463,7 +466,7 @@ export function QnaListPage() {
         </div>
 
         {/* 본문 */}
-        <div className="-mx-6 min-h-[700px] px-12 pt-[60px] pb-10">
+        <div className="-mx-6 px-12 pt-[60px] pb-10">
           <h3 className="mb-5 text-xl font-bold text-[#4D4D4D]">
             카테고리 선택
           </h3>
@@ -473,6 +476,7 @@ export function QnaListPage() {
             }
           >
             <CategoryFilter
+              key={filterResetKey}
               selectedId={tempCategoryId}
               onChange={setTempCategoryId}
             />


### PR DESCRIPTION
## Summary

- 필터 모달(QnaListPage) UI 개선 3종 및 기능 버그 2건 수정

## 변경 내용

### `src/components/common/Modal/Modal.tsx`
- 내부 컨테이너에 `mx-auto` 추가 → 데스크탑에서 좌측 치우침 해소, 화면 중앙 배치
- 내부 컨테이너에 `overflow-hidden` 추가 → 자식 요소가 `rounded-2xl` 경계 밖에 그려지던 문제 수정, 우상단 radius 정상 적용

### `src/pages/qna/QnaListPage.tsx`
- 필터 모달 본문 `min-h-[700px]` 제거 → 불필요한 내부 스크롤바 제거
- 필터 적용하기 버튼 `disabled={tempCategoryId !== categoryId}` 제거 → 카테고리 선택 시 버튼이 비활성화되던 반전 로직 수정
- 선택 초기화 버튼: `filterResetKey` + `key` prop 패턴으로 `CategoryFilter` 강제 재마운트 → 드롭다운 내부 state가 초기화되지 않던 문제 수정
- `aria-expanded={open}` → `aria-expanded={open ? 'true' : 'false'}` 명시적 문자열로 변경 (ARIA 스펙 준수)
- Tailwind 임의값 클래스 canonical 클래스로 교체 (`text-[#303030]` → `text-gray-700`, `rounded-[4px]` → `rounded-sm`)

## Test plan

- [ ] `/qna` 접속 → 필터 버튼 클릭 → 모달이 화면 중앙에 뜨는지 확인
- [ ] 모달 네 모서리가 모두 둥글게 처리되는지 확인 (특히 우상단)
- [ ] 모달 내부 스크롤바가 없는지 확인
- [ ] 카테고리(대/중/소분류) 선택 후 필터 적용하기 버튼 활성화 확인
- [ ] 선택 초기화 버튼 클릭 시 드롭다운이 초기화되는지 확인

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)