### PR TITLE
fix: QnA 로그아웃 버튼 미동작 및 답변 목록 로딩 실패 수정 (#135)

### DIFF
--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -142,9 +142,16 @@ function DevAuthPanel() {
 }
 
 export function DefaultLayout() {
+  const { logout } = useAuthStore()
+
+  const handleLogout = () => {
+    logout()
+    localStorage.removeItem('accessToken')
+  }
+
   return (
     <div className="flex min-h-screen flex-col">
-      <Header />
+      <Header onLogout={handleLogout} />
       <main className="flex-1">
         <Outlet />
       </main>

--- a/src/features/qna/answer-accept/queries.ts
+++ b/src/features/qna/answer-accept/queries.ts
@@ -12,8 +12,6 @@ export function useAcceptAnswer(questionId: number) {
         .post<AcceptAnswerResponse>(`/qna/answers/${answerId}/accept`)
         .then((res) => res.data),
     onSuccess: () => {
-      // TanStack Query가 두 호출을 내부적으로 병렬 처리한다
-      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
       queryClient.invalidateQueries({
         queryKey: ['question-detail', questionId],
       })

--- a/src/features/qna/answers/queries.ts
+++ b/src/features/qna/answers/queries.ts
@@ -18,7 +18,9 @@ export function usePostAnswer(questionId: number) {
         .post<PostAnswerResponse>(`/qna/questions/${questionId}/answers`, data)
         .then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+      queryClient.invalidateQueries({
+        queryKey: ['question-detail', questionId],
+      })
     },
   })
 }
@@ -49,7 +51,9 @@ export function usePutAnswer(answerId: number | undefined, questionId: number) {
       return res.data
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['answers', questionId] })
+      queryClient.invalidateQueries({
+        queryKey: ['question-detail', questionId],
+      })
     },
   })
 }

--- a/src/features/qna/question-detail/handler.ts
+++ b/src/features/qna/question-detail/handler.ts
@@ -1,6 +1,9 @@
 import { http, HttpResponse } from 'msw'
 import type { GetQuestionDetailResponse } from './types'
 
+const MOCK_ANSWER_ID = 801
+const MOCK_AUTHOR_ID = 211
+
 export const questionDetailHandler = [
   http.get(
     `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:question_id`,
@@ -27,7 +30,36 @@ export const questionDetailHandler = [
           course_name: 'OZ 코딩스쿨',
           cohort_name: '8기',
         },
-        answers: [],
+        answers: [
+          {
+            id: MOCK_ANSWER_ID,
+            author: {
+              id: MOCK_AUTHOR_ID,
+              nickname: '테스트유저',
+              profile_image_url: null,
+              course_name: 'OZ 코딩스쿨',
+              cohort_name: '8기',
+            },
+            content: '기존 답변 내용입니다.\n\n마크다운으로 작성된 답변입니다.',
+            is_adopted: false,
+            images: [],
+            comments: [
+              {
+                id: 1001,
+                author: {
+                  id: 301,
+                  nickname: '댓글러',
+                  profile_image_url: null,
+                },
+                content: '도움이 많이 되었습니다. 감사해요!',
+                created_at: new Date(Date.now() - 3600000).toISOString(),
+                updated_at: new Date(Date.now() - 3600000).toISOString(),
+              },
+            ],
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        ],
       }
       return HttpResponse.json(response, { status: 200 })
     }

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -12,11 +12,7 @@ import { AnswerSection } from '@/components/qna/AnswerSection'
 import { AnswerPromptCard } from '@/components/qna/AnswerPromptCard'
 import { useAuthStore } from '@/stores/authStore'
 import { ANSWER_ALLOWED_ROLES } from '@/constants/roles'
-import {
-  usePostAnswer,
-  useGetAnswers,
-  usePutAnswer,
-} from '@/features/qna/answers'
+import { usePostAnswer, usePutAnswer } from '@/features/qna/answers'
 import { useAcceptAnswer } from '@/features/qna/answer-accept'
 import { useGetQuestionDetail } from '@/features/qna/question-detail'
 import { useToast } from '@/hooks/useToast'
@@ -48,11 +44,9 @@ export function QnaDetailPage() {
     isError: isQuestionError,
   } = useGetQuestionDetail(numericQuestionId)
 
-  const {
-    data: answers,
-    isLoading: isAnswersLoading,
-    isError: isAnswersError,
-  } = useGetAnswers(numericQuestionId)
+  const answers = questionDetail?.answers
+  const isAnswersLoading = isQuestionLoading
+  const isAnswersError = isQuestionError
 
   const { mutate: postAnswer, isPending: isPostPending } =
     usePostAnswer(numericQuestionId)


### PR DESCRIPTION
## Summary

- `DefaultLayout`에서 `<Header />`에 `onLogout` prop을 전달하지 않아 로그아웃 버튼이 동작하지 않던 문제 수정
- 실제 API에 별도 `/qna/questions/:id/answers` 엔드포인트가 없어 답변 로딩이 실패하던 문제 수정 — `questionDetail.answers`를 직접 사용하도록 변경

## Changes

### 로그아웃 버튼 미동작 (`DefaultLayout.tsx`)
- `DefaultLayout`에서 `useAuthStore`의 `logout`을 호출하는 `handleLogout` 추가
- `<Header onLogout={handleLogout} />` 으로 prop 전달

### 답변 목록 로딩 실패 (`QnaDetailPage.tsx`)
- `useGetAnswers` 제거 → `questionDetail?.answers` 직접 사용
- `isAnswersLoading`, `isAnswersError`를 question-detail 상태에서 파생
- 이로 인해 `isAnswersError=true`로 인해 숨겨지던 **답변하기 버튼**도 함께 복구됨

### mutation invalidate 정합성 (`answers/queries.ts`, `answer-accept/queries.ts`)
- `usePostAnswer`, `usePutAnswer`, `useAcceptAnswer` onSuccess → `['question-detail', questionId]` invalidate로 통일

### MSW 목 업데이트 (`question-detail/handler.ts`)
- `questionDetailHandler` 응답에 answers 데이터 포함 (배포 환경과 로컬 동작 일치)

## Test plan

- [ ] 헤더 프로필 드롭다운 → 로그아웃 클릭 시 로그아웃 처리되는지 확인
- [ ] `https://qna.ozcodingschool.site/qna` 에서 질문 클릭 → 답변 목록이 정상 표시되는지 확인
- [ ] 답변 가능한 역할(STUDENT 등)로 로그인 후 답변하기 버튼이 나타나는지 확인
- [ ] 답변 작성/수정/채택 후 목록이 갱신되는지 확인

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)