### PR TITLE
fix: 앱 시작 시 쿠키 Refresh Token으로 Access Token 재발급 (#126)

### DIFF
--- a/src/providers/AuthBootstrap.tsx
+++ b/src/providers/AuthBootstrap.tsx
@@ -1,39 +1,71 @@
 import { useEffect, useState } from 'react'
+import axios from 'axios'
 import { useAuthStore } from '@/stores/authStore'
 import { fetchMe } from '@/features/accounts/me'
 import { Spinner } from '@/components'
 
+/** 쿠키의 Refresh Token으로 Access Token을 재발급받는다. */
+async function refreshAccessToken(): Promise<string> {
+  const { data } = await axios.post(
+    `${import.meta.env.VITE_API_BASE_URL}/accounts/me/refresh`,
+    {},
+    { withCredentials: true }
+  )
+  return data.access_token
+}
+
+/** /me 응답을 authStore에 저장한다. */
+function toLoginPayload(user: Awaited<ReturnType<typeof fetchMe>>) {
+  return {
+    id: user.id,
+    nickname: user.nickname,
+    email: user.email,
+    profileImage: user.profile_image,
+    role: user.role,
+  }
+}
+
 /**
- * 앱 시작 시 localStorage에 토큰이 있으면 /me를 호출해 사용자 정보를 복원한다.
- * 토큰이 없거나 만료되면 로그아웃 상태로 유지.
+ * 앱 시작 시 인증 상태를 복원한다.
+ * 1. localStorage에 토큰이 있으면 → /me 호출 (실패 시 refresh 후 재시도)
+ * 2. 토큰이 없으면 → 쿠키의 Refresh Token으로 재발급 시도 후 /me 호출
+ * 3. 모두 실패하면 비로그인 상태로 유지
  */
 export function AuthBootstrap({ children }: { children: React.ReactNode }) {
-  const hasToken = Boolean(localStorage.getItem('accessToken'))
-  const [isReady, setIsReady] = useState(!hasToken)
+  const [isReady, setIsReady] = useState(false)
   const { login, logout } = useAuthStore()
 
   useEffect(() => {
-    if (!hasToken) return
+    const hasToken = Boolean(localStorage.getItem('accessToken'))
 
-    fetchMe()
-      .then((user) => {
-        login({
-          id: user.id,
-          nickname: user.nickname,
-          email: user.email,
-          profileImage: user.profile_image,
-          role: user.role,
-        })
-      })
-      .catch(() => {
-        // 토큰 만료/무효 → 로그아웃
+    const restoreWithToken = async () => {
+      try {
+        const user = await fetchMe()
+        login(toLoginPayload(user))
+      } catch {
+        // 토큰 만료 → refresh 시도
+        localStorage.removeItem('accessToken')
+        await restoreWithRefresh()
+      }
+    }
+
+    const restoreWithRefresh = async () => {
+      try {
+        const newToken = await refreshAccessToken()
+        localStorage.setItem('accessToken', newToken)
+        const user = await fetchMe()
+        login(toLoginPayload(user))
+      } catch {
+        // 쿠키도 만료 → 비로그인 상태
         localStorage.removeItem('accessToken')
         logout()
-      })
-      .finally(() => {
-        setIsReady(true)
-      })
-  }, [hasToken, login, logout])
+      }
+    }
+
+    const restore = hasToken ? restoreWithToken : restoreWithRefresh
+
+    restore().finally(() => setIsReady(true))
+  }, [login, logout])
 
   if (!isReady) {
     return (


### PR DESCRIPTION
## 관련 이슈

- closes #126

## 작업 내용

- 앱 시작 시 localStorage에 accessToken이 없어도 쿠키의 Refresh Token으로 인증 상태를 복원하도록 수정

## 변경 사항

- `src/providers/AuthBootstrap.tsx`
  - `refreshAccessToken()` 함수 추가: 쿠키의 Refresh Token으로 `/accounts/me/refresh` 호출
  - `toLoginPayload()` 헬퍼 추가: /me 응답 → authStore 형식 변환
  - 기존: localStorage에 토큰 없으면 → 아무것도 안 함 (비로그인)
  - 수정: 토큰 없어도 → refresh 시도 → 성공 시 토큰 저장 + /me 호출 → 로그인 복원
  - 토큰 있는데 /me 실패 → refresh 재시도 후 그래도 실패하면 로그아웃

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다