### PR TITLE
chore: dev → main 통합 (#137, #140, #142)

### DIFF
--- a/.claude/scripts/rules/frontend-design-guide.checklist.js
+++ b/.claude/scripts/rules/frontend-design-guide.checklist.js
@@ -21,8 +21,7 @@ const checklist = [
     category: "Readability",
     name: "매직 넘버 명명",
     description: "의미 있는 숫자 리터럴이 명명된 상수로 추출되어 있는가?",
-    // 신규 숫자: cursor 위치 계산(indent.length+1+bullet.length+1 등)으로
-    // 문자 길이(newline=1, space=1)를 더하는 구조적 산술 — 매직 넘버 아님
+    // MSW handler delay(300)은 테스트 모킹 코드 — 매직 넘버 아님
     status: "N/A",
     violations: [],
   },
@@ -31,7 +30,7 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인증/권한)",
     description: "인증 체크, 권한 검사 등 공통 로직이 래퍼/가드 컴포넌트로 분리되어 있는가?",
-    // 인증/권한 로직 변경 없음
+    // isAuthenticated를 prop으로 받아 분기 — 인증 로직은 상위에서 관리
     status: "N/A",
     violations: [],
   },
@@ -49,8 +48,8 @@ const checklist = [
     category: "Readability",
     name: "조건부 렌더링 분리",
     description: "역할/상태에 따라 크게 다른 UI/로직이 별도 컴포넌트로 분리되어 있는가?",
-    // 신규 조건부 렌더링 없음
-    status: "N/A",
+    // isAuthenticated && 로 단순 표시/비표시 — 별도 컴포넌트 불필요
+    status: "O",
     violations: [],
   },
   {
@@ -58,7 +57,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 삼항 연산자 단순화",
     description: "중첩 삼항 연산자가 if/else 또는 IIFE로 대체되어 있는가?",
-    // 추가된 삼항: 모두 단순 2분기 (중첩 없음) — needsExtraNewline ? '\n' : '' 등
+    // isGetLoading ? '불러오고' : '생성하고' — 단순 2분기 (중첩 없음)
     status: "O",
     violations: [],
   },
@@ -67,7 +66,7 @@ const checklist = [
     category: "Readability",
     name: "시선 이동 감소 (Colocation)",
     description: "단일 사용처에서만 쓰이는 단순 로직이 사용 위치 근처에 배치되어 있는가?",
-    // 키다운 핸들러 내 인라인 처리 — 사용처와 로직이 동일 위치에 있음
+    // answerData, showAnswer 등 파생값이 사용처 근처에 정의됨
     status: "O",
     violations: [],
   },
@@ -76,8 +75,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 조건에 이름 붙이기",
     description: "2개 이상 조합된 boolean 표현식이 의미 있는 변수명으로 추출되어 있는가?",
-    // needsExtraNewline = !textAfter.startsWith('\n') 으로 명명됨
-    // prevLine === indent (단순 비교) — 추출 불필요
+    // hasExistingAnswer, isAutoOpen, showAnswer, isPending 등 명명됨
     status: "O",
     violations: [],
   },
