### PR TITLE
fix: 질문 폼 카테고리 미선택 AlertModal 추가 및 상세페이지 수정 버튼 위치 변경

### DIFF
--- a/src/components/qna/QuestionDetail/QuestionDetail.tsx
+++ b/src/components/qna/QuestionDetail/QuestionDetail.tsx
@@ -111,13 +111,20 @@ export function QuestionDetail({
             </div>
           </div>
 
-          {/* 메타 정보: 조회수 | 시간 */}
-          <div className="mt-5 flex items-center gap-[19px] text-base leading-normal tracking-[-0.03em] text-[#9D9D9D]">
-            <span>조회수 {questionDetail.view_count.toLocaleString()}</span>
-            <span className="text-[#CECECE]">·</span>
-            <time dateTime={questionDetail.created_at}>
-              {getRelativeTime(questionDetail.created_at)}
-            </time>
+          {/* 메타 정보: 조회수 | 시간 | 수정 버튼(작성자) */}
+          <div className="mt-5 flex items-center justify-between">
+            <div className="flex items-center gap-[19px] text-base leading-normal tracking-[-0.03em] text-[#9D9D9D]">
+              <span>조회수 {questionDetail.view_count.toLocaleString()}</span>
+              <span className="text-[#CECECE]">·</span>
+              <time dateTime={questionDetail.created_at}>
+                {getRelativeTime(questionDetail.created_at)}
+              </time>
+            </div>
+            {isQuestionOwner && (
+              <Button variant="ghost" size="sm" onClick={onEdit}>
+                수정
+              </Button>
+            )}
           </div>
 
           {/* 디바이더 */}
@@ -150,7 +157,7 @@ export function QuestionDetail({
             showToast={showToast}
           />
 
-          {/* 공유하기 pill 버튼 + 수정 버튼 */}
+          {/* 공유하기 pill 버튼 */}
           <div className="mt-6 flex items-center justify-end gap-2">
             <button
               type="button"
@@ -160,11 +167,6 @@ export function QuestionDetail({
               <LinkIcon />
               공유하기
             </button>
-            {isQuestionOwner && (
-              <Button variant="ghost" size="sm" onClick={onEdit}>
-                수정
-              </Button>
-            )}
           </div>
 
           {/* 하단 디바이더 */}

--- a/src/components/qna/QuestionForm/QuestionForm.tsx
+++ b/src/components/qna/QuestionForm/QuestionForm.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/common/Button'
 import { MarkdownEditor } from '@/components/qna/MarkdownEditor'
 import { Dropdown } from '@/components/common/Dropdown'
-import { AlertModal } from '@/components/common/Modal'
+import { Toast } from '@/components/common/Toast'
+import { useToast } from '@/hooks/useToast'
 import { useCategorySelector } from '@/hooks/useCategorySelector'
 
 const MIN_CONTENT_LENGTH = 5
@@ -49,10 +50,9 @@ export function QuestionForm({
     resolvedCategoryId,
   } = useCategorySelector(initialValues?.categoryId)
 
+  const { toast, showToast, hideToast } = useToast()
   const [title, setTitle] = useState(initialValues?.title ?? '')
   const [content, setContent] = useState(initialValues?.content ?? '')
-  const [alertMessage, setAlertMessage] = useState('')
-  const [isAlertOpen, setIsAlertOpen] = useState(false)
 
   const isDirty = title.trim().length > 0 || content.length > 0
 
@@ -77,23 +77,19 @@ export function QuestionForm({
     const isContentInvalid = content.trim().length < MIN_CONTENT_LENGTH
 
     if (isCategoryMissing) {
-      setAlertMessage('카테고리를 선택해 주세요.')
-      setIsAlertOpen(true)
+      showToast('카테고리를 선택해 주세요.', 'warning')
       return
     }
     if (!title.trim()) {
-      setAlertMessage('제목을 입력해 주세요.')
-      setIsAlertOpen(true)
+      showToast('제목을 입력해 주세요.', 'warning')
       return
     }
     if (isTitleInvalid) {
-      setAlertMessage(`제목을 ${MIN_TITLE_LENGTH}자 이상 입력해 주세요.`)
-      setIsAlertOpen(true)
+      showToast(`제목을 ${MIN_TITLE_LENGTH}자 이상 입력해 주세요.`, 'warning')
       return
     }
     if (isContentInvalid) {
-      setAlertMessage(`내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`)
-      setIsAlertOpen(true)
+      showToast(`내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`, 'warning')
       return
     }
 
@@ -173,11 +169,13 @@ export function QuestionForm({
         </div>
       </form>
 
-      <AlertModal
-        isOpen={isAlertOpen}
-        onClose={() => setIsAlertOpen(false)}
-        message={alertMessage}
-      />
+      {toast.visible && (
+        <Toast
+          message={toast.message}
+          variant={toast.variant}
+          onClose={hideToast}
+        />
+      )}
     </>
   )
 }

--- a/src/components/qna/QuestionForm/QuestionForm.tsx
+++ b/src/components/qna/QuestionForm/QuestionForm.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/common/Button'
 import { MarkdownEditor } from '@/components/qna/MarkdownEditor'
 import { Dropdown } from '@/components/common/Dropdown'
-import { Toast } from '@/components/common/Toast'
-import { useToast } from '@/hooks/useToast'
+import { AlertModal } from '@/components/common/Modal'
 import { useCategorySelector } from '@/hooks/useCategorySelector'
 
 const MIN_CONTENT_LENGTH = 5
@@ -50,9 +49,10 @@ export function QuestionForm({
     resolvedCategoryId,
   } = useCategorySelector(initialValues?.categoryId)
 
-  const { toast, showToast, hideToast } = useToast()
   const [title, setTitle] = useState(initialValues?.title ?? '')
   const [content, setContent] = useState(initialValues?.content ?? '')
+  const [alertMessage, setAlertMessage] = useState('')
+  const [isAlertOpen, setIsAlertOpen] = useState(false)
 
   const isDirty = title.trim().length > 0 || content.length > 0
 
@@ -77,19 +77,23 @@ export function QuestionForm({
     const isContentInvalid = content.trim().length < MIN_CONTENT_LENGTH
 
     if (isCategoryMissing) {
-      showToast('카테고리를 선택해 주세요.', 'warning')
+      setAlertMessage('카테고리를 선택해 주세요.')
+      setIsAlertOpen(true)
       return
     }
     if (!title.trim()) {
-      showToast('제목을 입력해 주세요.', 'warning')
+      setAlertMessage('제목을 입력해 주세요.')
+      setIsAlertOpen(true)
       return
     }
     if (isTitleInvalid) {
-      showToast(`제목을 ${MIN_TITLE_LENGTH}자 이상 입력해 주세요.`, 'warning')
+      setAlertMessage(`제목을 ${MIN_TITLE_LENGTH}자 이상 입력해 주세요.`)
+      setIsAlertOpen(true)
       return
     }
     if (isContentInvalid) {
-      showToast(`내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`, 'warning')
+      setAlertMessage(`내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`)
+      setIsAlertOpen(true)
       return
     }
 
@@ -169,13 +173,11 @@ export function QuestionForm({
         </div>
       </form>
 
-      {toast.visible && (
-        <Toast
-          message={toast.message}
-          variant={toast.variant}
-          onClose={hideToast}
-        />
-      )}
+      <AlertModal
+        isOpen={isAlertOpen}
+        onClose={() => setIsAlertOpen(false)}
+        message={alertMessage}
+      />
     </>
   )
 }

--- a/src/pages/qna/QnaEditPage.tsx
+++ b/src/pages/qna/QnaEditPage.tsx
@@ -1,10 +1,9 @@
 /**
  * @figma 질문 수정  https://www.figma.com/design/4rJmEFUU2HMWVy3qUcYZRs/%EC%A0%9C%EB%AA%A9-%EC%97%86%EC%9D%8C?node-id=1-9246&m=dev
  */
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router'
-import { Button, Dropdown, AlertModal } from '@/components'
-import { MarkdownEditor } from '@/components/qna/MarkdownEditor'
+import { QuestionForm, Toast } from '@/components'
 import { useQnaCategories } from '@/features/qna/categories'
 import {
   useSuspenseGetQuestionDetail,
@@ -12,122 +11,9 @@ import {
 } from '@/features/qna/question-edit'
 import type { GetQuestionDetailResponse } from '@/features/qna/question-detail'
 import { useAuthStore } from '@/stores/authStore'
-import { useCategorySelector } from '@/hooks/useCategorySelector'
+import { useToast } from '@/hooks/useToast'
 import { ROUTES } from '@/constants/routes'
 import { extractImageUrls } from '@/utils/extractImageUrls'
-
-const MIN_CONTENT_LENGTH = 5
-const MIN_TITLE_LENGTH = 3
-const MAX_TITLE_LENGTH = 100
-
-function getValidationMessage({
-  categoryId,
-  title,
-  content,
-}: {
-  categoryId: number | undefined
-  title: string
-  content: string
-}) {
-  if (categoryId == null) return '카테고리를 선택해 주세요.'
-  if (!title.trim()) return '제목을 입력해 주세요.'
-  if (title.trim().length < MIN_TITLE_LENGTH) {
-    return `제목을 ${MIN_TITLE_LENGTH}자 이상 입력해 주세요.`
-  }
-  if (content.trim().length < MIN_CONTENT_LENGTH) {
-    return `내용을 ${MIN_CONTENT_LENGTH}자 이상 입력해 주세요.`
-  }
-  return null
-}
-
-function useBeforeUnloadDirty(isDirty: boolean) {
-  useEffect(() => {
-    if (!isDirty) return
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault()
-      e.returnValue = ''
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [isDirty])
-}
-
-function CategoryFields({
-  selector,
-}: {
-  selector: ReturnType<typeof useCategorySelector>
-}) {
-  return (
-    <div className="flex flex-col gap-3 p-4 sm:flex-row">
-      <Dropdown
-        options={selector.largeOptions}
-        value={selector.largeCategoryId}
-        onChange={selector.handleLargeChange}
-        placeholder="대분류 선택"
-        className="flex-1"
-      />
-      <Dropdown
-        options={selector.mediumOptions}
-        value={selector.validMediumCategoryId}
-        onChange={selector.handleMediumChange}
-        placeholder="중분류 선택"
-        disabled={!selector.largeCategoryId || !selector.hasMedium}
-        className="flex-1"
-      />
-      <Dropdown
-        options={selector.smallOptions}
-        value={selector.validSmallCategoryId}
-        onChange={selector.handleSmallChange}
-        placeholder="소분류 선택"
-        disabled={!selector.validMediumCategoryId || !selector.hasSmall}
-        className="flex-1"
-      />
-    </div>
-  )
-}
-
-function TitleInput({
-  title,
-  onChange,
-}: {
-  title: string
-  onChange: (value: string) => void
-}) {
-  return (
-    <input
-      type="text"
-      placeholder={`제목을 입력해 주세요. (${MIN_TITLE_LENGTH}~${MAX_TITLE_LENGTH}자)`}
-      value={title}
-      onChange={(e) => onChange(e.target.value)}
-      maxLength={MAX_TITLE_LENGTH}
-      className="placeholder:text-text-muted text-text-heading border-border-base bg-primary-50 focus:border-primary h-12 w-full rounded-sm border px-4 text-base transition-colors duration-150 outline-none"
-    />
-  )
-}
-
-function EditActions({
-  isPending,
-  onCancel,
-}: {
-  isPending: boolean
-  onCancel: () => void
-}) {
-  return (
-    <div className="flex justify-end gap-3">
-      <Button
-        type="button"
-        variant="secondary"
-        onClick={onCancel}
-        disabled={isPending}
-      >
-        취소
-      </Button>
-      <Button type="submit" variant="primary" loading={isPending}>
-        수정하기
-      </Button>
-    </div>
-  )
-}
 
 interface QnaEditFormInnerProps {
   questionId: number
@@ -137,77 +23,53 @@ interface QnaEditFormInnerProps {
 function QnaEditFormInner({ questionId, question }: QnaEditFormInnerProps) {
   const navigate = useNavigate()
   const { mutate: updateQuestion, isPending } = useUpdateQuestion(questionId)
-  const categorySelector = useCategorySelector(question.category.id)
-  const currentCategoryId = categorySelector.resolvedCategoryId
-  const [title, setTitle] = useState(question.title)
-  const [content, setContent] = useState(question.content)
-  const [alertMessage, setAlertMessage] = useState('')
+  const { toast, showToast, hideToast } = useToast()
 
-  const isDirty =
-    title !== question.title ||
-    content !== question.content ||
-    currentCategoryId !== question.category.id
-
-  useBeforeUnloadDirty(isDirty)
-
-  const showAlert = (message: string) => setAlertMessage(message)
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-
-    const validationMessage = getValidationMessage({
-      categoryId: currentCategoryId,
-      title,
-      content,
-    })
-    if (validationMessage) return showAlert(validationMessage)
-    if (currentCategoryId == null) return
-
+  const handleSubmit = (data: {
+    categoryId: number
+    title: string
+    content: string
+  }) => {
     updateQuestion(
       {
-        category_id: currentCategoryId,
-        title: title.trim(),
-        content: content.trim(),
-        image_urls: extractImageUrls(content),
+        category_id: data.categoryId,
+        title: data.title,
+        content: data.content,
+        image_urls: extractImageUrls(data.content),
       },
       {
         onSuccess: () => {
           navigate(ROUTES.QNA.DETAIL.replace(':questionId', String(questionId)))
         },
         onError: () => {
-          showAlert('질문 수정에 실패했습니다. 다시 시도해 주세요.')
+          showToast('질문 수정에 실패했습니다. 다시 시도해 주세요.', 'error')
         },
       }
     )
   }
 
-  const handleCancel = () => {
-    navigate(ROUTES.QNA.DETAIL.replace(':questionId', String(questionId)))
-  }
-
   return (
     <>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-        <div className="border-border-base rounded-xl border">
-          <CategoryFields selector={categorySelector} />
-          <div className="border-border-base border-t" />
-          <div className="p-4">
-            <TitleInput title={title} onChange={setTitle} />
-          </div>
-        </div>
-
-        <div className="overflow-hidden rounded-xl">
-          <MarkdownEditor value={content} onChange={setContent} />
-        </div>
-
-        <EditActions isPending={isPending} onCancel={handleCancel} />
-      </form>
-
-      <AlertModal
-        isOpen={alertMessage !== ''}
-        onClose={() => setAlertMessage('')}
-        message={alertMessage}
+      <QuestionForm
+        initialValues={{
+          title: question.title,
+          content: question.content,
+          categoryId: question.category.id,
+        }}
+        isPending={isPending}
+        submitLabel="수정하기"
+        onSubmit={handleSubmit}
+        onCancel={() =>
+          navigate(ROUTES.QNA.DETAIL.replace(':questionId', String(questionId)))
+        }
       />
+      {toast.visible && (
+        <Toast
+          message={toast.message}
+          variant={toast.variant}
+          onClose={hideToast}
+        />
+      )}
     </>
   )
 }

--- a/src/pages/qna/QnaEditPage.tsx
+++ b/src/pages/qna/QnaEditPage.tsx
@@ -3,7 +3,7 @@
  */
 import { Suspense } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router'
-import { QuestionForm, Toast } from '@/components'
+import { QuestionForm, AlertModal } from '@/components'
 import { useQnaCategories } from '@/features/qna/categories'
 import {
   useSuspenseGetQuestionDetail,
@@ -11,7 +11,7 @@ import {
 } from '@/features/qna/question-edit'
 import type { GetQuestionDetailResponse } from '@/features/qna/question-detail'
 import { useAuthStore } from '@/stores/authStore'
-import { useToast } from '@/hooks/useToast'
+import { useState } from 'react'
 import { ROUTES } from '@/constants/routes'
 import { extractImageUrls } from '@/utils/extractImageUrls'
 
@@ -23,7 +23,7 @@ interface QnaEditFormInnerProps {
 function QnaEditFormInner({ questionId, question }: QnaEditFormInnerProps) {
   const navigate = useNavigate()
   const { mutate: updateQuestion, isPending } = useUpdateQuestion(questionId)
-  const { toast, showToast, hideToast } = useToast()
+  const [alertMessage, setAlertMessage] = useState('')
 
   const handleSubmit = (data: {
     categoryId: number
@@ -42,7 +42,7 @@ function QnaEditFormInner({ questionId, question }: QnaEditFormInnerProps) {
           navigate(ROUTES.QNA.DETAIL.replace(':questionId', String(questionId)))
         },
         onError: () => {
-          showToast('질문 수정에 실패했습니다. 다시 시도해 주세요.', 'error')
+          setAlertMessage('질문 수정에 실패했습니다. 다시 시도해 주세요.')
         },
       }
     )
@@ -63,13 +63,11 @@ function QnaEditFormInner({ questionId, question }: QnaEditFormInnerProps) {
           navigate(ROUTES.QNA.DETAIL.replace(':questionId', String(questionId)))
         }
       />
-      {toast.visible && (
-        <Toast
-          message={toast.message}
-          variant={toast.variant}
-          onClose={hideToast}
-        />
-      )}
+      <AlertModal
+        isOpen={alertMessage !== ''}
+        onClose={() => setAlertMessage('')}
+        message={alertMessage}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary

- 질문 등록/수정 폼에서 카테고리 미선택 시 AlertModal 노출 (제목·내용 검증과 동일한 방식으로 통일)
- `QnaEditPage` 인라인 폼 구현 제거 → `QuestionForm` 컴포넌트 재사용으로 등록/수정 동작 일치
- 질문 상세페이지 수정 버튼을 본문 하단에서 조회수·작성시간 메타 라인 우측으로 위치 이동

Closes #176

## Test plan

- [ ] 질문 등록 페이지: 카테고리 미선택 후 등록하기 클릭 → AlertModal 노출 확인
- [ ] 질문 등록 페이지: 제목 미입력, 내용 5자 미만 → 기존과 동일하게 AlertModal 노출 확인
- [ ] 질문 수정 페이지: 위 검증 동작이 등록 페이지와 동일하게 작동 확인
- [ ] 질문 상세페이지: 수정 버튼이 조회수 라인 우측에 위치 확인 (작성자 계정으로 확인)
- [ ] 질문 상세페이지: 비작성자 계정에서 수정 버튼 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)