### PR TITLE
fix: QnaListPage 탭 활성 언더라인 위치 버그 수정 (#125)

### DIFF
--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -90,7 +90,7 @@ export function TabList({
       tabIndex={-1}
       aria-label={ariaLabel}
       onKeyDown={handleKeyDown}
-      className={['border-border-base flex border-b', className]
+      className={['border-border-base flex', className]
         .filter(Boolean)
         .join(' ')}
     >
@@ -126,7 +126,7 @@ export function Tab({ value, children, disabled = false }: TabProps) {
         'relative shrink-0 px-4 py-3 text-sm font-medium transition-colors duration-150 outline-none',
         'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-inset',
         isActive
-          ? 'text-primary after:bg-primary after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:rounded-t-full'
+          ? 'text-primary after:bg-primary after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-t-full'
           : 'text-text-muted hover:text-text-body',
         disabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
       ]

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -343,7 +343,7 @@ export function QnaListPage() {
 
       {/* 탭 + 정렬/필터를 한 줄에 배치 */}
       <Tabs value={answerStatus} onChange={handleTabChange}>
-        <div className="flex items-end justify-between border-b border-[#CECECE] pb-2">
+        <div className="flex items-end justify-between border-b border-[#CECECE]">
           <TabList aria-label="답변 상태 필터" className="flex gap-10 border-0">
             <Tab value="all">전체보기</Tab>
             <Tab value="answered">답변완료</Tab>


### PR DESCRIPTION
## 관련 이슈

- closes #125

## 작업 내용

- `QnaListPage`에서 탭 활성 언더라인이 탭 중간에 표시되는 버그 수정

## 변경 사항

- `QnaListPage.tsx`: TabList를 감싸는 div에서 `pb-2` 제거
  - 하단 패딩(8px)이 버튼 바닥과 `border-b` 사이에 간격을 만들어, `after:bottom-0` 언더라인이 중간에 떠 보이는 원인이었음
- `Tabs.tsx`: Tab 활성 언더라인 `after:bottom-0` → `after:-bottom-px` 조정
  - 외부 div의 border와 정확히 맞닿도록 1px 오프셋 적용
- `Tabs.tsx`: TabList 기본 클래스에서 `border-b` 제거
  - QnaListPage처럼 외부 div가 border를 담당하는 구조에서 이중 border 방지

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다