### PR TITLE
fix: 프로필 드롭다운 hover 스타일 통일 + Q&A 질문하기 비로그인 리다이렉트

### DIFF
--- a/.claude/scripts/rules/frontend-design-guide.checklist.js
+++ b/.claude/scripts/rules/frontend-design-guide.checklist.js
@@ -21,8 +21,7 @@ const checklist = [
     category: "Readability",
     name: "매직 넘버 명명",
     description: "의미 있는 숫자 리터럴이 명명된 상수로 추출되어 있는가?",
-    // 신규 숫자: cursor 위치 계산(indent.length+1+bullet.length+1 등)으로
-    // 문자 길이(newline=1, space=1)를 더하는 구조적 산술 — 매직 넘버 아님
+    // 숫자 리터럴 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -31,8 +30,8 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인증/권한)",
     description: "인증 체크, 권한 검사 등 공통 로직이 래퍼/가드 컴포넌트로 분리되어 있는가?",
-    // 인증/권한 로직 변경 없음
-    status: "N/A",
+    // useAuthStore + redirectToLogin 유틸 사용 — 컴포넌트에 직접 작성 안 함
+    status: "O",
     violations: [],
   },
   {
@@ -40,7 +39,7 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인터랙션)",
     description: "다이얼로그/오버레이 등 복잡한 인터랙션이 전용 컴포넌트로 추출되어 있는가?",
-    // 신규 인터랙션 컴포넌트 없음
+    // 인터랙션 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -49,7 +48,7 @@ const checklist = [
     category: "Readability",
     name: "조건부 렌더링 분리",
     description: "역할/상태에 따라 크게 다른 UI/로직이 별도 컴포넌트로 분리되어 있는가?",
-    // 신규 조건부 렌더링 없음
+    // 조건부 렌더링 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -58,7 +57,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 삼항 연산자 단순화",
     description: "중첩 삼항 연산자가 if/else 또는 IIFE로 대체되어 있는가?",
-    // 추가된 삼항: 모두 단순 2분기 (중첩 없음) — needsExtraNewline ? '\n' : '' 등
+    // isAuthenticated ? navigate() : redirectToLogin() — 단순 2분기 (중첩 없음)
     status: "O",
     violations: [],
   },
@@ -67,7 +66,7 @@ const checklist = [
     category: "Readability",
     name: "시선 이동 감소 (Colocation)",
     description: "단일 사용처에서만 쓰이는 단순 로직이 사용 위치 근처에 배치되어 있는가?",
-    // 키다운 핸들러 내 인라인 처리 — 사용처와 로직이 동일 위치에 있음
+    // 인라인 클릭 핸들러 — 사용 위치에 배치
     status: "O",
     violations: [],
   },
@@ -76,9 +75,8 @@ const checklist = [
     category: "Readability",
     name: "복잡한 조건에 이름 붙이기",
     description: "2개 이상 조합된 boolean 표현식이 의미 있는 변수명으로 추출되어 있는가?",
-    // needsExtraNewline = !textAfter.startsWith('\n') 으로 명명됨
-    // prevLine === indent (단순 비교) — 추출 불필요
-    status: "O",
+    // isAuthenticated 단일 조건 — 조합 없음
+    status: "N/A",
     violations: [],
   },
 
@@ -106,7 +104,7 @@ const checklist = [
     category: "Predictability",
     name: "숨겨진 사이드 이펙트 제거",
     description: "함수가 이름에 드러나지 않은 사이드 이펙트(로깅, 분석 등)를 수행하지 않는가?",
-    // 신규 함수 없음 — keydown 핸들러 내 텍스트 조작만 수행
+    // 숨겨진 사이드 이펙트 없음
     status: "N/A",
     violations: [],
   },
@@ -135,7 +133,7 @@ const checklist = [
     category: "Cohesion",
     name: "도메인별 디렉토리 구조",
     description: "기능/도메인 관련 코드가 도메인 폴더에 묶여 있는가?",
-    // MarkdownEditor: src/components/qna/ 내 — 도메인 구조 준수
+    // 기존 파일 수정만 — 도메인 구조 유지
     status: "O",
     violations: [],
   },
