### PR TITLE
fix: QnaListPage 정렬 팝업 스타일 수정

### DIFF
--- a/src/pages/qna/QnaListPage.tsx
+++ b/src/pages/qna/QnaListPage.tsx
@@ -137,7 +137,7 @@ function SortPopover({
         <div
           ref={menuRef}
           role="menu"
-          className="absolute top-full right-0 z-50 mt-2 flex w-[138px] flex-col rounded-xl bg-white p-4 shadow-[0_0_16px_rgba(160,160,160,0.25)]"
+          className="absolute top-full right-0 z-50 mt-2 flex w-fit flex-col rounded-xl bg-white p-4"
         >
           {SORT_OPTIONS.map((opt) => (
             <button
@@ -159,7 +159,7 @@ function SortPopover({
                 }
               }}
               className={[
-                'flex h-[42px] items-center justify-center rounded px-5 text-xl font-extrabold transition-colors',
+                'flex h-[42px] items-center justify-center rounded px-5 text-sm font-semibold whitespace-nowrap transition-colors',
                 sort === opt
                   ? 'bg-[#EFE6FC] text-[#6201E0]'
                   : 'text-[#4D4D4D] hover:bg-[#EFE6FC]',


### PR DESCRIPTION
## Summary
- 정렬 팝업 shadow(테두리) 제거
- `whitespace-nowrap` + `w-fit` 적용으로 '오래된순' 텍스트 한 줄 표시
- 버튼 글자 크기 `text-xl font-extrabold` → `text-sm font-semibold` 축소

## Test plan
- [ ] 정렬 팝업 열었을 때 shadow 없이 표시되는지 확인
- [ ] '오래된순' 텍스트가 한 줄로 표시되는지 확인
- [ ] 최신순/오래된순 글자 크기가 줄어들었는지 확인
- [ ] 정렬 선택 기능 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)