### PR TITLE
fix: 로그아웃 시 서버 logout API 호출하여 쿠키 제거 (#137)

### DIFF
--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -6,6 +6,7 @@ import { ChatbotFab, ChatbotWidget } from '@/components/chatbot'
 import { ChatbotPageContextSync } from '@/features/chatbot/ChatbotPageContextSync'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserRole } from '@/stores/authStore'
+import api from '@/api/instance'
 
 // DEV 전용 권한별 로그인 패널 — 운영 빌드에서는 렌더링 안 됨
 interface RoleOption {
@@ -144,7 +145,12 @@ function DevAuthPanel() {
 export function DefaultLayout() {
   const { logout } = useAuthStore()
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      await api.post('/accounts/logout')
+    } catch {
+      // 서버 로그아웃 실패해도 클라이언트는 로그아웃 처리
+    }
     logout()
     localStorage.removeItem('accessToken')
   }


### PR DESCRIPTION
## 관련 이슈

- closes #137

## 작업 내용

- 로그아웃 버튼 클릭 시 `POST /api/v1/accounts/logout` API를 호출하여 서버 측 httpOnly 쿠키(refresh_token)를 만료 처리

## 변경 사항

- `src/components/layout/DefaultLayout.tsx`
  - `handleLogout`에 `api.post('/accounts/logout')` 호출 추가
  - API 실패 시에도 클라이언트 로그아웃은 정상 진행 (try-catch)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다