### PR TITLE
refactor: 챗봇 SSE 스트림 처리 단순화

### DIFF
--- a/src/features/chatbot/cs/hooks/useCsChat.ts
+++ b/src/features/chatbot/cs/hooks/useCsChat.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSSEAbort } from '@/features/chatbot/hooks/useSSEAbort'
-import { mapHistoryToMessages } from '@/features/chatbot/hooks/sseStream'
+import { mapHistoryToMessages } from '@/features/chatbot/utils/mapHistory'
 import { sendStreamingMessage } from '@/features/chatbot/hooks/sendStreamingMessage'
 import { useGetCsHistory, CS_HISTORY_QUERY_KEY } from '../queries'
 import type { ChatMessage } from '@/features/chatbot/widgetTypes'

--- a/src/features/chatbot/hooks/sendStreamingMessage.ts
+++ b/src/features/chatbot/hooks/sendStreamingMessage.ts
@@ -6,6 +6,7 @@ import { readSseMessageStream } from './sseStream'
 
 const ERROR_TEXT = '응답을 불러오지 못했습니다. 다시 시도해주세요.'
 const ERROR_BUFFER_TEXT = '응답이 너무 길어 중단되었습니다.'
+const DONE_COOLDOWN_MS = 500
 
 function clearAuthAndRedirectToLogin() {
   useAuthStore.getState().logout()
@@ -89,6 +90,21 @@ function appendErrorMessage(
   ])
 }
 
