### PR TITLE
fix: 프로필 이미지 호버 시 드롭다운이 마우스 이동 후에도 닫히지 않는 문제 수정

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -89,7 +89,7 @@ function ProfileMenu({
   const { user } = useAuthStore()
 
   return (
-    <div className="relative">
+    <div className="relative" onMouseLeave={() => setDropdownOpen(false)}>
       <button
         type="button"
         onMouseEnter={() => setDropdownOpen(true)}


### PR DESCRIPTION
## 관련 이슈

- closes #169

## 작업 내용

- 헤더 프로필 이미지에 마우스를 올리면 드롭다운이 열리지만, 마우스를 다른 곳으로 이동해도 닫히지 않는 버그 수정

## 변경 사항

- `src/components/layout/Header/Header.tsx`
  - `ProfileMenu` 래퍼 `div`에 `onMouseLeave` 핸들러 추가
  - 프로필 버튼과 드롭다운을 감싸는 래퍼 영역 전체를 벗어날 때만 드롭다운이 닫히도록 처리
  - 버튼 → 드롭다운으로 마우스를 이동하는 경우에는 같은 래퍼 안이므로 닫히지 않음

## 스크린샷 (선택)

## 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 불필요한 console.log 또는 디버깅 코드를 제거했습니다
- [x] 컨벤션에 맞게 작성했습니다