### PR TITLE
fix: 챗봇 허브 sessions 응답 스키마를 스웨거에 맞춤

### DIFF
--- a/src/features/chatbot/hub/HubView.tsx
+++ b/src/features/chatbot/hub/HubView.tsx
@@ -21,10 +21,9 @@ export function HubView() {
   }
 
   const handleSessionClick = (session: ChatSession) => {
+    // sessions 응답에는 questionTitle/firstAnswer가 없음 — 진입 후 history fallback이 처리
     enterQna({
       questionId: session.question_id,
-      questionTitle: session.question_title,
-      firstAnswer: session.first_answer,
     })
   }
 
@@ -87,7 +86,7 @@ export function HubView() {
         {!isLoading &&
           !isError &&
           data?.results?.map((session) => (
-            <div key={session.session_id}>
+            <div key={session.question_id}>
               <button
                 type="button"
                 onClick={() => handleSessionClick(session)}
@@ -108,7 +107,7 @@ export function HubView() {
                   질의응답 챗봇
                 </p>
                 <span className="shrink-0 text-[13px] text-[#9D9D9D]">
-                  {getRelativeTime(session.updated_at)}
+                  {getRelativeTime(session.created_at)}
                 </span>
               </button>
               <div className="border-t border-[#E8E8E8]" />

--- a/src/features/chatbot/sessions/handler.ts
+++ b/src/features/chatbot/sessions/handler.ts
@@ -1,26 +1,22 @@
 import { http, HttpResponse } from 'msw'
 import type { ChatSessionListResponse } from './types'
 
-// TODO: 실제 백엔드 응답 형식 확인 후 mock 데이터 조정 필요
+// swagger.yaml AiAnswerSessionItem 스키마 기준
 const mockSessions: ChatSessionListResponse = {
   // 빈 배열 테스트 시 아래 주석 해제:
   // results: [],
   results: [
     {
-      session_id: 1,
       question_id: 42,
-      question_title: '수강 신청 관련 질문',
-      first_answer: '수강 신청은 메인 페이지에서 진행하실 수 있습니다.',
-      created_at: '2026-04-28T10:00:00Z',
-      updated_at: '2026-04-28T10:05:00Z',
+      last_message: 'select_related는 JOIN을 사용하여 최적화합니다...',
+      role: 'assistant',
+      created_at: '2026-04-23T14:30:05',
     },
     {
-      session_id: 2,
-      question_id: 99,
-      question_title: 'TypeScript 제네릭 설명해주세요',
-      first_answer: null,
-      created_at: '2026-04-27T14:00:00Z',
-      updated_at: '2026-04-27T14:00:00Z',
+      question_id: 55,
+      last_message: 'JWT는 Header, Payload...',
+      role: 'assistant',
+      created_at: '2026-04-23T14:30:05',
     },
   ],
 }

--- a/src/features/chatbot/sessions/types.ts
+++ b/src/features/chatbot/sessions/types.ts
@@ -1,17 +1,14 @@
-// TODO: GET /api/v1/chatbot/sessions/ 실제 백엔드 응답과 필드명이 다를 수 있음
-// FEATURES.md 기준 작성, 실제 연동 시 타입과 매핑 조정 필요
+// GET /api/v1/qna/ai-answer/sessions/ — swagger.yaml AiAnswerSessionItem 기준
 
-/** GET /api/v1/chatbot/sessions/ 응답 내 개별 세션 */
+/** GET /api/v1/qna/ai-answer/sessions/ 응답 내 개별 세션 */
 export interface ChatSession {
-  session_id: number
   question_id: number
-  question_title: string | null
-  first_answer: string | null
+  last_message: string
+  role: 'user' | 'assistant'
   created_at: string
-  updated_at: string
 }
 
-/** GET /api/v1/chatbot/sessions/ 응답 */
+/** GET /api/v1/qna/ai-answer/sessions/ 응답 */
 export interface ChatSessionListResponse {
   results: ChatSession[]
 }


### PR DESCRIPTION
## 관련 이슈

- closes #155

## 작업 내용

- `GET /api/v1/qna/ai-answer/sessions/` 응답 스키마(`AiAnswerSessionItem`)와 프론트 타입·`HubView` 렌더링 코드의 미스매치를 해소합니다.
- 백엔드는 `question_id / last_message / role / created_at` 만 반환하므로 그 외 필드(`session_id`, `question_title`, `first_answer`, `updated_at`)에 대한 의존을 제거했습니다.

## 변경 사항

- `src/features/chatbot/sessions/types.ts`
  - `ChatSession` 을 스웨거 `AiAnswerSessionItem` 기준으로 재정의
- `src/features/chatbot/hub/HubView.tsx`
  - 리스트 `key` 를 `question_id` 로 변경 (기존 `session_id` 는 `undefined` 였음)
  - 상대 시간 표시를 `created_at` 기준으로 변경 (기존 `updated_at` 은 응답에 없음)
  - `enterQna` 호출 시 sessions 응답에 없는 `questionTitle`/`firstAnswer` 전달 제거 — 진입 후 `useQnaChat` 히스토리 fallback 이 처리
- `src/features/chatbot/sessions/handler.ts`
  - MSW mock 데이터를 새 스키마에 맞춰 갱신해 dev 회귀 방지

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다