### PR TITLE
chore: dev → main 통합 (#146, #144)

### DIFF
--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -128,7 +128,7 @@ export function ProfileDropdown({
             role="menuitem"
             tabIndex={-1}
             onClick={onLogout}
-            className="text-text-heading hover:text-primary h-12 justify-start tracking-tight"
+            className="text-text-heading hover:text-primary h-12 justify-start !rounded-md tracking-tight"
           >
             로그아웃
           </Button>

--- a/src/components/qna/AnswerCard/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard/AnswerCard.tsx
@@ -60,7 +60,7 @@ export function AnswerCard({
           <div className="flex items-center gap-5">
             <UserAvatar
               size="lg"
-              profileImageUrl={answer.author.profile_image_url}
+              profileImageUrl={answer.author.profile_img_url}
               nickname={answer.author.nickname}
             />
             <div>
@@ -109,10 +109,10 @@ export function AnswerCard({
         {/* 하단: 시간 + 디바이더 */}
         <div className="flex justify-end border-b border-[#CECECE] pt-8 pb-5">
           <time
-            dateTime={answer.updated_at}
+            dateTime={answer.updated_at ?? answer.created_at}
             className="text-base leading-normal tracking-[-0.03em] text-[#9D9D9D]"
           >
-            {getRelativeTime(answer.updated_at)}
+            {getRelativeTime(answer.updated_at ?? answer.created_at)}
           </time>
         </div>
 

--- a/src/components/qna/CommentList/CommentList.tsx
+++ b/src/components/qna/CommentList/CommentList.tsx
@@ -84,7 +84,7 @@ export function CommentList({ comments }: CommentListProps) {
           <li key={comment.id} className="group flex gap-[17px]">
             <UserAvatar
               size="lg"
-              profileImageUrl={comment.author.profile_image_url}
+              profileImageUrl={comment.author.profile_img_url}
               nickname={comment.author.nickname}
             />
             <div className="flex flex-1 flex-col gap-3 border-b border-[#CECECE] pb-5 group-last:border-b-0">

--- a/src/components/qna/QuestionDetail/QuestionDetail.tsx
+++ b/src/components/qna/QuestionDetail/QuestionDetail.tsx
@@ -102,7 +102,7 @@ export function QuestionDetail({
             <div className="flex shrink-0 items-center gap-3">
               <UserAvatar
                 size="lg"
-                profileImageUrl={questionDetail.author.profile_image_url}
+                profileImageUrl={questionDetail.author.profile_img_url}
                 nickname={questionDetail.author.nickname}
               />
               <span className="text-base leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D]">

--- a/src/features/accounts/me/handler.ts
+++ b/src/features/accounts/me/handler.ts
@@ -13,7 +13,7 @@ export const meHandlers = [
       id: 1,
       nickname: 'dev',
       email: 'dev@test.com',
-      profile_image: null,
+      profile_image_url: null,
       role: 'STUDENT',
     })
   }),

--- a/src/features/accounts/me/types.ts
+++ b/src/features/accounts/me/types.ts
@@ -2,6 +2,6 @@ export interface MeResponse {
   id: number
   nickname: string
   email: string
-  profile_image: string | null
+  profile_img_url: string | null
   role: 'USER' | 'STUDENT' | 'TA' | 'OM' | 'LC' | 'ADMIN'
 }

--- a/src/features/qna/answer-comments/handler.ts
+++ b/src/features/qna/answer-comments/handler.ts
@@ -6,7 +6,7 @@ const MAX_COMMENT_LENGTH = 500
 const MOCK_AUTHOR: AnswerComment['author'] = {
   id: 211,
   nickname: '테스트유저',
-  profile_image_url: null,
+  profile_img_url: null,
 }
 
 // answerId → 댓글 목록 (MSW 인메모리 상태)

--- a/src/features/qna/answer-comments/types.ts
+++ b/src/features/qna/answer-comments/types.ts
@@ -12,7 +12,7 @@ export interface PostCommentResponse {
 export interface CommentAuthor {
   id: number
   nickname: string
-  profile_image_url: string | null
+  profile_img_url: string | null
 }
 
 export interface AnswerComment {

--- a/src/features/qna/answers/handler.ts
+++ b/src/features/qna/answers/handler.ts
@@ -35,7 +35,7 @@ export const answersHandlers = [
           author: {
             id: MOCK_AUTHOR_ID,
             nickname: '테스트유저',
-            profile_image_url: null,
+            profile_img_url: null,
             course_name: 'OZ 코딩스쿨',
             cohort_name: '8기',
           },
@@ -45,7 +45,7 @@ export const answersHandlers = [
           comments: [
             {
               id: 1001,
-              author: { id: 301, nickname: '댓글러', profile_image_url: null },
+              author: { id: 301, nickname: '댓글러', profile_img_url: null },
               content: '도움이 많이 되었습니다. 감사해요!',
               created_at: new Date(Date.now() - 3600000).toISOString(),
               updated_at: new Date(Date.now() - 3600000).toISOString(),
@@ -55,7 +55,7 @@ export const answersHandlers = [
               author: {
                 id: 302,
                 nickname: '개발공부중',
-                profile_image_url: null,
+                profile_img_url: null,
               },
               content: '저도 같은 문제로 고민했는데 덕분에 해결했어요.',
               created_at: new Date(Date.now() - 1800000).toISOString(),

--- a/src/features/qna/answers/types.ts
+++ b/src/features/qna/answers/types.ts
@@ -15,7 +15,7 @@ export interface PostAnswerResponse {
 export interface AnswerAuthor {
   id: number
   nickname: string
-  profile_image_url: string | null
+  profile_img_url: string | null
   course_name: string
   cohort_name: string
 }
@@ -30,10 +30,10 @@ export interface GetAnswerItem {
   author: AnswerAuthor
   content: string
   is_adopted: boolean
-  images: AnswerImage[]
+  images?: AnswerImage[]
   comments: AnswerComment[]
   created_at: string
-  updated_at: string
+  updated_at?: string
 }
 
 export type GetAnswersResponse = GetAnswerItem[]

--- a/src/features/qna/question-detail/handler.ts
+++ b/src/features/qna/question-detail/handler.ts
@@ -26,7 +26,7 @@ export const questionDetailHandler = [
         author: {
           id: 100,
           nickname: '질문자',
-          profile_image_url: null,
+          profile_img_url: null,
           course_name: 'OZ 코딩스쿨',
           cohort_name: '8기',
         },
@@ -36,7 +36,7 @@ export const questionDetailHandler = [
             author: {
               id: MOCK_AUTHOR_ID,
               nickname: '테스트유저',
-              profile_image_url: null,
+              profile_img_url: null,
               course_name: 'OZ 코딩스쿨',
               cohort_name: '8기',
             },
@@ -49,7 +49,7 @@ export const questionDetailHandler = [
                 author: {
                   id: 301,
                   nickname: '댓글러',
-                  profile_image_url: null,
+                  profile_img_url: null,
                 },
                 content: '도움이 많이 되었습니다. 감사해요!',
                 created_at: new Date(Date.now() - 3600000).toISOString(),

--- a/src/features/qna/question-detail/types.ts
+++ b/src/features/qna/question-detail/types.ts
@@ -3,7 +3,7 @@ import type { GetAnswerItem } from '@/features/qna/answers'
 export interface QuestionAuthor {
   id: number
   nickname: string
-  profile_image_url: string | null
+  profile_img_url: string | null
   course_name: string
   cohort_name: string
 }

--- a/src/pages/qna/QnaDetailPage.tsx
+++ b/src/pages/qna/QnaDetailPage.tsx
@@ -254,7 +254,9 @@ export function QnaDetailPage() {
                 isLoading={isPutPending}
                 mode="edit"
                 initialContent={myAnswer.content}
-                initialImgUrls={myAnswer.images.map((img) => img.img_url)}
+                initialImgUrls={
+                  myAnswer.images?.map((img) => img.img_url) ?? []
+                }
                 answerId={myAnswer.id}
               />
             ) : (

--- a/src/providers/AuthBootstrap.tsx
+++ b/src/providers/AuthBootstrap.tsx
@@ -20,7 +20,7 @@ function toLoginPayload(user: Awaited<ReturnType<typeof fetchMe>>) {
     id: user.id,
     nickname: user.nickname,
     email: user.email,
-    profileImage: user.profile_image,
+    profileImage: user.profile_img_url,
     role: user.role,
   }
 }


### PR DESCRIPTION
## 작업 내용

### 1. 프로필 드롭다운 로그아웃 버튼 모서리 통일 (#146)
- 로그아웃 버튼 hover 모서리를 수강생등록/마이페이지와 동일한 `rounded-md`로 통일

### 2. profile_img_url 필드명 정합성 수정 (#144)
- 프로필 이미지 필드명 정합성 수정 및 answers 타입 방어처리

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다