@@ -88,8 +86,8 @@ const checklist = [
     category: "Predictability",
     name: "API 훅 반환 타입 표준화",
     description: "유사한 API 훅들이 일관된 반환 타입(UseQueryResult 등)을 사용하는가?",
-    // API 훅 변경 없음
-    status: "N/A",
+    // useGetAiFirstAnswer는 UseQueryResult 반환 — 프로젝트 패턴과 일관
+    status: "O",
     violations: [],
   },
   {
@@ -106,7 +104,7 @@ const checklist = [
     category: "Predictability",
     name: "숨겨진 사이드 이펙트 제거",
     description: "함수가 이름에 드러나지 않은 사이드 이펙트(로깅, 분석 등)를 수행하지 않는가?",
-    // 신규 함수 없음 — keydown 핸들러 내 텍스트 조작만 수행
+    // 숨겨진 사이드 이펙트 없음
     status: "N/A",
     violations: [],
   },
@@ -135,7 +133,7 @@ const checklist = [
     category: "Cohesion",
     name: "도메인별 디렉토리 구조",
     description: "기능/도메인 관련 코드가 도메인 폴더에 묶여 있는가?",
-    // MarkdownEditor: src/components/qna/ 내 — 도메인 구조 준수
+    // features/qna/question-ai-answer/ 내 — 도메인 구조 준수
     status: "O",
     violations: [],
   },
@@ -144,8 +142,8 @@ const checklist = [
     category: "Cohesion",
     name: "상수와 로직의 근접성",
     description: "상수가 사용 로직과 가까운 위치에 정의되어 있거나 이름으로 용도가 명확한가?",
-    // 신규 상수 없음
-    status: "N/A",
+    // AI_FIRST_ANSWER_QUERY_KEY가 queries.ts에 정의 — 사용 로직과 같은 파일
+    status: "O",
     violations: [],
   },
 
@@ -155,7 +153,7 @@ const checklist = [
     category: "Coupling",
     name: "성급한 추상화 지양",
     description: "단순히 비슷하다는 이유로 섣불리 공통 훅/함수로 추출되지 않았는가?",
-    // 불필요한 추상화 없음 — 기존 onKeyDown 핸들러 내 분기 추가
+    // 성급한 추상화 없음
     status: "N/A",
     violations: [],
   },
@@ -164,7 +162,7 @@ const checklist = [
     category: "Coupling",
     name: "상태 관리 범위 축소",
     description: "여러 관심사가 하나의 훅/컨텍스트에 묶이지 않고 분리되어 있는가?",
-    // 상태 변경 없음
+    // GET/POST 분리 유지
     status: "N/A",
     violations: [],
   },
@@ -173,8 +171,8 @@ const checklist = [
     category: "Coupling",
     name: "Props Drilling 제거",
     description: "3단계 이상 props 전달이 컴포지션(children)으로 대체되어 있는가?",
-    // 신규 props 없음
-    status: "N/A",
+    // isAuthenticated: QnaDetailPage → QuestionDetail(직접 사용) → AiFirstAnswerSection — QuestionDetail이 직접 사용하므로 drilling 아님
+    status: "O",
     violations: [],
   },
 ];

