### PR TITLE
fix: profile_img_url 필드명 정합성 수정 및 answers 타입 방어처리 (#139)

### DIFF
--- a/src/components/qna/AnswerCard/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard/AnswerCard.tsx
@@ -60,7 +60,7 @@ export function AnswerCard({
           <div className="flex items-center gap-5">
             <UserAvatar
               size="lg"
-              profileImageUrl={answer.author.profile_image_url}
+              profileImageUrl={answer.author.profile_img_url}
               nickname={answer.author.nickname}
             />
             <div>
@@ -109,10 +109,10 @@ export function AnswerCard({
         {/* 하단: 시간 + 디바이더 */}
         <div className="flex justify-end border-b border-[#CECECE] pt-8 pb-5">
           <time
-            dateTime={answer.updated_at}
+            dateTime={answer.updated_at ?? answer.created_at}
             className="text-base leading-normal tracking-[-0.03em] text-[#9D9D9D]"
           >
-            {getRelativeTime(answer.updated_at)}
+            {getRelativeTime(answer.updated_at ?? answer.created_at)}
           </time>
         </div>
 

--- a/src/components/qna/CommentList/CommentList.tsx
+++ b/src/components/qna/CommentList/CommentList.tsx
@@ -84,7 +84,7 @@ export function CommentList({ comments }: CommentListProps) {
           <li key={comment.id} className="group flex gap-[17px]">
             <UserAvatar
               size="lg"
-              profileImageUrl={comment.author.profile_image_url}
+              profileImageUrl={comment.author.profile_img_url}
               nickname={comment.author.nickname}
             />
             <div className="flex flex-1 flex-col gap-3 border-b border-[#CECECE] pb-5 group-last:border-b-0">

--- a/src/components/qna/QuestionDetail/QuestionDetail.tsx
+++ b/src/components/qna/QuestionDetail/QuestionDetail.tsx
@@ -102,7 +102,7 @@ export function QuestionDetail({
             <div className="flex shrink-0 items-center gap-3">
               <UserAvatar
                 size="lg"
-                profileImageUrl={questionDetail.author.profile_image_url}
+                profileImageUrl={questionDetail.author.profile_img_url}
                 nickname={questionDetail.author.nickname}
               />
               <span className="text-base leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D]">

--- a/src/features/accounts/me/handler.ts
+++ b/src/features/accounts/me/handler.ts
@@ -13,7 +13,7 @@ export const meHandlers = [
       id: 1,
       nickname: 'dev',
       email: 'dev@test.com',
-      profile_image: null,
+      profile_image_url: null,
       role: 'STUDENT',
     })
   }),

--- a/src/features/accounts/me/types.ts
+++ b/src/features/accounts/me/types.ts
@@ -2,6 +2,6 @@ export interface MeResponse {
   id: number
   nickname: string
   email: string
-  profile_image: string | null
+  profile_img_url: string | null
   role: 'USER' | 'STUDENT' | 'TA' | 'OM' | 'LC' | 'ADMIN'
 }

--- a/src/features/qna/answer-comments/handler.ts
+++ b/src/features/qna/answer-comments/handler.ts
@@ -6,7 +6,7 @@ const MAX_COMMENT_LENGTH = 500
 const MOCK_AUTHOR: AnswerComment['author'] = {
   id: 211,
   nickname: '테스트유저',
-  profile_image_url: null,
+  profile_img_url: null,
 }
 
 // answerId → 댓글 목록 (MSW 인메모리 상태)

--- a/src/features/qna/answer-comments/types.ts
+++ b/src/features/qna/answer-comments/types.ts
@@ -12,7 +12,7 @@ export interface PostCommentResponse {
 export interface CommentAuthor {
   id: number
   nickname: string
-  profile_image_url: string | null
+  profile_img_url: string | null
 }
 
 export interface AnswerComment {

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -35,7 +35,7 @@ export const answersHandlers = [
           author: {
             id: MOCK_AUTHOR_ID,
             nickname: '테스트유저',
-            profile_image_url: null,
+            profile_img_url: null,
             course_name: 'OZ 코딩스쿨',
             cohort_name: '8기',
           },
@@ -45,7 +45,7 @@ export const answersHandlers = [
           comments: [
             {
               id: 1001,
-              author: { id: 301, nickname: '댓글러', profile_image_url: null },
+              author: { id: 301, nickname: '댓글러', profile_img_url: null },
               content: '도움이 많이 되었습니다. 감사해요!',
               created_at: new Date(Date.now() - 3600000).toISOString(),
               updated_at: new Date(Date.now() - 3600000).toISOString(),
@@ -55,7 +55,7 @@ export const answersHandlers = [
               author: {
                 id: 302,
                 nickname: '개발공부중',
-                profile_image_url: null,
+                profile_img_url: null,
               },
               content: '저도 같은 문제로 고민했는데 덕분에 해결했어요.',
               created_at: new Date(Date.now() - 1800000).toISOString(),

--- a/src/features/qna/answers/types.ts
+++ b/src/features/qna/answers/types.ts
@@ -15,7 +15,7 @@ export interface PostAnswerResponse {
 export interface AnswerAuthor {
   id: number
   nickname: string
-  profile_image_url: string | null
+  profile_img_url: string | null
   course_name: string
   cohort_name: string
 }
@@ -30,10 +30,10 @@ export interface GetAnswerItem {
   author: AnswerAuthor
   content: string
   is_adopted: boolean
-  images: AnswerImage[]
+  images?: AnswerImage[]
   comments: AnswerComment[]
   created_at: string
-  updated_at: string
+  updated_at?: string
 }
 
 export type GetAnswersResponse = GetAnswerItem[]

--- a/src/features/qna/question-detail/handler.ts
+++ b/src/features/qna/question-detail/handler.ts
@@ -26,7 +26,7 @@ export const questionDetailHandler = [
         author: {
           id: 100,
           nickname: '질문자',
-          profile_image_url: null,
+          profile_img_url: null,
           course_name: 'OZ 코딩스쿨',
           cohort_name: '8기',
         },
@@ -36,7 +36,7 @@ export const questionDetailHandler = [
             author: {
               id: MOCK_AUTHOR_ID,
               nickname: '테스트유저',
-              profile_image_url: null,
+              profile_img_url: null,
               course_name: 'OZ 코딩스쿨',
               cohort_name: '8기',
             },
@@ -49,7 +49,7 @@ export const questionDetailHandler = [
                 author: {
                   id: 301,
                   nickname: '댓글러',
-                  profile_image_url: null,
+                  profile_img_url: null,
                 },
                 content: '도움이 많이 되었습니다. 감사해요!',
                 created_at: new Date(Date.now() - 3600000).toISOString(),

--- a/src/features/qna/question-detail/types.ts
+++ b/src/features/qna/question-detail/types.ts
@@ -3,7 +3,7 @@ import type { GetAnswerItem } from '@/features/qna/answers'
 export interface QuestionAuthor {
   id: number
   nickname: string
-  profile_image_url: string | null
+  profile_img_url: string | null
   course_name: string
   cohort_name: string
 }

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -254,7 +254,9 @@ export function QnaDetailPage() {
                 isLoading={isPutPending}
                 mode="edit"
                 initialContent={myAnswer.content}
-                initialImgUrls={myAnswer.images.map((img) => img.img_url)}
+                initialImgUrls={
+                  myAnswer.images?.map((img) => img.img_url) ?? []
+                }
                 answerId={myAnswer.id}
               />
             ) : (

--- a/src/providers/AuthBootstrap.tsx
+++ b/src/providers/AuthBootstrap.tsx
@@ -20,7 +20,7 @@ function toLoginPayload(user: Awaited<ReturnType<typeof fetchMe>>) {
     id: user.id,
     nickname: user.nickname,
     email: user.email,
-    profileImage: user.profile_image,
+    profileImage: user.profile_img_url,
     role: user.role,
   }
 }


### PR DESCRIPTION
## Summary

- Swagger 기준 `profile_img_url`로 전체 필드명 통일 → 헤더 프로필 이미지 정상화
- `GetAnswerItem.images`, `updated_at` optional 처리로 실제 API 응답과 타입 정합성 확보

## Changes

### 프로필 이미지 필드명 (`profile_image` / `profile_image_url` → `profile_img_url`)
- `MeResponse`, `QuestionAuthor`, `AnswerAuthor`, `CommentAuthor` 타입 수정
- `AuthBootstrap.toLoginPayload`: `profile_img_url` 매핑 → 로그인 후 헤더 프로필 이미지 정상 표시
- 관련 컴포넌트 (`QuestionDetail`, `AnswerCard`, `CommentList`) 및 MSW 핸들러 일괄 수정

### `GetAnswerItem` 타입 방어처리
- `images?: AnswerImage[]` — Swagger 응답에 없는 필드를 optional로 변경
- `updated_at?: string` — optional 처리 + `AnswerCard`에서 `created_at` fallback 적용
- `QnaDetailPage`: `myAnswer.images?.map(...) ?? []` optional chaining 적용

## Test plan

- [ ] 배포 후 로그인 시 헤더 프로필 이미지가 실제 이미지로 표시되는지 확인
- [ ] QnA 상세 페이지에서 답변 카드, 댓글이 정상 렌더링되는지 확인
- [ ] 답변 수정 모드 진입 시 에러 없이 동작하는지 확인

> **참고**: 수강생 로그인 후 답변하기 카드 미노출 문제는 `canAnswer` 조건(`isAuthenticated && ANSWER_ALLOWED_ROLES.has(role)`) 관련으로, 테스트 계정의 실제 role 값 확인이 필요합니다. 프로필 이미지 fix 배포 후 재확인 요청드립니다.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)