@@ -144,7 +142,7 @@ const checklist = [
     category: "Cohesion",
     name: "상수와 로직의 근접성",
     description: "상수가 사용 로직과 가까운 위치에 정의되어 있거나 이름으로 용도가 명확한가?",
-    // 신규 상수 없음
+    // 상수 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -155,7 +153,7 @@ const checklist = [
     category: "Coupling",
     name: "성급한 추상화 지양",
     description: "단순히 비슷하다는 이유로 섣불리 공통 훅/함수로 추출되지 않았는가?",
-    // 불필요한 추상화 없음 — 기존 onKeyDown 핸들러 내 분기 추가
+    // 추상화 추가 없음
     status: "N/A",
     violations: [],
   },
@@ -164,7 +162,7 @@ const checklist = [
     category: "Coupling",
     name: "상태 관리 범위 축소",
     description: "여러 관심사가 하나의 훅/컨텍스트에 묶이지 않고 분리되어 있는가?",
-    // 상태 변경 없음
+    // 상태 관리 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -173,7 +171,7 @@ const checklist = [
     category: "Coupling",
     name: "Props Drilling 제거",
     description: "3단계 이상 props 전달이 컴포지션(children)으로 대체되어 있는가?",
-    // 신규 props 없음
+    // props drilling 없음
     status: "N/A",
     violations: [],
   },

--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -109,7 +109,7 @@ export function ProfileDropdown({
             href={EXTERNAL_URLS.SIGNUP}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary flex h-12 items-center px-3 text-sm font-medium"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors"
           >
             수강생 등록
           </a>
@@ -117,7 +117,7 @@ export function ProfileDropdown({
             href={EXTERNAL_URLS.MYPAGE}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary flex h-12 items-center px-3 text-sm font-medium tracking-tight"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium tracking-tight transition-colors"
           >
             마이페이지
           </a>

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -25,6 +25,8 @@ import {
 import { useQnaQuestions } from '@/features/qna/questions'
 import type { QuestionsListParams } from '@/features/qna/questions'
 import { ROUTES } from '@/constants/routes'
+import { useAuthStore } from '@/stores/authStore'
+import { redirectToLogin } from '@/utils/loginRedirect'
 
 type AnswerStatus = 'all' | 'answered' | 'unanswered'
 type SortOption = NonNullable<QuestionsListParams['sort']>
@@ -175,6 +177,7 @@ function SortPopover({
 export function QnaListPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
 
   const rawAnswerStatus = searchParams.get('answer_status') ?? 'all'
   const answerStatus: AnswerStatus = (
@@ -333,7 +336,9 @@ export function QnaListPage() {
 
         <button
           type="button"
-          onClick={() => navigate(ROUTES.QNA.WRITE)}
+          onClick={() =>
+            isAuthenticated ? navigate(ROUTES.QNA.WRITE) : redirectToLogin()
+          }
           className="flex h-12 items-center gap-2 rounded-sm bg-[#6201E0] px-9 text-base font-bold text-white transition-colors hover:bg-[#4E01B3]"
         >
           <Pencil className="h-5 w-5" />


### PR DESCRIPTION
## 관련 이슈

- closes #142

## 작업 내용

### 1. 프로필 드롭다운 hover 스타일 통일
- 수강생등록/마이페이지 항목에 로그아웃과 동일한 hover 배경색 적용

### 2. Q&A 질문하기 비로그인 리다이렉트
- 비로그인 유저가 "질문하기" 클릭 시 `https://my.ozcodingschool.site/login`으로 이동

## 변경 사항

- `ProfileDropdown.tsx`: `<a>` 태그에 `hover:bg-bg-accent`, `rounded-md`, `transition-colors` 추가
- `QnaListPage.tsx`: `useAuthStore`로 인증 상태 확인, 비로그인 시 `redirectToLogin()` 호출

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다