--- a/.claude/scripts/rules/frontend-design-guide.checklist.js
+++ b/.claude/scripts/rules/frontend-design-guide.checklist.js
@@ -21,8 +21,7 @@ const checklist = [
     category: "Readability",
     name: "매직 넘버 명명",
     description: "의미 있는 숫자 리터럴이 명명된 상수로 추출되어 있는가?",
-    // 신규 숫자: cursor 위치 계산(indent.length+1+bullet.length+1 등)으로
-    // 문자 길이(newline=1, space=1)를 더하는 구조적 산술 — 매직 넘버 아님
+    // 숫자 리터럴 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -31,8 +30,8 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인증/권한)",
     description: "인증 체크, 권한 검사 등 공통 로직이 래퍼/가드 컴포넌트로 분리되어 있는가?",
-    // 인증/권한 로직 변경 없음
-    status: "N/A",
+    // useAuthStore + redirectToLogin 유틸 사용 — 컴포넌트에 직접 작성 안 함
+    status: "O",
     violations: [],
   },
   {
@@ -40,7 +39,7 @@ const checklist = [
     category: "Readability",
     name: "구현 세부사항 추상화 (인터랙션)",
     description: "다이얼로그/오버레이 등 복잡한 인터랙션이 전용 컴포넌트로 추출되어 있는가?",
-    // 신규 인터랙션 컴포넌트 없음
+    // 인터랙션 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -49,7 +48,7 @@ const checklist = [
     category: "Readability",
     name: "조건부 렌더링 분리",
     description: "역할/상태에 따라 크게 다른 UI/로직이 별도 컴포넌트로 분리되어 있는가?",
-    // 신규 조건부 렌더링 없음
+    // 조건부 렌더링 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -58,7 +57,7 @@ const checklist = [
     category: "Readability",
     name: "복잡한 삼항 연산자 단순화",
     description: "중첩 삼항 연산자가 if/else 또는 IIFE로 대체되어 있는가?",
-    // 추가된 삼항: 모두 단순 2분기 (중첩 없음) — needsExtraNewline ? '\n' : '' 등
+    // isAuthenticated ? navigate() : redirectToLogin() — 단순 2분기 (중첩 없음)
     status: "O",
     violations: [],
   },
@@ -67,7 +66,7 @@ const checklist = [
     category: "Readability",
     name: "시선 이동 감소 (Colocation)",
     description: "단일 사용처에서만 쓰이는 단순 로직이 사용 위치 근처에 배치되어 있는가?",
-    // 키다운 핸들러 내 인라인 처리 — 사용처와 로직이 동일 위치에 있음
+    // 인라인 클릭 핸들러 — 사용 위치에 배치
     status: "O",
     violations: [],
   },
@@ -76,9 +75,8 @@ const checklist = [
     category: "Readability",
     name: "복잡한 조건에 이름 붙이기",
     description: "2개 이상 조합된 boolean 표현식이 의미 있는 변수명으로 추출되어 있는가?",
-    // needsExtraNewline = !textAfter.startsWith('\n') 으로 명명됨
-    // prevLine === indent (단순 비교) — 추출 불필요
-    status: "O",
+    // isAuthenticated 단일 조건 — 조합 없음
+    status: "N/A",
     violations: [],
   },
 
@@ -106,7 +104,7 @@ const checklist = [
     category: "Predictability",
     name: "숨겨진 사이드 이펙트 제거",
     description: "함수가 이름에 드러나지 않은 사이드 이펙트(로깅, 분석 등)를 수행하지 않는가?",
-    // 신규 함수 없음 — keydown 핸들러 내 텍스트 조작만 수행
+    // 숨겨진 사이드 이펙트 없음
     status: "N/A",
     violations: [],
   },
@@ -135,7 +133,7 @@ const checklist = [
     category: "Cohesion",
     name: "도메인별 디렉토리 구조",
     description: "기능/도메인 관련 코드가 도메인 폴더에 묶여 있는가?",
-    // MarkdownEditor: src/components/qna/ 내 — 도메인 구조 준수
+    // 기존 파일 수정만 — 도메인 구조 유지
     status: "O",
     violations: [],
   },
@@ -144,7 +142,7 @@ const checklist = [
     category: "Cohesion",
     name: "상수와 로직의 근접성",
     description: "상수가 사용 로직과 가까운 위치에 정의되어 있거나 이름으로 용도가 명확한가?",
-    // 신규 상수 없음
+    // 상수 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -155,7 +153,7 @@ const checklist = [
     category: "Coupling",
     name: "성급한 추상화 지양",
     description: "단순히 비슷하다는 이유로 섣불리 공통 훅/함수로 추출되지 않았는가?",
-    // 불필요한 추상화 없음 — 기존 onKeyDown 핸들러 내 분기 추가
+    // 추상화 추가 없음
     status: "N/A",
     violations: [],
   },
@@ -164,7 +162,7 @@ const checklist = [
     category: "Coupling",
     name: "상태 관리 범위 축소",
     description: "여러 관심사가 하나의 훅/컨텍스트에 묶이지 않고 분리되어 있는가?",
-    // 상태 변경 없음
+    // 상태 관리 변경 없음
     status: "N/A",
     violations: [],
   },
@@ -173,7 +171,7 @@ const checklist = [
     category: "Coupling",
     name: "Props Drilling 제거",
     description: "3단계 이상 props 전달이 컴포지션(children)으로 대체되어 있는가?",
-    // 신규 props 없음
+    // props drilling 없음
     status: "N/A",
     violations: [],
   },

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -6,6 +6,7 @@ import { ChatbotFab, ChatbotWidget } from '@/components/chatbot'
 import { ChatbotPageContextSync } from '@/features/chatbot/ChatbotPageContextSync'
 import { useAuthStore } from '@/stores/authStore'
 import type { UserRole } from '@/stores/authStore'
+import api from '@/api/instance'
 
 // DEV 전용 권한별 로그인 패널 — 운영 빌드에서는 렌더링 안 됨
 interface RoleOption {
@@ -144,7 +145,12 @@ function DevAuthPanel() {
 export function DefaultLayout() {
   const { logout } = useAuthStore()
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      await api.post('/accounts/logout')
+    } catch {
+      // 서버 로그아웃 실패해도 클라이언트는 로그아웃 처리
+    }
     logout()
     localStorage.removeItem('accessToken')
   }

--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -109,7 +109,7 @@ export function ProfileDropdown({
             href={EXTERNAL_URLS.SIGNUP}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary flex h-12 items-center px-3 text-sm font-medium"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors"
           >
             수강생 등록
           </a>
@@ -117,7 +117,7 @@ export function ProfileDropdown({
             href={EXTERNAL_URLS.MYPAGE}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary flex h-12 items-center px-3 text-sm font-medium tracking-tight"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium tracking-tight transition-colors"
           >
             마이페이지
           </a>

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -2,9 +2,14 @@ import { useState } from 'react'
 import rehypeSanitize from 'rehype-sanitize'
 import MDEditor from '@uiw/react-md-editor'
 import { ChevronDown, ChevronUp } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/common/Button'
 import { Spinner } from '@/components/common/Spinner'
-import { useCreateAiFirstAnswer } from '@/features/qna/question-ai-answer'
+import {
+  useGetAiFirstAnswer,
+  useCreateAiFirstAnswer,
+} from '@/features/qna/question-ai-answer'
+import { AI_FIRST_ANSWER_QUERY_KEY } from '@/features/qna/question-ai-answer/queries'
 import { useChatbotStore } from '@/stores/chatbotStore'
 import { handleApiError } from '@/utils/handleApiError'
 import type { ToastVariant } from '@/components'
@@ -25,24 +30,56 @@ const AI_ANSWER_ERROR_MESSAGES: Partial<Record<number, string>> = {
 interface AiFirstAnswerSectionProps {
   questionId: number
   questionTitle: string
+  isAuthenticated: boolean
   showToast: (message: string, variant: ToastVariant) => void
 }
 
 export function AiFirstAnswerSection({
   questionId,
   questionTitle,
+  isAuthenticated,
   showToast,
 }: AiFirstAnswerSectionProps) {
-  const { mutate, data, isPending, status, reset } =
-    useCreateAiFirstAnswer(questionId)
+  const queryClient = useQueryClient()
+
+  // GET: 기존 답변 조회 (로그인 유저만)
+  const {
+    data: existingAnswer,
+    isLoading: isGetLoading,
+    isError: isGetError,
+  } = useGetAiFirstAnswer(questionId, isAuthenticated)
+
+  // POST: 답변 생성
+  const {
+    mutate,
+    data: createdAnswer,
+    isPending: isCreatePending,
+    reset,
+  } = useCreateAiFirstAnswer(questionId)
+
   const enterQna = useChatbotStore((s) => s.enterQna)
+
+  // 기존 답변이 있으면 자동으로 펼침
+  const hasExistingAnswer = !!existingAnswer
   const [isOpen, setIsOpen] = useState(false)
+  const isAutoOpen = hasExistingAnswer
+  const showAnswer = isAutoOpen || isOpen
+
+  const answerData = existingAnswer ?? createdAnswer
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const handleRequest = () => {
+    if (!isAuthenticated) {
+      showToast('로그인이 필요합니다', 'error')
+      return
+    }
     setErrorMessage(null)
     mutate(undefined, {
-      onSuccess: () => setIsOpen(true),
+      onSuccess: (data) => {
+        setIsOpen(true)
+        // GET 캐시도 갱신
+        queryClient.setQueryData(AI_FIRST_ANSWER_QUERY_KEY(questionId), data)
+      },
       onError: (error) => {
         const { message } = handleApiError(error, AI_ANSWER_ERROR_MESSAGES)
         setErrorMessage(message)
@@ -53,23 +90,26 @@ export function AiFirstAnswerSection({
   }
 
   const handleAskMore = () => {
-    if (!data) return
+    if (!answerData) return
     enterQna({
       questionId,
       questionTitle,
-      firstAnswer: data.output,
+      firstAnswer: answerData.output,
     })
   }
 
   const toggleOpen = () => {
-    if (status !== 'success') {
-      handleRequest()
-    } else {
+    // 이미 답변 데이터가 있으면 토글만
+    if (answerData) {
       setIsOpen((v) => !v)
+      return
     }
+    // 없으면 생성 요청
+    handleRequest()
   }
 
-  const ChevronIcon = isOpen ? ChevronUp : ChevronDown
+  const isPending = isCreatePending || isGetLoading
+  const ChevronIcon = showAnswer ? ChevronUp : ChevronDown
 
   return (
     <div className="mt-16">
@@ -104,8 +144,11 @@ export function AiFirstAnswerSection({
           >
             {isPending ? (
               <span className="inline-flex items-center gap-2">
-                <Spinner size="sm" label="AI 답변 생성 중" />
-                <span>AI가 답변을 생성하고 있습니다...</span>
+                <Spinner size="sm" label="AI 답변 로딩 중" />
+                <span>
+                  AI가 답변을 {isGetLoading ? '불러오고' : '생성하고'}{' '}
+                  있습니다...
+                </span>
               </span>
             ) : (
               <>
@@ -121,20 +164,29 @@ export function AiFirstAnswerSection({
       </div>
 
       {/* 펼쳐진 AI 답변 */}
-      {isOpen && status === 'success' && data && (
+      {showAnswer && answerData && (
         <div className="mt-4 rounded-2xl bg-[#F8F8F8] p-7">
           <div data-color-mode="light" className="prose max-w-none text-sm">
             <MDEditor.Markdown
-              source={data.output}
+              source={answerData.output}
               rehypePlugins={[rehypeSanitize]}
             />
           </div>
-          <div className="mt-4 flex justify-end">
-            <Button variant="outline" size="sm" onClick={handleAskMore}>
-              추가 질문하기
-            </Button>
-          </div>
+          {isAuthenticated && (
+            <div className="mt-4 flex justify-end">
+              <Button variant="outline" size="sm" onClick={handleAskMore}>
+                추가 질문하기
+              </Button>
+            </div>
+          )}
         </div>
+      )}
+
+      {/* GET 조회 실패 시 안내 (네트워크 등) */}
+      {isGetError && !answerData && isAuthenticated && (
+        <p className="text-error mt-2 text-xs">
+          AI 답변을 불러오지 못했습니다. 다시 시도해주세요.
+        </p>
       )}
 
       {errorMessage && (

--- a/src/components/qna/QuestionDetail/QuestionDetail.tsx
+++ b/src/components/qna/QuestionDetail/QuestionDetail.tsx
@@ -142,14 +142,13 @@ export function QuestionDetail({
             </div>
           )}
 
-          {/* AI 1차 답변 */}
-          {isAuthenticated && (
-            <AiFirstAnswerSection
-              questionId={questionDetail.id}
-              questionTitle={questionDetail.title}
-              showToast={showToast}
-            />
-          )}
+          {/* AI 1차 답변 — 모든 유저에게 표시 */}
+          <AiFirstAnswerSection
+            questionId={questionDetail.id}
+            questionTitle={questionDetail.title}
+            isAuthenticated={isAuthenticated}
+            showToast={showToast}
+          />
 
           {/* 공유하기 pill 버튼 + 수정 버튼 */}
           <div className="mt-6 flex items-center justify-end gap-2">

--- a/src/features/qna/question-ai-answer/handler.ts
+++ b/src/features/qna/question-ai-answer/handler.ts
@@ -2,6 +2,38 @@ import { http, HttpResponse, delay } from 'msw'
 import type { AiFirstAnswerResponse } from './types'
 
 export const aiAnswerHandlers = [
+  // GET: 캐시된 초기응답 조회
+  http.get(
+    `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:questionId/ai-answer`,
+    async ({ params }) => {
+      await delay(300)
+
+      const response: AiFirstAnswerResponse = {
+        question_id: Number(params.questionId),
+        output: [
+          '## AI 답변',
+          '',
+          '리스트는 **수정 가능한(mutable)** 자료구조이며, 튜플은 **수정 불가능한(immutable)** 자료구조입니다.',
+          '',
+          '### 주요 차이점',
+          '',
+          '| 항목 | list | tuple |',
+          '|------|------|-------|',
+          '| 변경 가능 | O | X |',
+          '| 문법 | `[]` | `()` |',
+          '| 속도 | 느림 | 빠름 |',
+          '',
+          '> 성능이 중요한 경우 튜플이 리스트보다 약간 더 빠릅니다.',
+        ].join('\n'),
+        using_model: 'gemini-2.5-pro',
+        created_at: '2025-03-01 14:20:33',
+      }
+
+      return HttpResponse.json(response, { status: 200 })
+    }
+  ),
+
+  // POST: 초기응답 생성
   http.post(
     `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:questionId/ai-answer`,
     async ({ params }) => {

--- a/src/features/qna/question-ai-answer/index.ts
+++ b/src/features/qna/question-ai-answer/index.ts
@@ -1,3 +1,3 @@
 export type { AiFirstAnswerResponse } from './types'
-export { useCreateAiFirstAnswer } from './queries'
+export { useGetAiFirstAnswer, useCreateAiFirstAnswer } from './queries'
 export { aiAnswerHandlers } from './handler'

--- a/src/features/qna/question-ai-answer/queries.ts
+++ b/src/features/qna/question-ai-answer/queries.ts
@@ -1,6 +1,24 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import api from '@/api/instance'
 import type { AiFirstAnswerResponse } from './types'
+
+export const AI_FIRST_ANSWER_QUERY_KEY = (questionId: number) =>
+  ['qna', 'ai-first-answer', questionId] as const
+
+export function useGetAiFirstAnswer(
+  questionId: number,
+  enabled: boolean = true
+) {
+  return useQuery<AiFirstAnswerResponse>({
+    queryKey: AI_FIRST_ANSWER_QUERY_KEY(questionId),
+    queryFn: () =>
+      api
+        .get<AiFirstAnswerResponse>(`/qna/questions/${questionId}/ai-answer`)
+        .then((res) => res.data),
+    enabled: enabled && questionId > 0,
+    retry: false,
+  })
+}
 
 export function useCreateAiFirstAnswer(questionId: number) {
   return useMutation({

--- a/src/features/qna/question-ai-answer/types.ts
+++ b/src/features/qna/question-ai-answer/types.ts
@@ -1,5 +1,5 @@
 export interface AiFirstAnswerResponse {
-  id: number
+  id?: number
   question_id: number
   output: string
   using_model: string

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -25,6 +25,8 @@ import {
 import { useQnaQuestions } from '@/features/qna/questions'
 import type { QuestionsListParams } from '@/features/qna/questions'
 import { ROUTES } from '@/constants/routes'
+import { useAuthStore } from '@/stores/authStore'
+import { redirectToLogin } from '@/utils/loginRedirect'
 
 type AnswerStatus = 'all' | 'answered' | 'unanswered'
 type SortOption = NonNullable<QuestionsListParams['sort']>
@@ -175,6 +177,7 @@ function SortPopover({
 export function QnaListPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
 
   const rawAnswerStatus = searchParams.get('answer_status') ?? 'all'
   const answerStatus: AnswerStatus = (
@@ -333,7 +336,9 @@ export function QnaListPage() {
 
         <button
           type="button"
-          onClick={() => navigate(ROUTES.QNA.WRITE)}
+          onClick={() =>
+            isAuthenticated ? navigate(ROUTES.QNA.WRITE) : redirectToLogin()
+          }
           className="flex h-12 items-center gap-2 rounded-sm bg-[#6201E0] px-9 text-base font-bold text-white transition-colors hover:bg-[#4E01B3]"
         >
           <Pencil className="h-5 w-5" />


### PR DESCRIPTION
## 관련 이슈

- closes #137
- closes #140
- closes #142

## 작업 내용

### 1. 로그아웃 시 서버 logout API 호출 (#137)
- 로그아웃 시 서버 API 호출하여 쿠키 제거

### 2. AI 초기답변 모든 유저에게 표시 (#140)
- `isAuthenticated` 가드 제거 → 비로그인 유저에게도 AI 답변 섹션 표시
- GET 조회 추가로 기존 답변 자동 펼침
- 비로그인 클릭 시 "로그인이 필요합니다" 토스트

### 3. 프로필 드롭다운 hover 통일 + Q&A 비로그인 리다이렉트 (#142)
- 수강생등록/마이페이지 hover 스타일을 로그아웃과 동일하게 적용
- Q&A 질문하기 비로그인 시 로그인 페이지로 리다이렉트

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다