### PR TITLE
release: dev → main 동기화 (#160, #162, #164, #165, #166)

### DIFF
--- a/src/components/chatbot/ChatbotFab.tsx
+++ b/src/components/chatbot/ChatbotFab.tsx
@@ -1,7 +1,7 @@
 import { useShallow } from 'zustand/react/shallow'
 import { useChatbotStore } from '@/stores/chatbotStore'
 import { useAuthStore } from '@/stores/authStore'
-import chatbotRobot from '@/assets/chatbot-robot.png'
+import { ChatbotRobotImage } from './ChatbotRobotImage'
 
 export function ChatbotFab() {
   const { isOpen, toggle } = useChatbotStore(
@@ -48,13 +48,7 @@ export function ChatbotFab() {
           />
         </svg>
       ) : (
-        <img
-          src={chatbotRobot}
-          alt=""
-          aria-hidden="true"
-          className="h-[52px] w-[49px] object-contain"
-          draggable={false}
-        />
+        <ChatbotRobotImage className="h-[52px] w-[49px] object-contain" />
       )}
     </button>
   )

--- a/src/components/chatbot/ChatbotRobotImage/ChatbotRobotImage.tsx
+++ b/src/components/chatbot/ChatbotRobotImage/ChatbotRobotImage.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { Bot } from 'lucide-react'
+import chatbotRobot from '@/assets/chatbot-robot.png'
+
+interface ChatbotRobotImageProps {
+  className: string
+}
+
+export function ChatbotRobotImage({ className }: ChatbotRobotImageProps) {
+  const [isBroken, setIsBroken] = useState(false)
+
+  if (isBroken) {
+    return (
+      <Bot
+        aria-hidden="true"
+        className={className}
+        color="#58249D"
+        strokeWidth={1.8}
+      />
+    )
+  }
+
+  return (
+    <img
+      src={chatbotRobot}
+      alt=""
+      aria-hidden="true"
+      className={className}
+      draggable={false}
+      onError={() => setIsBroken(true)}
+    />
+  )
+}

--- a/src/components/chatbot/ChatbotRobotImage/index.ts
+++ b/src/components/chatbot/ChatbotRobotImage/index.ts
@@ -1,0 +1,1 @@
+export { ChatbotRobotImage } from './ChatbotRobotImage'

--- a/src/components/chatbot/MessageList/MessageList.tsx
+++ b/src/components/chatbot/MessageList/MessageList.tsx
@@ -7,8 +7,6 @@ import userAvatarImg from '@/assets/user-avatar.png'
 
 interface MessageListProps {
   messages: ChatMessage[]
-  showGreeting?: boolean
-  onAskMore?: () => void
 }
 
 function renderAssistantContent(message: ChatMessage) {
@@ -60,39 +58,7 @@ function UserAvatar() {
   )
 }
 
-/** 인사말 카드 — QnaChatView 최상단에 표시 */
-function GreetingCard({ onAskMore }: { onAskMore?: () => void }) {
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-start gap-2">
-        <BotAvatar />
-        <div
-          className="max-w-[75%] rounded-xl px-3.5 py-2.5 text-[14px] leading-[19.6px] tracking-[-0.57px] text-[#707070]"
-          style={{ backgroundColor: '#F5F5F5' }}
-        >
-          <p>안녕하세요, 도로시입니다.</p>
-        </div>
-      </div>
-      {onAskMore && (
-        <div className="ml-11">
-          <button
-            type="button"
-            onClick={onAskMore}
-            className="rounded-full border border-[#6201E0] px-4 py-1.5 text-[13px] leading-[18px] font-medium tracking-[-0.3px] text-[#6201E0] transition-colors hover:bg-[#6201E0]/5 active:bg-[#6201E0]/10"
-          >
-            추가 질문하기
-          </button>
-        </div>
-      )}
-    </div>
-  )
-}
-
-export function MessageList({
-  messages,
-  showGreeting,
-  onAskMore,
-}: MessageListProps) {
+export function MessageList({ messages }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -108,7 +74,6 @@ export function MessageList({
       aria-atomic={false}
       className="flex flex-1 flex-col gap-4 overflow-y-auto bg-white p-4"
     >
-      {showGreeting && <GreetingCard onAskMore={onAskMore} />}
       {messages.map((msg, idx) => {
         const isUser = msg.role === 'user'
         return (

--- a/src/components/chatbot/MessageList/MessageList.tsx
+++ b/src/components/chatbot/MessageList/MessageList.tsx
@@ -7,6 +7,8 @@ import userAvatarImg from '@/assets/user-avatar.png'
 
 interface MessageListProps {
   messages: ChatMessage[]
+  showGreeting?: boolean
+  onAskMore?: () => void
 }
 
 function renderAssistantContent(message: ChatMessage) {
@@ -58,7 +60,39 @@ function UserAvatar() {
   )
 }
 
-export function MessageList({ messages }: MessageListProps) {
+/** 인사말 카드 — QnaChatView 최상단에 표시 */
+function GreetingCard({ onAskMore }: { onAskMore?: () => void }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-start gap-2">
+        <BotAvatar />
+        <div
+          className="max-w-[75%] rounded-xl px-3.5 py-2.5 text-[14px] leading-[19.6px] tracking-[-0.57px] text-[#707070]"
+          style={{ backgroundColor: '#F5F5F5' }}
+        >
+          <p>안녕하세요, 도로시입니다.</p>
+        </div>
+      </div>
+      {onAskMore && (
+        <div className="ml-11">
+          <button
+            type="button"
+            onClick={onAskMore}
+            className="rounded-full border border-[#6201E0] px-4 py-1.5 text-[13px] leading-[18px] font-medium tracking-[-0.3px] text-[#6201E0] transition-colors hover:bg-[#6201E0]/5 active:bg-[#6201E0]/10"
+          >
+            추가 질문하기
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function MessageList({
+  messages,
+  showGreeting,
+  onAskMore,
+}: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -74,6 +108,7 @@ export function MessageList({ messages }: MessageListProps) {
       aria-atomic={false}
       className="flex flex-1 flex-col gap-4 overflow-y-auto bg-white p-4"
     >
+      {showGreeting && <GreetingCard onAskMore={onAskMore} />}
       {messages.map((msg, idx) => {
         const isUser = msg.role === 'user'
         return (

--- a/src/components/chatbot/MessageList/MessageList.tsx
+++ b/src/components/chatbot/MessageList/MessageList.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import rehypeSanitize from 'rehype-sanitize'
 import MDEditor from '@uiw/react-md-editor'
 import type { ChatMessage } from '@/features/chatbot/widgetTypes'
-import chatbotRobot from '@/assets/chatbot-robot.png'
+import { ChatbotRobotImage } from '@/components/chatbot/ChatbotRobotImage'
 import userAvatarImg from '@/assets/user-avatar.png'
 
 interface MessageListProps {
@@ -31,12 +31,7 @@ function BotAvatar() {
       style={{ boxShadow: '0px 4px 4px 0px rgba(0,0,0,0.25)' }}
       aria-hidden="true"
     >
-      <img
-        src={chatbotRobot}
-        alt=""
-        className="h-[33px] w-[33px] object-contain"
-        draggable={false}
-      />
+      <ChatbotRobotImage className="h-[33px] w-[33px] object-contain" />
     </div>
   )
 }
@@ -61,8 +56,8 @@ function UserAvatar() {
 export function MessageList({ messages }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  useLayoutEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'end' })
   }, [messages])
 
   return (

--- a/src/components/chatbot/index.ts
+++ b/src/components/chatbot/index.ts
@@ -1,5 +1,6 @@
 export { ChatbotFab } from './ChatbotFab'
 export { ChatbotWidget } from './ChatbotWidget'
 export { ChatbotHeader } from './ChatbotHeader'
+export { ChatbotRobotImage } from './ChatbotRobotImage'
 export { MessageList } from './MessageList'
 export { ChatInput } from './ChatInput'

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -107,9 +107,15 @@ export interface TabProps {
   value: string
   children: React.ReactNode
   disabled?: boolean
+  className?: string
 }
 
-export function Tab({ value, children, disabled = false }: TabProps) {
+export function Tab({
+  value,
+  children,
+  disabled = false,
+  className = '',
+}: TabProps) {
   const { activeTab, onChange, baseId } = useTabsContext()
   const isActive = activeTab === value
 
@@ -124,6 +130,7 @@ export function Tab({ value, children, disabled = false }: TabProps) {
       onClick={() => !disabled && onChange(value)}
       className={[
         'relative shrink-0 px-4 py-3 text-sm font-medium transition-colors duration-150 outline-none',
+        className,
         'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-inset',
         isActive
           ? 'text-primary after:bg-primary after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-t-full'

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -130,15 +130,44 @@ export function AiFirstAnswerSection({
             className="absolute top-4 -left-[12px] border-y-[6px] border-r-[12px] border-y-transparent border-r-[#F8F8F8]"
           />
 
-          {showAnswer && answerData ? (
-            /* 펼쳐진 상태 — 버튼 없이 답변만 표시 */
-            <>
-              <p className="text-lg leading-normal font-bold tracking-[-0.03em] text-[#121212]">
+          {/* 항상 표시: 질문 제목 + 답변 보기 토글 버튼 */}
+          <p className="truncate text-base leading-normal tracking-[-0.03em] text-[#707070]">
+            {questionTitle}
+          </p>
+          <button
+            type="button"
+            onClick={toggleOpen}
+            disabled={isPending}
+            className="mt-2 inline-flex flex-wrap items-center gap-1 text-lg leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? (
+              <span className="inline-flex items-center gap-2">
+                <Spinner size="sm" label="AI 답변 로딩 중" />
+                <span>
+                  AI가 답변을 {isGetLoading ? '불러오고' : '생성하고'}{' '}
+                  있습니다...
+                </span>
+              </span>
+            ) : (
+              <>
+                <span>질문에 대한</span>
+                <img src={aiBotImg} alt="" className="mx-0.5 inline h-9 w-9" />
+                <strong className="text-black">AI 질의응답 챗봇</strong>
+                <span>답변 보기</span>
+                <ChevronIcon className="ml-1 h-4 w-4 shrink-0 text-[#4D4D4D]" />
+              </>
+            )}
+          </button>
+
+          {/* 카드 확장 영역 — 클릭 시 아래로 펼쳐짐 */}
+          {showAnswer && answerData && (
+            <div className="mt-4 border-t border-[#E0E0E0] pt-4">
+              <p className="mb-3 text-lg leading-normal font-bold tracking-[-0.03em] text-[#121212]">
                 AI 질의응답 챗봇 답변
               </p>
               <div
                 data-color-mode="light"
-                className="prose mt-3 max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
+                className="prose max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
               >
                 <MDEditor.Markdown
                   source={answerData.output}
@@ -152,42 +181,7 @@ export function AiFirstAnswerSection({
                   </Button>
                 </div>
               )}
-            </>
-          ) : (
-            /* 접힌 상태 — 질문 제목 + 답변 보기 토글 버튼 */
-            <>
-              <p className="truncate text-base leading-normal tracking-[-0.03em] text-[#707070]">
-                {questionTitle}
-              </p>
-              <button
-                type="button"
-                onClick={toggleOpen}
-                disabled={isPending}
-                className="mt-2 inline-flex flex-wrap items-center gap-1 text-lg leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D] disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {isPending ? (
-                  <span className="inline-flex items-center gap-2">
-                    <Spinner size="sm" label="AI 답변 로딩 중" />
-                    <span>
-                      AI가 답변을 {isGetLoading ? '불러오고' : '생성하고'}{' '}
-                      있습니다...
-                    </span>
-                  </span>
-                ) : (
-                  <>
-                    <span>질문에 대한</span>
-                    <img
-                      src={aiBotImg}
-                      alt=""
-                      className="mx-0.5 inline h-9 w-9"
-                    />
-                    <strong className="text-black">AI 질의응답 챗봇</strong>
-                    <span>답변 보기</span>
-                    <ChevronIcon className="ml-1 h-4 w-4 shrink-0 text-[#4D4D4D]" />
-                  </>
-                )}
-              </button>
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -164,7 +164,10 @@ export function AiFirstAnswerSection({
           {/* 펼쳐진 AI 답변 — 말풍선 카드 내부 */}
           {showAnswer && answerData && (
             <div className="mt-4 border-t border-[#E0E0E0] pt-4">
-              <div data-color-mode="light" className="prose max-w-none text-sm">
+              <div
+                data-color-mode="light"
+                className="prose max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
+              >
                 <MDEditor.Markdown
                   source={answerData.output}
                   rehypePlugins={[rehypeSanitize]}

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -139,7 +139,10 @@ export function AiFirstAnswerSection({
                 className="prose mt-3 max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
               >
                 <MDEditor.Markdown
-                  source={answerData.output}
+                  source={answerData.output
+                    .replace(/^#*\s*AI\s*답변\s*\n[-=]+\s*\n?/i, '')
+                    .replace(/^#*\s*AI\s*답변\s*\n?/i, '')
+                    .trimStart()}
                   rehypePlugins={[rehypeSanitize]}
                 />
               </div>

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -160,27 +160,27 @@ export function AiFirstAnswerSection({
               </>
             )}
           </button>
-        </div>
-      </div>
 
-      {/* 펼쳐진 AI 답변 */}
-      {showAnswer && answerData && (
-        <div className="mt-4 rounded-2xl bg-[#F8F8F8] p-7">
-          <div data-color-mode="light" className="prose max-w-none text-sm">
-            <MDEditor.Markdown
-              source={answerData.output}
-              rehypePlugins={[rehypeSanitize]}
-            />
-          </div>
-          {isAuthenticated && (
-            <div className="mt-4 flex justify-end">
-              <Button variant="outline" size="sm" onClick={handleAskMore}>
-                추가 질문하기
-              </Button>
+          {/* 펼쳐진 AI 답변 — 말풍선 카드 내부 */}
+          {showAnswer && answerData && (
+            <div className="mt-4 border-t border-[#E0E0E0] pt-4">
+              <div data-color-mode="light" className="prose max-w-none text-sm">
+                <MDEditor.Markdown
+                  source={answerData.output}
+                  rehypePlugins={[rehypeSanitize]}
+                />
+              </div>
+              {isAuthenticated && (
+                <div className="mt-4 flex justify-end">
+                  <Button variant="outline" size="sm" onClick={handleAskMore}>
+                    추가 질문하기
+                  </Button>
+                </div>
+              )}
             </div>
           )}
         </div>
-      )}
+      </div>
 
       {/* GET 조회 실패 시 안내 (네트워크 등) */}
       {isGetError && !answerData && isAuthenticated && (

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -130,43 +130,15 @@ export function AiFirstAnswerSection({
             className="absolute top-4 -left-[12px] border-y-[6px] border-r-[12px] border-y-transparent border-r-[#F8F8F8]"
           />
 
-          {/* 질문 미리보기 텍스트 */}
-          <p className="truncate text-base leading-normal tracking-[-0.03em] text-[#707070]">
-            {questionTitle}
-          </p>
-
-          {/* 답변 보기 CTA */}
-          <button
-            type="button"
-            onClick={toggleOpen}
-            disabled={isPending}
-            className="mt-2 inline-flex flex-wrap items-center gap-1 text-lg leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isPending ? (
-              <span className="inline-flex items-center gap-2">
-                <Spinner size="sm" label="AI 답변 로딩 중" />
-                <span>
-                  AI가 답변을 {isGetLoading ? '불러오고' : '생성하고'}{' '}
-                  있습니다...
-                </span>
-              </span>
-            ) : (
-              <>
-                <span>질문에 대한</span>
-                <img src={aiBotImg} alt="" className="mx-0.5 inline h-9 w-9" />
-                <strong className="text-black">AI 질의응답 챗봇</strong>
-                <span>답변 보기</span>
-                <ChevronIcon className="ml-1 h-4 w-4 shrink-0 text-[#4D4D4D]" />
-              </>
-            )}
-          </button>
-
-          {/* 펼쳐진 AI 답변 — 말풍선 카드 내부 */}
-          {showAnswer && answerData && (
-            <div className="mt-4 border-t border-[#E0E0E0] pt-4">
+          {showAnswer && answerData ? (
+            /* 펼쳐진 상태 — 버튼 없이 답변만 표시 */
+            <>
+              <p className="text-lg leading-normal font-bold tracking-[-0.03em] text-[#121212]">
+                AI 질의응답 챗봇 답변
+              </p>
               <div
                 data-color-mode="light"
-                className="prose max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
+                className="prose mt-3 max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
               >
                 <MDEditor.Markdown
                   source={answerData.output}
@@ -180,7 +152,42 @@ export function AiFirstAnswerSection({
                   </Button>
                 </div>
               )}
-            </div>
+            </>
+          ) : (
+            /* 접힌 상태 — 질문 제목 + 답변 보기 토글 버튼 */
+            <>
+              <p className="truncate text-base leading-normal tracking-[-0.03em] text-[#707070]">
+                {questionTitle}
+              </p>
+              <button
+                type="button"
+                onClick={toggleOpen}
+                disabled={isPending}
+                className="mt-2 inline-flex flex-wrap items-center gap-1 text-lg leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isPending ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Spinner size="sm" label="AI 답변 로딩 중" />
+                    <span>
+                      AI가 답변을 {isGetLoading ? '불러오고' : '생성하고'}{' '}
+                      있습니다...
+                    </span>
+                  </span>
+                ) : (
+                  <>
+                    <span>질문에 대한</span>
+                    <img
+                      src={aiBotImg}
+                      alt=""
+                      className="mx-0.5 inline h-9 w-9"
+                    />
+                    <strong className="text-black">AI 질의응답 챗봇</strong>
+                    <span>답변 보기</span>
+                    <ChevronIcon className="ml-1 h-4 w-4 shrink-0 text-[#4D4D4D]" />
+                  </>
+                )}
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -130,44 +130,15 @@ export function AiFirstAnswerSection({
             className="absolute top-4 -left-[12px] border-y-[6px] border-r-[12px] border-y-transparent border-r-[#F8F8F8]"
           />
 
-          {/* 항상 표시: 질문 제목 + 답변 보기 토글 버튼 */}
-          <p className="truncate text-base leading-normal tracking-[-0.03em] text-[#707070]">
-            {questionTitle}
-          </p>
-          <button
-            type="button"
-            onClick={toggleOpen}
-            disabled={isPending}
-            className="mt-2 inline-flex flex-wrap items-center gap-1 text-lg leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isPending ? (
-              <span className="inline-flex items-center gap-2">
-                <Spinner size="sm" label="AI 답변 로딩 중" />
-                <span>
-                  AI가 답변을 {isGetLoading ? '불러오고' : '생성하고'}{' '}
-                  있습니다...
-                </span>
-              </span>
-            ) : (
-              <>
-                <span>질문에 대한</span>
-                <img src={aiBotImg} alt="" className="mx-0.5 inline h-9 w-9" />
-                <strong className="text-black">AI 질의응답 챗봇</strong>
-                <span>답변 보기</span>
-                <ChevronIcon className="ml-1 h-4 w-4 shrink-0 text-[#4D4D4D]" />
-              </>
-            )}
-          </button>
-
-          {/* 카드 확장 영역 — 클릭 시 아래로 펼쳐짐 */}
-          {showAnswer && answerData && (
-            <div className="mt-4 border-t border-[#E0E0E0] pt-4">
-              <p className="mb-3 text-lg leading-normal font-bold tracking-[-0.03em] text-[#121212]">
+          {showAnswer && answerData ? (
+            /* 펼쳐진 상태 (이미지 3) — 답변 표시, 버튼 없음 */
+            <div className="animate-fade-in">
+              <p className="text-lg leading-normal font-bold tracking-[-0.03em] text-[#121212]">
                 AI 질의응답 챗봇 답변
               </p>
               <div
                 data-color-mode="light"
-                className="prose max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
+                className="prose mt-3 max-w-none text-sm [&_.wmde-markdown]:!bg-transparent [&_.wmde-markdown_*]:!bg-transparent"
               >
                 <MDEditor.Markdown
                   source={answerData.output}
@@ -182,6 +153,41 @@ export function AiFirstAnswerSection({
                 </div>
               )}
             </div>
+          ) : (
+            /* 접힌 상태 (이미지 2) — 질문 제목 + 답변 보기 버튼 */
+            <>
+              <p className="truncate text-base leading-normal tracking-[-0.03em] text-[#707070]">
+                {questionTitle}
+              </p>
+              <button
+                type="button"
+                onClick={toggleOpen}
+                disabled={isPending}
+                className="mt-2 inline-flex flex-wrap items-center gap-1 text-lg leading-normal font-bold tracking-[-0.03em] text-[#4D4D4D] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isPending ? (
+                  <span className="inline-flex items-center gap-2">
+                    <Spinner size="sm" label="AI 답변 로딩 중" />
+                    <span>
+                      AI가 답변을 {isGetLoading ? '불러오고' : '생성하고'}{' '}
+                      있습니다...
+                    </span>
+                  </span>
+                ) : (
+                  <>
+                    <span>질문에 대한</span>
+                    <img
+                      src={aiBotImg}
+                      alt=""
+                      className="mx-0.5 inline h-9 w-9"
+                    />
+                    <strong className="text-black">AI 질의응답 챗봇</strong>
+                    <span>답변 보기</span>
+                    <ChevronIcon className="ml-1 h-4 w-4 shrink-0 text-[#4D4D4D]" />
+                  </>
+                )}
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
+++ b/src/components/qna/AiFirstAnswerSection/AiFirstAnswerSection.tsx
@@ -60,10 +60,8 @@ export function AiFirstAnswerSection({
   const enterQna = useChatbotStore((s) => s.enterQna)
 
   // 기존 답변이 있으면 자동으로 펼침
-  const hasExistingAnswer = !!existingAnswer
   const [isOpen, setIsOpen] = useState(false)
-  const isAutoOpen = hasExistingAnswer
-  const showAnswer = isAutoOpen || isOpen
+  const showAnswer = isOpen
 
   const answerData = existingAnswer ?? createdAnswer
   const [errorMessage, setErrorMessage] = useState<string | null>(null)

--- a/src/components/qna/AnswerCard/AnswerCard.tsx
+++ b/src/components/qna/AnswerCard/AnswerCard.tsx
@@ -4,6 +4,8 @@ import { UserAvatar } from '@/components/common/UserAvatar'
 import { CommentForm } from '@/components/qna/CommentForm'
 import { CommentList } from '@/components/qna/CommentList'
 import { getRelativeTime } from '@/utils/relativeTime'
+import { useAuthStore } from '@/stores/authStore'
+import { ANSWER_ALLOWED_ROLES } from '@/constants/roles'
 
 interface AnswerCardProps {
   answer: GetAnswerItem
@@ -32,6 +34,10 @@ export function AnswerCard({
   showForm,
   onEditAction,
 }: AnswerCardProps) {
+  const userRole = useAuthStore((s) => s.user?.role)
+  const canComment =
+    isAuthenticated && userRole != null && ANSWER_ALLOWED_ROLES.has(userRole)
+
   const canShowAcceptButton =
     isQuestionOwner && !anyAdopted && answer.author.id !== userId
 
@@ -117,7 +123,7 @@ export function AnswerCard({
         </div>
 
         {/* 댓글 입력 (먼저) → 댓글 목록 (나중) — Figma 순서 */}
-        {isAuthenticated && (
+        {canComment && (
           <CommentForm answerId={answer.id} questionId={numericQuestionId} />
         )}
 

--- a/src/features/chatbot/cs/hooks/useCsChat.ts
+++ b/src/features/chatbot/cs/hooks/useCsChat.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSSEAbort } from '@/features/chatbot/hooks/useSSEAbort'
-import { mapHistoryToMessages } from '@/features/chatbot/hooks/sseStream'
+import { mapHistoryToMessages } from '@/features/chatbot/utils/mapHistory'
 import { sendStreamingMessage } from '@/features/chatbot/hooks/sendStreamingMessage'
 import { useGetCsHistory, CS_HISTORY_QUERY_KEY } from '../queries'
 import type { ChatMessage } from '@/features/chatbot/widgetTypes'

--- a/src/features/chatbot/hooks/sendStreamingMessage.ts
+++ b/src/features/chatbot/hooks/sendStreamingMessage.ts
@@ -6,6 +6,7 @@ import { readSseMessageStream } from './sseStream'
 
 const ERROR_TEXT = '응답을 불러오지 못했습니다. 다시 시도해주세요.'
 const ERROR_BUFFER_TEXT = '응답이 너무 길어 중단되었습니다.'
+const DONE_COOLDOWN_MS = 500
 
 function clearAuthAndRedirectToLogin() {
   useAuthStore.getState().logout()
@@ -89,6 +90,21 @@ function appendErrorMessage(
   ])
 }
 
+function waitForDoneCooldown(signal: AbortSignal) {
+  if (signal.aborted) return Promise.resolve()
+
+  return new Promise<void>((resolve) => {
+    const finish = () => {
+      clearTimeout(timeoutId)
+      signal.removeEventListener('abort', finish)
+      resolve()
+    }
+    const timeoutId = setTimeout(finish, DONE_COOLDOWN_MS)
+
+    signal.addEventListener('abort', finish, { once: true })
+  })
+}
+
 export async function sendStreamingMessage({
   text,
   endpoint,
@@ -128,7 +144,8 @@ export async function sendStreamingMessage({
   let hasReceivedChunk = false
 
   try {
-    const response = await requestStream(endpoint, trimmed, reset())
+    const signal = reset()
+    const response = await requestStream(endpoint, trimmed, signal)
     if (handleHttpStatus({ response, assistantId, onRateLimit })) return
 
     const result = await readSseMessageStream({
@@ -147,6 +164,10 @@ export async function sendStreamingMessage({
     completed = result.completed
     hasReceivedChunk = result.hasReceivedChunk
 
+    if (result.completed) {
+      await waitForDoneCooldown(signal)
+    }
+
     if (result.bufferExceeded) {
       appendErrorMessage(setMessages, idPrefix, ERROR_BUFFER_TEXT)
     }
@@ -163,7 +184,7 @@ export async function sendStreamingMessage({
     )
   } finally {
     setIsStreaming(false)
-    if (completed) {
+    if (completed || hasReceivedChunk) {
       invalidateQueries(queryClient, invalidateQueryKeys)
     }
   }

--- a/src/features/chatbot/hooks/sseStream.ts
+++ b/src/features/chatbot/hooks/sseStream.ts
@@ -1,144 +1,9 @@
-import type { ChatMessage } from '@/features/chatbot/widgetTypes'
-
 const DEFAULT_MAX_BUFFER_SIZE = 100_000
 
-export interface ChatHistoryMessage {
-  role: 'user' | 'assistant'
-  message?: string
-  content?: string
-  id?: string | number
-}
-
-export interface SseStreamResult {
+interface SseStreamResult {
   completed: boolean
   hasReceivedChunk: boolean
   bufferExceeded: boolean
-}
-
-interface ParsedSseEvent {
-  done: boolean
-  message: string | null
-}
-
-interface StreamState {
-  assistantText: string
-  completed: boolean
-  hasReceivedChunk: boolean
-  bufferExceeded: boolean
-}
-
-export function mapHistoryToMessages(
-  results: ChatHistoryMessage[],
-  idPrefix: string
-): ChatMessage[] {
-  return results.map((item, index) => ({
-    id: item.id?.toString() ?? `${idPrefix}-history-${index}`,
-    role: item.role,
-    message: item.message ?? item.content ?? '',
-  }))
-}
-
-function parseSseEvent(event: string): ParsedSseEvent {
-  const line = event.split('\n').find((l) => l.startsWith('data:'))
-  if (!line) return { done: false, message: null }
-
-  const data = line.replace(/^data:\s*/, '').trim()
-  if (data === '[DONE]') return { done: true, message: null }
-
-  try {
-    const chunk = JSON.parse(data) as { message?: unknown }
-    return {
-      done: false,
-      message: typeof chunk.message === 'string' ? chunk.message : null,
-    }
-  } catch {
-    return { done: false, message: null }
-  }
-}
-
-function splitSseEvents(buffer: string) {
-  const events = buffer.split('\n\n')
-  return {
-    events,
-    rest: events.pop() ?? '',
-  }
-}
-
-function applySseEvent({
-  event,
-  state,
-  maxBufferSize,
-  onChunk,
-  onBufferExceeded,
-}: {
-  event: string
-  state: StreamState
-  maxBufferSize: number
-  onChunk: (message: string) => void
-  onBufferExceeded?: () => void
-}) {
-  const parsed = parseSseEvent(event)
-
-  if (parsed.done) {
-    state.completed = true
-    return
-  }
-  if (parsed.message == null) return
-
-  state.hasReceivedChunk = true
-  state.assistantText += parsed.message
-
-  if (state.assistantText.length > maxBufferSize) {
-    state.bufferExceeded = true
-    onBufferExceeded?.()
-    return
-  }
-
-  onChunk(parsed.message)
-}
-
-function getSseReader(response: Response) {
-  const reader = response.body?.getReader()
-  if (!reader) throw new Error('ReadableStream 없음')
-  return reader
-}
-
-async function readNextChunk({
-  reader,
-  decoder,
-  buffer,
-  state,
-  maxBufferSize,
-  onChunk,
-  onBufferExceeded,
-}: {
-  reader: ReadableStreamDefaultReader<Uint8Array>
-  decoder: TextDecoder
-  buffer: string
-  state: StreamState
-  maxBufferSize: number
-  onChunk: (message: string) => void
-  onBufferExceeded?: () => void
-}) {
-  const { done, value } = await reader.read()
-  if (done) return { buffer, done: true }
-
-  const { events, rest } = splitSseEvents(
-    buffer + decoder.decode(value, { stream: true })
-  )
-
-  for (const event of events) {
-    applySseEvent({
-      event,
-      state,
-      maxBufferSize,
-      onChunk,
-      onBufferExceeded,
-    })
-    if (state.completed || state.bufferExceeded) break
-  }
-
-  return { buffer: rest, done: false }
 }
 
 export async function readSseMessageStream({
@@ -152,38 +17,54 @@ export async function readSseMessageStream({
   onBufferExceeded?: () => void
   maxBufferSize?: number
 }): Promise<SseStreamResult> {
-  const reader = getSseReader(response)
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error('ReadableStream 없음')
+
   const decoder = new TextDecoder()
   let buffer = ''
-  const state: StreamState = {
-    assistantText: '',
-    completed: false,
-    hasReceivedChunk: false,
-    bufferExceeded: false,
-  }
+  let total = 0
+  let completed = false
+  let hasReceivedChunk = false
+  let bufferExceeded = false
 
-  while (true) {
-    const next = await readNextChunk({
-      reader,
-      decoder,
-      buffer,
-      state,
-      maxBufferSize,
-      onChunk,
-      onBufferExceeded,
-    })
-    buffer = next.buffer
-    const done = next.done || state.completed || state.bufferExceeded
+  while (!completed && !bufferExceeded) {
+    const { done, value } = await reader.read()
     if (done) break
+
+    buffer += decoder.decode(value, { stream: true })
+    const events = buffer.split('\n\n')
+    buffer = events.pop() ?? ''
+
+    for (const event of events) {
+      const dataLine = event
+        .split('\n')
+        .find((line) => line.startsWith('data:'))
+      if (!dataLine) continue
+
+      const data = dataLine.slice(5).trim()
+      if (data === '[DONE]') {
+        completed = true
+        break
+      }
+
+      try {
+        const chunk = JSON.parse(data) as { message?: unknown }
+        if (typeof chunk.message !== 'string') continue
+
+        total += chunk.message.length
+        if (total > maxBufferSize) {
+          bufferExceeded = true
+          onBufferExceeded?.()
+          break
+        }
+
+        hasReceivedChunk = true
+        onChunk(chunk.message)
+      } catch {
+        // malformed SSE chunk는 무시하고 다음 이벤트를 계속 처리한다.
+      }
+    }
   }
 
-  if (!state.completed && state.hasReceivedChunk) {
-    state.completed = true
-  }
-
-  return {
-    completed: state.completed,
-    hasReceivedChunk: state.hasReceivedChunk,
-    bufferExceeded: state.bufferExceeded,
-  }
+  return { completed, hasReceivedChunk, bufferExceeded }
 }

--- a/src/features/chatbot/hub/HubView.tsx
+++ b/src/features/chatbot/hub/HubView.tsx
@@ -4,7 +4,7 @@ import { useChatbotStore } from '@/stores/chatbotStore'
 import { useGetSessions } from '@/features/chatbot/sessions'
 import type { ChatSession } from '@/features/chatbot/sessions'
 import { getRelativeTime } from '@/utils/relativeTime'
-import chatbotRobot from '@/assets/chatbot-robot.png'
+import { ChatbotRobotImage } from '@/components/chatbot/ChatbotRobotImage'
 
 export function HubView() {
   const { setView, enterQna, close } = useChatbotStore(
@@ -14,7 +14,8 @@ export function HubView() {
       close: s.close,
     }))
   )
-  const { data, isLoading, isError, refetch } = useGetSessions()
+  const { data, isLoading, isFetching, isError, refetch } = useGetSessions()
+  const isRefreshingSessions = isLoading || isFetching
 
   const handleCsClick = () => {
     setView('cs')
@@ -47,12 +48,7 @@ export function HubView() {
             className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white"
             style={{ boxShadow: '0px 2px 4px rgba(0,0,0,0.15)' }}
           >
-            <img
-              src={chatbotRobot}
-              alt=""
-              className="h-[42px] w-[42px] object-contain"
-              draggable={false}
-            />
+            <ChatbotRobotImage className="h-[42px] w-[42px] object-contain" />
           </div>
           <p className="min-w-0 flex-1 truncate text-[16px] font-medium text-[#121212]">
             AI OZ 시스템 챗봇
@@ -62,7 +58,7 @@ export function HubView() {
         <div className="border-t border-[#E8E8E8]" />
 
         {/* Q&A 세션 목록 */}
-        {isLoading && (
+        {isRefreshingSessions && (
           <div className="flex items-center justify-center py-6">
             <div className="border-primary h-5 w-5 animate-spin rounded-full border-2 border-t-transparent" />
           </div>
@@ -83,7 +79,7 @@ export function HubView() {
           </div>
         )}
 
-        {!isLoading &&
+        {!isRefreshingSessions &&
           !isError &&
           data?.results?.map((session) => (
             <div key={session.question_id}>
@@ -96,12 +92,7 @@ export function HubView() {
                   className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white"
                   style={{ boxShadow: '0px 2px 4px rgba(0,0,0,0.15)' }}
                 >
-                  <img
-                    src={chatbotRobot}
-                    alt=""
-                    className="h-[42px] w-[42px] object-contain"
-                    draggable={false}
-                  />
+                  <ChatbotRobotImage className="h-[42px] w-[42px] object-contain" />
                 </div>
                 <p className="min-w-0 flex-1 truncate text-[16px] font-medium text-[#121212]">
                   질의응답 챗봇

--- a/src/features/chatbot/qna/QnaChatView.tsx
+++ b/src/features/chatbot/qna/QnaChatView.tsx
@@ -81,13 +81,7 @@ export function QnaChatView({ questionId }: QnaChatViewProps) {
             </button>
           </div>
         ) : (
-          <MessageList
-            messages={messages}
-            showGreeting
-            onAskMore={() =>
-              document.getElementById('chatbot-message-input')?.focus()
-            }
-          />
+          <MessageList messages={messages} />
         )}
       </div>
 

--- a/src/features/chatbot/qna/QnaChatView.tsx
+++ b/src/features/chatbot/qna/QnaChatView.tsx
@@ -81,7 +81,13 @@ export function QnaChatView({ questionId }: QnaChatViewProps) {
             </button>
           </div>
         ) : (
-          <MessageList messages={messages} />
+          <MessageList
+            messages={messages}
+            showGreeting
+            onAskMore={() =>
+              document.getElementById('chatbot-message-input')?.focus()
+            }
+          />
         )}
       </div>
 

--- a/src/features/chatbot/qna/hooks/useQnaChat.ts
+++ b/src/features/chatbot/qna/hooks/useQnaChat.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSSEAbort } from '@/features/chatbot/hooks/useSSEAbort'
-import { mapHistoryToMessages } from '@/features/chatbot/hooks/sseStream'
+import { mapHistoryToMessages } from '@/features/chatbot/utils/mapHistory'
 import { sendStreamingMessage } from '@/features/chatbot/hooks/sendStreamingMessage'
 import { useGetQnaHistory, QNA_HISTORY_QUERY_KEY } from '../queries'
 import { SESSIONS_QUERY_KEY } from '@/features/chatbot/sessions/queries'

--- a/src/features/chatbot/sessions/queries.ts
+++ b/src/features/chatbot/sessions/queries.ts
@@ -11,6 +11,8 @@ export const sessionsQueryOptions = queryOptions({
       .get<ChatSessionListResponse>('/qna/ai-answer/sessions')
       .then((r) => r.data),
   staleTime: 0,
+  refetchOnMount: 'always',
+  refetchOnWindowFocus: true,
 })
 
 export function useGetSessions() {

--- a/src/features/chatbot/utils/mapHistory.ts
+++ b/src/features/chatbot/utils/mapHistory.ts
@@ -1,0 +1,19 @@
+import type { ChatMessage } from '@/features/chatbot/widgetTypes'
+
+interface ChatHistoryMessage {
+  role: 'user' | 'assistant'
+  message?: string
+  content?: string
+  id?: string | number
+}
+
+export function mapHistoryToMessages(
+  results: ChatHistoryMessage[],
+  idPrefix: string
+): ChatMessage[] {
+  return results.map((item, index) => ({
+    id: item.id?.toString() ?? `${idPrefix}-history-${index}`,
+    role: item.role,
+    message: item.message ?? item.content ?? '',
+  }))
+}

--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -159,7 +159,7 @@ function SortPopover({
                 }
               }}
               className={[
-                'flex h-[42px] items-center justify-center rounded px-5 text-base font-bold transition-colors',
+                'flex h-[42px] items-center justify-center rounded px-5 text-xl font-extrabold transition-colors',
                 sort === opt
                   ? 'bg-[#EFE6FC] text-[#6201E0]'
                   : 'text-[#4D4D4D] hover:bg-[#EFE6FC]',
@@ -324,12 +324,12 @@ export function QnaListPage() {
   return (
     <div className="mx-auto w-full max-w-[944px] overflow-hidden px-4 pt-[52px] pb-20">
       {/* 페이지 타이틀 */}
-      <h1 className="mb-8 text-[32px] leading-[1.4] font-bold tracking-[-0.03em] text-[#121212]">
+      <h1 className="mb-2 text-[32px] leading-[1.4] font-bold tracking-[-0.03em] text-[#121212]">
         질의응답
       </h1>
 
       {/* 검색바 + 질문하기 버튼 */}
-      <div className="mb-[52px] flex items-center justify-between">
+      <div className="mb-3 flex items-center justify-between">
         <SearchInput
           value={inputValue}
           onValueChange={setInputValue}
@@ -354,7 +354,7 @@ export function QnaListPage() {
             }
             navigate(ROUTES.QNA.WRITE)
           }}
-          className="flex h-12 items-center gap-2 rounded-sm bg-[#6201E0] px-9 text-base font-bold text-white transition-colors hover:bg-[#4E01B3]"
+          className="flex h-12 items-center gap-2 rounded-sm bg-[#6201E0] px-9 text-xl font-extrabold text-white transition-colors hover:bg-[#4E01B3]"
         >
           <Pencil className="h-5 w-5" />
           질문하기
@@ -364,14 +364,20 @@ export function QnaListPage() {
       {/* 탭 + 정렬/필터를 한 줄에 배치 */}
       <Tabs value={answerStatus} onChange={handleTabChange}>
         <div className="flex items-end justify-between border-b border-[#CECECE]">
-          <TabList aria-label="답변 상태 필터" className="flex gap-10 border-0">
-            <Tab value="all">전체보기</Tab>
-            <Tab value="answered">답변완료</Tab>
-            <Tab value="unanswered">답변 대기중</Tab>
+          <TabList aria-label="답변 상태 필터" className="flex gap-6 border-0">
+            <Tab value="all" className="text-xl font-extrabold">
+              전체보기
+            </Tab>
+            <Tab value="answered" className="text-xl font-extrabold">
+              답변완료
+            </Tab>
+            <Tab value="unanswered" className="text-xl font-extrabold">
+              답변 대기중
+            </Tab>
           </TabList>
 
           {/* 정렬 popover + 필터 */}
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 pb-3">
             <SortPopover
               sort={sort}
               onSelect={(opt) => updateParam('sort', opt)}
@@ -463,7 +469,7 @@ export function QnaListPage() {
                 updateParam('category_id', id != null ? String(id) : null)
                 setShowCategoryModal(false)
               }}
-              className="h-[54px] w-[278px] rounded bg-[#6201E0] text-xl font-bold text-white transition-colors hover:bg-[#4E01B3]"
+              className="h-[54px] w-[278px] rounded bg-[#6201E0] text-xl font-extrabold text-white transition-colors hover:bg-[#4E01B3]"
             >
               필터 적용하기
             </button>
@@ -487,7 +493,7 @@ export function QnaListPage() {
 
         {/* 본문 */}
         <div className="-mx-6 px-12 pt-[60px] pb-10">
-          <h3 className="mb-5 text-xl font-bold text-[#4D4D4D]">
+          <h3 className="mb-5 text-xl font-extrabold text-[#4D4D4D]">
             카테고리 선택
           </h3>
           <Suspense


### PR DESCRIPTION
## 관련 이슈

- closes (해당 없음 — 누적 머지)

## 작업 내용

dev 브랜치에 머지된 5개 PR을 main 으로 반영합니다.

- #160 feat: QnA 챗봇 인사말 카드 및 AI 답변 카드 아코디언 UI
- #162 style: QnA 목록 페이지 디자인 수정
- #164 fix: 일반 회원(USER role) 답변 카드 댓글 입력폼 노출 제한
- #165 fix: 챗봇 이미지와 세션 목록 동작 개선
- #166 refactor: 챗봇 SSE 스트림 처리 단순화

## 변경 사항

**챗봇**
- `ChatbotRobotImage` 컴포넌트 신설 — 로봇 이미지 로드 실패 시 lucide `Bot` 아이콘 fallback
- `ChatbotFab`, `MessageList`, `HubView` 의 로봇 이미지를 신규 컴포넌트로 교체
- `MessageList` 스크롤을 `useLayoutEffect` + `block: 'end'` 로 변경 (smooth 제거, 즉시 하단)
- 허브 세션 목록을 진입/포커스 시 재조회 (`refetchOnMount: 'always'`, `refetchOnWindowFocus: true`)
- SSE 스트림 처리 로직 단순화 (`sseStream.ts` 약 200줄 정리)
- `mapHistory` 유틸 신설로 sessions/history 응답 매핑 일원화

**QnA**
- `AiFirstAnswerSection` 카드 아코디언 구조로 개편 (기본 접힘, 클릭 시 펼침)
- AI 답변 마크다운 'AI답변' 헤딩/구분선 제거, 배경색 카드와 통일
- `AnswerCard` 댓글 입력폼을 `canComment` (role 기반) 조건으로 노출 제한
- `QnaListPage` 디자인 수정

**공통**
- `Tabs` 컴포넌트 일부 수정

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다