### PR TITLE
fix: 챗봇 이미지와 세션 목록 동작 개선

### DIFF
--- a/src/components/chatbot/ChatbotFab.tsx
+++ b/src/components/chatbot/ChatbotFab.tsx
@@ -1,7 +1,7 @@
 import { useShallow } from 'zustand/react/shallow'
 import { useChatbotStore } from '@/stores/chatbotStore'
 import { useAuthStore } from '@/stores/authStore'
-import chatbotRobot from '@/assets/chatbot-robot.png'
+import { ChatbotRobotImage } from './ChatbotRobotImage'
 
 export function ChatbotFab() {
   const { isOpen, toggle } = useChatbotStore(
@@ -48,13 +48,7 @@ export function ChatbotFab() {
           />
         </svg>
       ) : (
-        <img
-          src={chatbotRobot}
-          alt=""
-          aria-hidden="true"
-          className="h-[52px] w-[49px] object-contain"
-          draggable={false}
-        />
+        <ChatbotRobotImage className="h-[52px] w-[49px] object-contain" />
       )}
     </button>
   )

--- a/src/components/chatbot/ChatbotRobotImage/ChatbotRobotImage.tsx
+++ b/src/components/chatbot/ChatbotRobotImage/ChatbotRobotImage.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { Bot } from 'lucide-react'
+import chatbotRobot from '@/assets/chatbot-robot.png'
+
+interface ChatbotRobotImageProps {
+  className: string
+}
+
+export function ChatbotRobotImage({ className }: ChatbotRobotImageProps) {
+  const [isBroken, setIsBroken] = useState(false)
+
+  if (isBroken) {
+    return (
+      <Bot
+        aria-hidden="true"
+        className={className}
+        color="#58249D"
+        strokeWidth={1.8}
+      />
+    )
+  }
+
+  return (
+    <img
+      src={chatbotRobot}
+      alt=""
+      aria-hidden="true"
+      className={className}
+      draggable={false}
+      onError={() => setIsBroken(true)}
+    />
+  )
+}

--- a/src/components/chatbot/ChatbotRobotImage/index.ts
+++ b/src/components/chatbot/ChatbotRobotImage/index.ts
@@ -1,0 +1,1 @@
+export { ChatbotRobotImage } from './ChatbotRobotImage'

--- a/src/components/chatbot/MessageList/MessageList.tsx
+++ b/src/components/chatbot/MessageList/MessageList.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import rehypeSanitize from 'rehype-sanitize'
 import MDEditor from '@uiw/react-md-editor'
 import type { ChatMessage } from '@/features/chatbot/widgetTypes'
-import chatbotRobot from '@/assets/chatbot-robot.png'
+import { ChatbotRobotImage } from '@/components/chatbot/ChatbotRobotImage'
 import userAvatarImg from '@/assets/user-avatar.png'
 
 interface MessageListProps {
@@ -31,12 +31,7 @@ function BotAvatar() {
       style={{ boxShadow: '0px 4px 4px 0px rgba(0,0,0,0.25)' }}
       aria-hidden="true"
     >
-      <img
-        src={chatbotRobot}
-        alt=""
-        className="h-[33px] w-[33px] object-contain"
-        draggable={false}
-      />
+      <ChatbotRobotImage className="h-[33px] w-[33px] object-contain" />
     </div>
   )
 }
@@ -61,8 +56,8 @@ function UserAvatar() {
 export function MessageList({ messages }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  useLayoutEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'end' })
   }, [messages])
 
   return (

--- a/src/components/chatbot/index.ts
+++ b/src/components/chatbot/index.ts
@@ -1,5 +1,6 @@
 export { ChatbotFab } from './ChatbotFab'
 export { ChatbotWidget } from './ChatbotWidget'
 export { ChatbotHeader } from './ChatbotHeader'
+export { ChatbotRobotImage } from './ChatbotRobotImage'
 export { MessageList } from './MessageList'
 export { ChatInput } from './ChatInput'

--- a/src/features/chatbot/hub/HubView.tsx
+++ b/src/features/chatbot/hub/HubView.tsx
@@ -4,7 +4,7 @@ import { useChatbotStore } from '@/stores/chatbotStore'
 import { useGetSessions } from '@/features/chatbot/sessions'
 import type { ChatSession } from '@/features/chatbot/sessions'
 import { getRelativeTime } from '@/utils/relativeTime'
-import chatbotRobot from '@/assets/chatbot-robot.png'
+import { ChatbotRobotImage } from '@/components/chatbot/ChatbotRobotImage'
 
 export function HubView() {
   const { setView, enterQna, close } = useChatbotStore(
@@ -14,7 +14,8 @@ export function HubView() {
       close: s.close,
     }))
   )
