### PR TITLE
fix: 프로필 드롭다운 로그아웃 버튼 모서리 통일

### DIFF
--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -128,7 +128,7 @@ export function ProfileDropdown({
             role="menuitem"
             tabIndex={-1}
             onClick={onLogout}
-            className="text-text-heading hover:text-primary h-12 justify-start tracking-tight"
+            className="text-text-heading hover:text-primary h-12 justify-start !rounded-md tracking-tight"
           >
             로그아웃
           </Button>


### PR DESCRIPTION
## 관련 이슈

- 없음 (UI 일관성 수정)

## 작업 내용

- 로그아웃 버튼의 hover 모서리가 `rounded-full`(Button ghost 기본값)이었던 것을 수강생등록/마이페이지와 동일한 `rounded-md`로 통일

## 변경 사항

- `ProfileDropdown.tsx`: 로그아웃 Button에 `!rounded-md` 추가

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다