### PR TITLE
fix: QnA 챗봇 세션 히스토리 엔드포인트 수정

### DIFF
--- a/src/features/chatbot/qna/handler.ts
+++ b/src/features/chatbot/qna/handler.ts
@@ -1,9 +1,9 @@
 import { http, HttpResponse } from 'msw'
 
 export const qnaChatbotHandlers = [
-  // GET /api/v1/qna/questions/:questionId/ai-answer — 히스토리 조회
+  // GET /api/v1/qna/questions/:questionId/chatbot — 히스토리 조회 및 세션 활성화
   http.get(
-    `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:questionId/ai-answer`,
+    `${import.meta.env.VITE_API_BASE_URL}/qna/questions/:questionId/chatbot`,
     () => {
       // 빈 히스토리 테스트 시 아래 주석 해제:
       // return HttpResponse.json({ results: [] })

--- a/src/features/chatbot/qna/queries.ts
+++ b/src/features/chatbot/qna/queries.ts
@@ -10,7 +10,7 @@ export const qnaHistoryQueryOptions = (questionId: number) =>
     queryKey: [...QNA_HISTORY_QUERY_KEY(questionId)],
     queryFn: () =>
       api
-        .get<QnaHistoryResponse>(`/qna/questions/${questionId}/ai-answer`)
+        .get<QnaHistoryResponse>(`/qna/questions/${questionId}/chatbot`)
         .then((r) => r.data),
     staleTime: 0,
     enabled: Boolean(questionId),


### PR DESCRIPTION
## 변경 사항
- QnA 챗봇 히스토리 조회 API를 백엔드 세션 활성화 엔드포인트인 /qna/questions/{questionId}/chatbot으로 수정
- MSW QnA 챗봇 히스토리 핸들러도 동일 엔드포인트로 정렬

## 원인
- 백엔드는 GET /qna/questions/{id}/chatbot 호출 시 Redis 세션을 활성화함
- 기존 프론트는 GET /qna/questions/{id}/ai-answer를 호출해 세션이 생성되지 않았고, 이후 POST /qna/questions/{id}/chatbot에서 403이 발생함

## 검증
- 
pm.cmd exec -- eslint src/features/chatbot/qna/queries.ts src/features/chatbot/qna/handler.ts
- push 훅 build 통과