### PR TITLE
dev → main 병합

### DIFF
--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -90,7 +90,7 @@ export function TabList({
       tabIndex={-1}
       aria-label={ariaLabel}
       onKeyDown={handleKeyDown}
-      className={['border-border-base flex border-b', className]
+      className={['border-border-base flex', className]
         .filter(Boolean)
         .join(' ')}
     >
@@ -126,7 +126,7 @@ export function Tab({ value, children, disabled = false }: TabProps) {
         'relative shrink-0 px-4 py-3 text-sm font-medium transition-colors duration-150 outline-none',
         'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-inset',
         isActive
-          ? 'text-primary after:bg-primary after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:rounded-t-full'
+          ? 'text-primary after:bg-primary after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-t-full'
           : 'text-text-muted hover:text-text-body',
         disabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
       ]

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -142,9 +142,16 @@ function DevAuthPanel() {
 }
 
 export function DefaultLayout() {
+  const { logout } = useAuthStore()
+
+  const handleLogout = () => {
+    logout()
+    localStorage.removeItem('accessToken')
+  }
+
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
+      <Header onLogout={handleLogout} />
       <main className="flex-1">
         <Outlet />
       </main>

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -14,17 +14,24 @@ interface RoleOption {
   label: string
   color: string
   nickname?: string
+  profileImage?: string
 }
 
 const ROLE_OPTIONS: RoleOption[] = [
   { role: 'USER', label: '일반회원', color: 'bg-gray-500' },
-  { role: 'STUDENT', label: '수강생', color: 'bg-blue-400' },
+  {
+    role: 'STUDENT',
+    label: '수강생 (이미지 있음)',
+    color: 'bg-blue-400',
+    profileImage: 'https://i.pravatar.cc/80?u=student',
+  },
   {
     role: 'STUDENT',
     id: 100,
     label: '질문 작성자',
     color: 'bg-blue-600',
     nickname: '질문자',
+    profileImage: 'https://i.pravatar.cc/80?u=100',
   },
   {
     role: 'STUDENT',
@@ -52,13 +59,20 @@ function DevAuthPanel() {
 
   if (!import.meta.env.DEV) return null
 
-  const handleLogin = ({ id, role, label, nickname }: RoleOption) => {
+  const handleLogin = ({
+    id,
+    role,
+    label,
+    nickname,
+    profileImage,
+  }: RoleOption) => {
     localStorage.setItem('accessToken', 'dev-mock-token')
     login({
       id,
       nickname: nickname ?? `Dev ${label}`,
       email: `${role.toLowerCase()}@test.com`,
       role,
+      profileImage,
     })
   }
 

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -105,6 +105,9 @@ function ProfileMenu({
           width={40}
           height={40}
           className="aspect-square h-10 w-10 rounded-full object-cover"
+          onError={(e) => {
+            e.currentTarget.src = defaultProfile
+          }}
         />
       </button>
 

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -38,7 +38,7 @@ function HeaderLogo() {
 
 function HeaderNav() {
   return (
-    <nav className="hidden items-center gap-8 md:flex lg:gap-15">
+    <nav className="flex items-center gap-15">
       <a
         href={EXTERNAL_URLS.COMMUNITY}
         className="hover:text-primary px-2.5 py-2.5 text-lg tracking-tight text-gray-900 transition-colors duration-150"
@@ -135,7 +135,7 @@ export function Header({
 
       <div className="border-b border-black/20 bg-white">
         <div className="max-w-container mx-auto flex h-16 items-center justify-between px-4">
-          <div className="flex items-center gap-8 lg:gap-15">
+          <div className="flex items-center gap-15">
             <HeaderLogo />
             <HeaderNav />
           </div>

--- a/src/features/qna/answer-accept/queries.ts
+++ b/src/features/qna/answer-accept/queries.ts
@@ -12,8 +12,6 @@ export function useAcceptAnswer(questionId: number) {
         .post<AcceptAnswerResponse>(`/qna/answers/${answerId}/accept`)
         .then((res) => res.data),
     onSuccess: () => {
-      // TanStack Query가 두 호출을 내부적으로 병렬 처리한다
-      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
       queryClient.invalidateQueries({
         queryKey: ['question-detail', questionId],
       })

--- a/src/features/qna/answers/queries.ts
+++ b/src/features/qna/answers/queries.ts
@@ -18,7 +18,9 @@ export function usePostAnswer(questionId: number) {
         .post<PostAnswerResponse>(`/qna/questions/${questionId}/answers`, data)
         .then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+      queryClient.invalidateQueries({
+        queryKey: ['question-detail', questionId],
+      })
     },
   })
 }
@@ -49,7 +51,9 @@ export function usePutAnswer(answerId: number | undefined, questionId: number) {
       return res.data
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+      queryClient.invalidateQueries({
+        queryKey: ['question-detail', questionId],
+      })
     },
   })
 }

--- a/src/features/qna/question-detail/handler.ts
+++ b/src/features/qna/question-detail/handler.ts
@@ -1,6 +1,9 @@
 import { http, HttpResponse } from 'msw'
 import type { GetQuestionDetailResponse } from './types'
 
+const MOCK_ANSWER_ID = 801
+const MOCK_AUTHOR_ID = 211
+
 export const questionDetailHandler = [
   http.get(
     `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:question_id`,
@@ -27,7 +30,36 @@ export const questionDetailHandler = [
           course_name: 'OZ 코딩스쿨',
           cohort_name: '8기',
         },
-        answers: [],
+        answers: [
+          {
+            id: MOCK_ANSWER_ID,
+            author: {
+              id: MOCK_AUTHOR_ID,
+              nickname: '테스트유저',
+              profile_image_url: null,
+              course_name: 'OZ 코딩스쿨',
+              cohort_name: '8기',
+            },
+            content: '기존 답변 내용입니다.\n\n마크다운으로 작성된 답변입니다.',
+            is_adopted: false,
+            images: [],
+            comments: [
+              {
+                id: 1001,
+                author: {
+                  id: 301,
+                  nickname: '댓글러',
+                  profile_image_url: null,
+                },
+                content: '도움이 많이 되었습니다. 감사해요!',
+                created_at: new Date(Date.now() - 3600000).toISOString(),
+                updated_at: new Date(Date.now() - 3600000).toISOString(),
+              },
+            ],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        ],
       }
       return HttpResponse.json(response, { status: 200 })
     }

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -12,11 +12,7 @@ import { AnswerSection } from '@/components/qna/AnswerSection'
 import { AnswerPromptCard } from '@/components/qna/AnswerPromptCard'
 import { useAuthStore } from '@/stores/authStore'
 import { ANSWER_ALLOWED_ROLES } from '@/constants/roles'
-import {
-  usePostAnswer,
-  useGetAnswers,
-  usePutAnswer,
-} from '@/features/qna/answers'
+import { usePostAnswer, usePutAnswer } from '@/features/qna/answers'
 import { useAcceptAnswer } from '@/features/qna/answer-accept'
 import { useGetQuestionDetail } from '@/features/qna/question-detail'
 import { useToast } from '@/hooks/useToast'
@@ -48,11 +44,9 @@ export function QnaDetailPage() {
     isError: isQuestionError,
   } = useGetQuestionDetail(numericQuestionId)
 
-  const {
-    data: answers,
-    isLoading: isAnswersLoading,
-    isError: isAnswersError,
-  } = useGetAnswers(numericQuestionId)
+  const answers = questionDetail?.answers
+  const isAnswersLoading = isQuestionLoading
+  const isAnswersError = isQuestionError
 
   const { mutate: postAnswer, isPending: isPostPending } =
     usePostAnswer(numericQuestionId)

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -343,7 +343,7 @@ export function QnaListPage() {
 
       {/* 탭 + 정렬/필터를 한 줄에 배치 */}
       <Tabs value={answerStatus} onChange={handleTabChange}>
-        <div className="flex items-end justify-between border-b border-[#CECECE] pb-2">
+        <div className="flex items-end justify-between border-b border-[#CECECE]">
           <TabList aria-label="답변 상태 필터" className="flex gap-10 border-0">
             <Tab value="all">전체보기</Tab>
             <Tab value="answered">답변완료</Tab>


### PR DESCRIPTION
## 관련 이슈

- closes #126
- closes #125
- closes #128
- closes #131
- closes #135

## 작업 내용

- fix: 앱 시작 시 쿠키 Refresh Token으로 Access Token 재발급 로직 추가 (#126)
- fix: 챗봇 SSE 요청에서 Accept 헤더 제거하여 406 오류 해결 (#128)
- fix: QnaListPage 탭 활성 언더라인 위치 버그 수정 (#125)
- fix: 헤더 네비게이션 반응형 동작 통일 + 로그인 시 프로필 이미지 표시 (#131)
- fix: QnA 로그아웃 버튼 미동작 및 답변 목록 로딩 실패 수정 (#135)

## 변경 사항

- `src/providers/AuthBootstrap.tsx` — localStorage에 토큰 없어도 쿠키 Refresh Token으로 인증 복원
- `src/features/chatbot/hooks/sendStreamingMessage.ts` — SSE 요청 Accept 헤더 제거
- `src/components/common/Tabs/Tabs.tsx` — 탭 언더라인 위치 수정
- `src/components/layout/Header/Header.tsx` — 반응형 네비게이션 통일 + 프로필 이미지 표시
- `src/components/layout/DefaultLayout.tsx` — 헤더 레이아웃 수정
- `src/pages/qna/QnaDetailPage.tsx` — 로그아웃 버튼 동작 수정
- `src/features/qna/answers/queries.ts` — 답변 목록 로딩 수정
- 미사용 chatbot 모듈 삭제 (session-detail, support)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다