+function waitForDoneCooldown(signal: AbortSignal) {
+  if (signal.aborted) return Promise.resolve()
+
+  return new Promise<void>((resolve) => {
+    const finish = () => {
+      clearTimeout(timeoutId)
+      signal.removeEventListener('abort', finish)
+      resolve()
+    }
+    const timeoutId = setTimeout(finish, DONE_COOLDOWN_MS)
+
+    signal.addEventListener('abort', finish, { once: true })
+  })
+}
+
 export async function sendStreamingMessage({
   text,
   endpoint,
@@ -128,7 +144,8 @@ export async function sendStreamingMessage({
   let hasReceivedChunk = false
 
   try {
-    const response = await requestStream(endpoint, trimmed, reset())
+    const signal = reset()
+    const response = await requestStream(endpoint, trimmed, signal)
     if (handleHttpStatus({ response, assistantId, onRateLimit })) return
 
     const result = await readSseMessageStream({
@@ -147,6 +164,10 @@ export async function sendStreamingMessage({
     completed = result.completed
     hasReceivedChunk = result.hasReceivedChunk
 
+    if (result.completed) {
+      await waitForDoneCooldown(signal)
+    }
+
     if (result.bufferExceeded) {
       appendErrorMessage(setMessages, idPrefix, ERROR_BUFFER_TEXT)
     }
@@ -163,7 +184,7 @@ export async function sendStreamingMessage({
     )
   } finally {
     setIsStreaming(false)
-    if (completed) {
+    if (completed || hasReceivedChunk) {
       invalidateQueries(queryClient, invalidateQueryKeys)
     }
   }

--- a/src/features/chatbot/hooks/sseStream.ts
+++ b/src/features/chatbot/hooks/sseStream.ts
@@ -1,144 +1,9 @@
-import type { ChatMessage } from '@/features/chatbot/widgetTypes'
-
 const DEFAULT_MAX_BUFFER_SIZE = 100_000
 
-export interface ChatHistoryMessage {
-  role: 'user' | 'assistant'
-  message?: string
-  content?: string
-  id?: string | number
-}
-
-export interface SseStreamResult {
+interface SseStreamResult {
   completed: boolean
   hasReceivedChunk: boolean
   bufferExceeded: boolean
-}
-
-interface ParsedSseEvent {
-  done: boolean
-  message: string | null
-}
-
-interface StreamState {
-  assistantText: string
-  completed: boolean
-  hasReceivedChunk: boolean
-  bufferExceeded: boolean
-}
-
-export function mapHistoryToMessages(
-  results: ChatHistoryMessage[],
-  idPrefix: string
-): ChatMessage[] {
-  return results.map((item, index) => ({
-    id: item.id?.toString() ?? `${idPrefix}-history-${index}`,
-    role: item.role,
-    message: item.message ?? item.content ?? '',
-  }))
-}
-
-function parseSseEvent(event: string): ParsedSseEvent {
-  const line = event.split('\n').find((l) => l.startsWith('data:'))
-  if (!line) return { done: false, message: null }
-
-  const data = line.replace(/^data:\s*/, '').trim()
-  if (data === '[DONE]') return { done: true, message: null }
-
-  try {
-    const chunk = JSON.parse(data) as { message?: unknown }
-    return {
-      done: false,
-      message: typeof chunk.message === 'string' ? chunk.message : null,
-    }
-  } catch {
-    return { done: false, message: null }
-  }
-}
-
-function splitSseEvents(buffer: string) {
-  const events = buffer.split('\n\n')
-  return {
-    events,
-    rest: events.pop() ?? '',
-  }
-}
-
-function applySseEvent({
-  event,
-  state,
-  maxBufferSize,
-  onChunk,
-  onBufferExceeded,
-}: {
-  event: string
-  state: StreamState
-  maxBufferSize: number
-  onChunk: (message: string) => void
-  onBufferExceeded?: () => void
-}) {
-  const parsed = parseSseEvent(event)
-
-  if (parsed.done) {
-    state.completed = true
-    return
-  }
-  if (parsed.message == null) return
-
-  state.hasReceivedChunk = true
-  state.assistantText += parsed.message
-
-  if (state.assistantText.length > maxBufferSize) {
-    state.bufferExceeded = true
-    onBufferExceeded?.()
-    return
-  }
-
-  onChunk(parsed.message)
-}
-
-function getSseReader(response: Response) {
-  const reader = response.body?.getReader()
-  if (!reader) throw new Error('ReadableStream 없음')
-  return reader
-}
-
-async function readNextChunk({
-  reader,
-  decoder,
-  buffer,
-  state,
-  maxBufferSize,
-  onChunk,
-  onBufferExceeded,
-}: {
-  reader: ReadableStreamDefaultReader<Uint8Array>
-  decoder: TextDecoder
-  buffer: string
-  state: StreamState
-  maxBufferSize: number
-  onChunk: (message: string) => void
-  onBufferExceeded?: () => void
-}) {
-  const { done, value } = await reader.read()
-  if (done) return { buffer, done: true }
-
-  const { events, rest } = splitSseEvents(
-    buffer + decoder.decode(value, { stream: true })
-  )
-
-  for (const event of events) {
-    applySseEvent({
-      event,
-      state,
-      maxBufferSize,
-      onChunk,
-      onBufferExceeded,
-    })
-    if (state.completed || state.bufferExceeded) break
-  }
-
-  return { buffer: rest, done: false }
 }
 
 export async function readSseMessageStream({
@@ -152,38 +17,54 @@ export async function readSseMessageStream({
   onBufferExceeded?: () => void
   maxBufferSize?: number
 }): Promise<SseStreamResult> {
-  const reader = getSseReader(response)
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error('ReadableStream 없음')
+
   const decoder = new TextDecoder()
   let buffer = ''
-  const state: StreamState = {
-    assistantText: '',
-    completed: false,
-    hasReceivedChunk: false,
-    bufferExceeded: false,
-  }
+  let total = 0
+  let completed = false
+  let hasReceivedChunk = false
+  let bufferExceeded = false
 
-  while (true) {
-    const next = await readNextChunk({
-      reader,
-      decoder,
-      buffer,
-      state,
-      maxBufferSize,
-      onChunk,
-      onBufferExceeded,
-    })
-    buffer = next.buffer
-    const done = next.done || state.completed || state.bufferExceeded
+  while (!completed && !bufferExceeded) {
+    const { done, value } = await reader.read()
     if (done) break
+
+    buffer += decoder.decode(value, { stream: true })
+    const events = buffer.split('\n\n')
+    buffer = events.pop() ?? ''
+
+    for (const event of events) {
+      const dataLine = event
+        .split('\n')
+        .find((line) => line.startsWith('data:'))
+      if (!dataLine) continue
+
+      const data = dataLine.slice(5).trim()
+      if (data === '[DONE]') {
+        completed = true
+        break
+      }
+
+      try {
+        const chunk = JSON.parse(data) as { message?: unknown }
+        if (typeof chunk.message !== 'string') continue
+
+        total += chunk.message.length
+        if (total > maxBufferSize) {
+          bufferExceeded = true
+          onBufferExceeded?.()
+          break
+        }
+
+        hasReceivedChunk = true
+        onChunk(chunk.message)
+      } catch {
+        // malformed SSE chunk는 무시하고 다음 이벤트를 계속 처리한다.
+      }
+    }
   }
 
-  if (!state.completed && state.hasReceivedChunk) {
-    state.completed = true
-  }
-
-  return {
-    completed: state.completed,
-    hasReceivedChunk: state.hasReceivedChunk,
-    bufferExceeded: state.bufferExceeded,
-  }
+  return { completed, hasReceivedChunk, bufferExceeded }
 }

--- a/src/features/chatbot/qna/hooks/useQnaChat.ts
+++ b/src/features/chatbot/qna/hooks/useQnaChat.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSSEAbort } from '@/features/chatbot/hooks/useSSEAbort'
-import { mapHistoryToMessages } from '@/features/chatbot/hooks/sseStream'
+import { mapHistoryToMessages } from '@/features/chatbot/utils/mapHistory'
 import { sendStreamingMessage } from '@/features/chatbot/hooks/sendStreamingMessage'
 import { useGetQnaHistory, QNA_HISTORY_QUERY_KEY } from '../queries'
 import { SESSIONS_QUERY_KEY } from '@/features/chatbot/sessions/queries'

--- a/src/features/chatbot/utils/mapHistory.ts
+++ b/src/features/chatbot/utils/mapHistory.ts
@@ -1,0 +1,19 @@
+import type { ChatMessage } from '@/features/chatbot/widgetTypes'
+
+interface ChatHistoryMessage {
+  role: 'user' | 'assistant'
+  message?: string
+  content?: string
+  id?: string | number
+}
+
+export function mapHistoryToMessages(
+  results: ChatHistoryMessage[],
+  idPrefix: string
+): ChatMessage[] {
+  return results.map((item, index) => ({
+    id: item.id?.toString() ?? `${idPrefix}-history-${index}`,
+    role: item.role,
+    message: item.message ?? item.content ?? '',
+  }))
+}


### PR DESCRIPTION
## 변경 사항
- sseStream.ts에서 히스토리 매핑 책임을 분리하고 SSE 파서 로직을 단일 함수 중심으로 단순화
- mapHistoryToMessages를 src/features/chatbot/utils/mapHistory.ts로 이동
- [DONE] 수신 여부만 completed로 판단하도록 의미를 명확화
- 기존 동작 보존을 위해 chunk를 받은 경우에도 캐시 무효화가 실행되도록 completed || hasReceivedChunk 조건 적용
- [DONE] 정상 수신 후 500ms abortable 쿨다운을 추가해 입력 재활성화와 캐시 무효화 타이밍을 늦춤

## 검증
- 
pm.cmd exec -- eslint src/features/chatbot/hooks/sseStream.ts src/features/chatbot/hooks/sendStreamingMessage.ts src/features/chatbot/utils/mapHistory.ts src/features/chatbot/cs/hooks/useCsChat.ts src/features/chatbot/qna/hooks/useQnaChat.ts
  - 오류 없음, 기존 규칙상 복잡도 경고만 존재
- 
pm.cmd run build
- push 훅 build 통과