### PR TITLE
fix: QnA 추가 질문 진입 시 무한 리렌더 수정

### DIFF
--- a/src/stores/chatbotStore.ts
+++ b/src/stores/chatbotStore.ts
@@ -84,7 +84,10 @@ export const useChatbotStore = create<ChatbotState>()(
         ),
 
       markQnaLimitExceeded: (questionId) => {
-        const next = new Set(get().qnaLimitExceededIds)
+        const current = get().qnaLimitExceededIds
+        // 이미 포함되어 있으면 새 Set을 만들지 않음 (무한 리렌더 방지)
+        if (current.has(questionId)) return
+        const next = new Set(current)
         next.add(questionId)
         set(
           { qnaLimitExceededIds: next },
@@ -94,7 +97,10 @@ export const useChatbotStore = create<ChatbotState>()(
       },
 
       clearQnaLimitExceeded: (questionId) => {
-        const next = new Set(get().qnaLimitExceededIds)
+        const current = get().qnaLimitExceededIds
+        // 포함되어 있지 않으면 새 Set을 만들지 않음 (무한 리렌더 방지)
+        if (!current.has(questionId)) return
+        const next = new Set(current)
         next.delete(questionId)
         set(
           { qnaLimitExceededIds: next },


### PR DESCRIPTION
## 관련 이슈

- closes #151

## 작업 내용

- `chatbotStore.markQnaLimitExceeded` / `clearQnaLimitExceeded` 가 questionId의 Set 포함 여부와 상관없이 매번 새 Set을 만들어 `set()` 을 호출하던 문제를 수정했습니다.
- 변화가 없을 때는 early return 하도록 가드를 추가해 `qnaLimitExceededIds` 참조 안정성을 보장합니다.

## 변경 사항

- `src/stores/chatbotStore.ts`
  - `markQnaLimitExceeded`: 이미 Set에 포함된 questionId면 no-op
  - `clearQnaLimitExceeded`: Set에 없는 questionId면 no-op

## 재현 → 수정 흐름

1. (이전) AI 1차 답변에서 **추가 질문하기** 클릭 → `enterQna()` → QnA 챗봇 뷰 마운트
2. `useQnaChat` (`src/features/chatbot/qna/hooks/useQnaChat.ts:73-79`) useEffect 가 빈 히스토리에서 `clearQnaLimitExceeded(questionId)` 호출
3. 매번 새 Set 생성 → `qnaLimitExceededIds` 참조 변경 → `useShallow` 가 본 `store` 객체 변경 → useEffect 재실행 → 무한 루프 (React error #185)
4. (수정 후) 가드로 인해 실제 변화가 없으면 `set()` 미호출 → 참조 유지 → 루프 종료

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다