### PR TITLE
fix: 일반 회원(USER role) 답변 카드 댓글 입력폼 노출 제한

### DIFF
--- a/src/components/qna/AnswerCard/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard/AnswerCard.tsx
@@ -4,6 +4,8 @@ import { UserAvatar } from '@/components/common/UserAvatar'
 import { CommentForm } from '@/components/qna/CommentForm'
 import { CommentList } from '@/components/qna/CommentList'
 import { getRelativeTime } from '@/utils/relativeTime'
+import { useAuthStore } from '@/stores/authStore'
+import { ANSWER_ALLOWED_ROLES } from '@/constants/roles'
 
 interface AnswerCardProps {
   answer: GetAnswerItem
@@ -32,6 +34,10 @@ export function AnswerCard({
   showForm,
   onEditAction,
 }: AnswerCardProps) {
+  const userRole = useAuthStore((s) => s.user?.role)
+  const canComment =
+    isAuthenticated && userRole != null && ANSWER_ALLOWED_ROLES.has(userRole)
+
   const canShowAcceptButton =
     isQuestionOwner && !anyAdopted && answer.author.id !== userId
 
@@ -117,7 +123,7 @@ export function AnswerCard({
         </div>
 
         {/* 댓글 입력 (먼저) → 댓글 목록 (나중) — Figma 순서 */}
-        {isAuthenticated && (
+        {canComment && (
           <CommentForm answerId={answer.id} questionId={numericQuestionId} />
         )}
 


### PR DESCRIPTION
## 관련 이슈

- closes #163

## 작업 내용

- `AnswerCard` 컴포넌트에서 `useAuthStore`로 사용자 role을 직접 읽어 댓글 입력폼 노출 여부를 결정
- 기존 `isAuthenticated` 단독 체크 → `canComment` (인증 + role 복합 조건) 로 변경

## 변경 사항

- `src/components/qna/AnswerCard/AnswerCard.tsx`
  - `useAuthStore`, `ANSWER_ALLOWED_ROLES` import 추가
  - `canComment = isAuthenticated && userRole != null && ANSWER_ALLOWED_ROLES.has(userRole)` 파생 변수 추가
  - `{isAuthenticated && <CommentForm>}` → `{canComment && <CommentForm>}` 조건 변경
  - `USER` role(일반 회원)은 `ANSWER_ALLOWED_ROLES`에 포함되지 않으므로 입력폼 미노출
  - role이 `STUDENT`, `TA`, `OM`, `LC`, `ADMIN`인 경우에만 입력폼 노출

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다