### PR TITLE
fix: 질문하기 토스트 메시지 수정 + 수강생 등록 테두리·엔드포인트 변경 (#148 #149)

### DIFF
--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -109,7 +109,7 @@ export function ProfileDropdown({
             href={EXTERNAL_URLS.SIGNUP}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors outline-none"
           >
             수강생 등록
           </a>

--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -106,10 +106,10 @@ export function ProfileDropdown({
         {/* 메뉴 항목 */}
         <div className="flex flex-col gap-1">
           <a
-            href={EXTERNAL_URLS.SIGNUP}
+            href={EXTERNAL_URLS.ENROLL}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors outline-none"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors outline-none focus-visible:outline-none"
           >
             수강생 등록
           </a>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,6 +3,7 @@ export const EXTERNAL_URLS = {
   HOME: 'https://my.ozcodingschool.site/',
   LOGIN: 'https://my.ozcodingschool.site/login',
   SIGNUP: 'https://my.ozcodingschool.site/signup',
+  ENROLL: 'http://my.ozcodingschool.site/enroll',
   MYPAGE: 'https://my.ozcodingschool.site/mypage',
   COMMUNITY: 'https://community.ozcodingschool.site/community',
   QNA: 'https://qna.ozcodingschool.site/',

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -21,12 +21,14 @@ import {
   Pagination,
   QuestionCard,
   CategoryFilter,
+  Toast,
 } from '@/components'
 import { useQnaQuestions } from '@/features/qna/questions'
 import type { QuestionsListParams } from '@/features/qna/questions'
 import { ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/authStore'
 import { redirectToLogin } from '@/utils/loginRedirect'
+import { useToast } from '@/hooks/useToast'
 
 type AnswerStatus = 'all' | 'answered' | 'unanswered'
 type SortOption = NonNullable<QuestionsListParams['sort']>
@@ -178,6 +180,8 @@ export function QnaListPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const user = useAuthStore((s) => s.user)
+  const { toast, showToast, hideToast } = useToast()
 
   const rawAnswerStatus = searchParams.get('answer_status') ?? 'all'
   const answerStatus: AnswerStatus = (
@@ -336,9 +340,17 @@ export function QnaListPage() {
 
         <button
           type="button"
-          onClick={() =>
-            isAuthenticated ? navigate(ROUTES.QNA.WRITE) : redirectToLogin()
-          }
+          onClick={() => {
+            if (!isAuthenticated) {
+              redirectToLogin()
+              return
+            }
+            if (user?.role !== 'STUDENT') {
+              showToast('수강생만 질문하기가 가능합니다.', 'info')
+              return
+            }
+            navigate(ROUTES.QNA.WRITE)
+          }}
           className="flex h-12 items-center gap-2 rounded-sm bg-[#6201E0] px-9 text-base font-bold text-white transition-colors hover:bg-[#4E01B3]"
         >
           <Pencil className="h-5 w-5" />
@@ -488,6 +500,14 @@ export function QnaListPage() {
           </Suspense>
         </div>
       </Modal>
+
+      {toast.visible && (
+        <Toast
+          message={toast.message}
+          variant={toast.variant}
+          onClose={hideToast}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -346,7 +346,10 @@ export function QnaListPage() {
               return
             }
             if (user?.role !== 'STUDENT') {
-              showToast('수강생만 질문하기가 가능합니다.', 'info')
+              showToast(
+                '수강생 전용 기능입니다. 먼저 수강 신청을 완료해 주세요.',
+                'info'
+              )
               return
             }
             navigate(ROUTES.QNA.WRITE)


### PR DESCRIPTION
## 관련 이슈

- closes #148
- closes #149

## 작업 내용

- QnaListPage 질문하기 버튼 클릭 시 일반 유저(role이 STUDENT가 아닌 경우)에게 표시되는 토스트 메시지 문구 수정
- 헤더 프로필 이미지 호버 시 드롭다운 내 수강생 등록 항목에 나타나는 불필요한 포커스 테두리 제거
- 수강생 등록 링크 엔드포인트 변경

## 변경 사항

- `src/pages/qna/QnaListPage.tsx`: 토스트 메시지 `'수강생만 질문하기가 가능합니다.'` → `'수강생 전용 기능입니다. 먼저 수강 신청을 완료해 주세요.'`
- `src/components/layout/Header/ProfileDropdown.tsx`: 수강생 등록 `<a>` 태그에 `focus-visible:outline-none` 추가 (브라우저 UA 스타일시트보다 높은 명시도로 포커스 테두리 제거), `href`를 `EXTERNAL_URLS.ENROLL`로 변경
- `src/constants/routes.ts`: `EXTERNAL_URLS.ENROLL: 'http://my.ozcodingschool.site/enroll'` 추가

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다