### PR TITLE
chore: dev → main 통합 (#156, #154)

### DIFF
--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -109,7 +109,7 @@ export function ProfileDropdown({
             href={EXTERNAL_URLS.SIGNUP}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors outline-none"
           >
             수강생 등록
           </a>

--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -106,10 +106,10 @@ export function ProfileDropdown({
         {/* 메뉴 항목 */}
         <div className="flex flex-col gap-1">
           <a
-            href={EXTERNAL_URLS.SIGNUP}
+            href={EXTERNAL_URLS.ENROLL}
             role="menuitem"
             tabIndex={-1}
-            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors outline-none"
+            className="text-text-heading hover:text-primary hover:bg-bg-accent flex h-12 items-center rounded-md px-3 text-sm font-medium transition-colors outline-none focus-visible:outline-none"
           >
             수강생 등록
           </a>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,6 +3,7 @@ export const EXTERNAL_URLS = {
   HOME: 'https://my.ozcodingschool.site/',
   LOGIN: 'https://my.ozcodingschool.site/login',
   SIGNUP: 'https://my.ozcodingschool.site/signup',
+  ENROLL: 'http://my.ozcodingschool.site/enroll',
   MYPAGE: 'https://my.ozcodingschool.site/mypage',
   COMMUNITY: 'https://community.ozcodingschool.site/community',
   QNA: 'https://qna.ozcodingschool.site/',

--- a/src/features/chatbot/hub/HubView.tsx
+++ b/src/features/chatbot/hub/HubView.tsx
@@ -21,10 +21,9 @@ export function HubView() {
   }
 
   const handleSessionClick = (session: ChatSession) => {
+    // sessions 응답에는 questionTitle/firstAnswer가 없음 — 진입 후 history fallback이 처리
     enterQna({
       questionId: session.question_id,
-      questionTitle: session.question_title,
-      firstAnswer: session.first_answer,
     })
   }
 
@@ -87,7 +86,7 @@ export function HubView() {
         {!isLoading &&
           !isError &&
           data?.results?.map((session) => (
-            <div key={session.session_id}>
+            <div key={session.question_id}>
               <button
                 type="button"
                 onClick={() => handleSessionClick(session)}
@@ -108,7 +107,7 @@ export function HubView() {
                   질의응답 챗봇
                 </p>
                 <span className="shrink-0 text-[13px] text-[#9D9D9D]">
-                  {getRelativeTime(session.updated_at)}
+                  {getRelativeTime(session.created_at)}
                 </span>
               </button>
               <div className="border-t border-[#E8E8E8]" />

--- a/src/features/chatbot/sessions/handler.ts
+++ b/src/features/chatbot/sessions/handler.ts
@@ -1,26 +1,22 @@
 import { http, HttpResponse } from 'msw'
 import type { ChatSessionListResponse } from './types'
 
-// TODO: 실제 백엔드 응답 형식 확인 후 mock 데이터 조정 필요
+// swagger.yaml AiAnswerSessionItem 스키마 기준
 const mockSessions: ChatSessionListResponse = {
   // 빈 배열 테스트 시 아래 주석 해제:
   // results: [],
   results: [
     {
-      session_id: 1,
       question_id: 42,
-      question_title: '수강 신청 관련 질문',
-      first_answer: '수강 신청은 메인 페이지에서 진행하실 수 있습니다.',
-      created_at: '2026-04-28T10:00:00Z',
-      updated_at: '2026-04-28T10:05:00Z',
+      last_message: 'select_related는 JOIN을 사용하여 최적화합니다...',
+      role: 'assistant',
+      created_at: '2026-04-23T14:30:05',
     },
     {
-      session_id: 2,
-      question_id: 99,
-      question_title: 'TypeScript 제네릭 설명해주세요',
-      first_answer: null,
-      created_at: '2026-04-27T14:00:00Z',
-      updated_at: '2026-04-27T14:00:00Z',
+      question_id: 55,
+      last_message: 'JWT는 Header, Payload...',
+      role: 'assistant',
+      created_at: '2026-04-23T14:30:05',
     },
   ],
 }

--- a/src/features/chatbot/sessions/types.ts
+++ b/src/features/chatbot/sessions/types.ts
@@ -1,17 +1,14 @@
-// TODO: GET /api/v1/chatbot/sessions/ 실제 백엔드 응답과 필드명이 다를 수 있음
-// FEATURES.md 기준 작성, 실제 연동 시 타입과 매핑 조정 필요
+// GET /api/v1/qna/ai-answer/sessions/ — swagger.yaml AiAnswerSessionItem 기준
 
-/** GET /api/v1/chatbot/sessions/ 응답 내 개별 세션 */
+/** GET /api/v1/qna/ai-answer/sessions/ 응답 내 개별 세션 */
 export interface ChatSession {
-  session_id: number
   question_id: number
-  question_title: string | null
-  first_answer: string | null
+  last_message: string
+  role: 'user' | 'assistant'
   created_at: string
-  updated_at: string
 }
 
-/** GET /api/v1/chatbot/sessions/ 응답 */
+/** GET /api/v1/qna/ai-answer/sessions/ 응답 */
 export interface ChatSessionListResponse {
   results: ChatSession[]
 }

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -21,12 +21,14 @@ import {
   Pagination,
   QuestionCard,
   CategoryFilter,
+  Toast,
 } from '@/components'
 import { useQnaQuestions } from '@/features/qna/questions'
 import type { QuestionsListParams } from '@/features/qna/questions'
 import { ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/authStore'
 import { redirectToLogin } from '@/utils/loginRedirect'
+import { useToast } from '@/hooks/useToast'
 
 type AnswerStatus = 'all' | 'answered' | 'unanswered'
 type SortOption = NonNullable<QuestionsListParams['sort']>
@@ -178,6 +180,8 @@ export function QnaListPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const user = useAuthStore((s) => s.user)
+  const { toast, showToast, hideToast } = useToast()
 
   const rawAnswerStatus = searchParams.get('answer_status') ?? 'all'
   const answerStatus: AnswerStatus = (
@@ -336,9 +340,17 @@ export function QnaListPage() {
 
         <button
           type="button"
-          onClick={() =>
-            isAuthenticated ? navigate(ROUTES.QNA.WRITE) : redirectToLogin()
-          }
+          onClick={() => {
+            if (!isAuthenticated) {
+              redirectToLogin()
+              return
+            }
+            if (user?.role !== 'STUDENT') {
+              showToast('수강생만 질문하기가 가능합니다.', 'info')
+              return
+            }
+            navigate(ROUTES.QNA.WRITE)
+          }}
           className="flex h-12 items-center gap-2 rounded-sm bg-[#6201E0] px-9 text-base font-bold text-white transition-colors hover:bg-[#4E01B3]"
         >
           <Pencil className="h-5 w-5" />
@@ -488,6 +500,14 @@ export function QnaListPage() {
           </Suspense>
         </div>
       </Modal>
+
+      {toast.visible && (
+        <Toast
+          message={toast.message}
+          variant={toast.variant}
+          onClose={hideToast}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -346,7 +346,10 @@ export function QnaListPage() {
               return
             }
             if (user?.role !== 'STUDENT') {
-              showToast('수강생만 질문하기가 가능합니다.', 'info')
+              showToast(
+                '수강생 전용 기능입니다. 먼저 수강 신청을 완료해 주세요.',
+                'info'
+              )
               return
             }
             navigate(ROUTES.QNA.WRITE)


### PR DESCRIPTION
## 관련 이슈

- closes #155

## 작업 내용

dev 브랜치를 main에 통합합니다.

## 포함 PR

- #156 fix: 챗봇 허브 sessions 응답 스키마를 스웨거에 맞춤 (closes #155)
- #154 fix: 질문하기 토스트 메시지 수정 + 수강생 등록 테두리·엔드포인트 변경 (#148 #149)

## 변경 사항 요약

- 챗봇 허브 sessions 응답 스키마를 스웨거(`AiAnswerSessionItem`)에 맞춤 — 챗봇 허브에 새 QnA 세션이 표시되지 않던 버그 수정
- 질문하기 토스트 메시지 / 수강생 등록 테두리·엔드포인트 정비

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다