-  const { data, isLoading, isError, refetch } = useGetSessions()
+  const { data, isLoading, isFetching, isError, refetch } = useGetSessions()
+  const isRefreshingSessions = isLoading || isFetching
 
   const handleCsClick = () => {
     setView('cs')
@@ -47,12 +48,7 @@ export function HubView() {
             className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white"
             style={{ boxShadow: '0px 2px 4px rgba(0,0,0,0.15)' }}
           >
-            <img
-              src={chatbotRobot}
-              alt=""
-              className="h-[42px] w-[42px] object-contain"
-              draggable={false}
-            />
+            <ChatbotRobotImage className="h-[42px] w-[42px] object-contain" />
           </div>
           <p className="min-w-0 flex-1 truncate text-[16px] font-medium text-[#121212]">
             AI OZ 시스템 챗봇
@@ -62,7 +58,7 @@ export function HubView() {
         <div className="border-t border-[#E8E8E8]" />
 
         {/* Q&A 세션 목록 */}
-        {isLoading && (
+        {isRefreshingSessions && (
           <div className="flex items-center justify-center py-6">
             <div className="border-primary h-5 w-5 animate-spin rounded-full border-2 border-t-transparent" />
           </div>
@@ -83,7 +79,7 @@ export function HubView() {
           </div>
         )}
 
-        {!isLoading &&
+        {!isRefreshingSessions &&
           !isError &&
           data?.results?.map((session) => (
             <div key={session.question_id}>
@@ -96,12 +92,7 @@ export function HubView() {
                   className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white"
                   style={{ boxShadow: '0px 2px 4px rgba(0,0,0,0.15)' }}
                 >
-                  <img
-                    src={chatbotRobot}
-                    alt=""
-                    className="h-[42px] w-[42px] object-contain"
-                    draggable={false}
-                  />
+                  <ChatbotRobotImage className="h-[42px] w-[42px] object-contain" />
                 </div>
                 <p className="min-w-0 flex-1 truncate text-[16px] font-medium text-[#121212]">
                   질의응답 챗봇

--- a/src/features/chatbot/sessions/queries.ts
+++ b/src/features/chatbot/sessions/queries.ts
@@ -11,6 +11,8 @@ export const sessionsQueryOptions = queryOptions({
       .get<ChatSessionListResponse>('/qna/ai-answer/sessions')
       .then((r) => r.data),
   staleTime: 0,
+  refetchOnMount: 'always',
+  refetchOnWindowFocus: true,
 })
 
 export function useGetSessions() {


### PR DESCRIPTION
## 변경 사항
- 챗봇 로봇 이미지 로드 실패 시 Bot 아이콘 fallback 표시
- 허브 세션 목록을 진입/포커스 시 재조회하고, 재조회 중 오래된 세션 캐시를 숨김
- 채팅 메시지 목록 진입 시 smooth 애니메이션 없이 즉시 하단으로 스크롤

## 검증
- 
pm.cmd exec -- eslint src/components/chatbot/ChatbotRobotImage/ChatbotRobotImage.tsx src/components/chatbot/ChatbotRobotImage/index.ts src/components/chatbot/index.ts src/components/chatbot/ChatbotFab.tsx src/components/chatbot/MessageList/MessageList.tsx src/features/chatbot/hub/HubView.tsx src/features/chatbot/sessions/queries.ts
- 
pm.cmd run build
- push 훅 build 통과